### PR TITLE
SourceList should be unsealed

### DIFF
--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -17,7 +17,7 @@ namespace DynamicData
     /// An editable observable list.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>
-    public sealed class SourceList<T> : ISourceList<T>
+    public class SourceList<T> : ISourceList<T>
     {
         private readonly ISubject<IChangeSet<T>> _changes = new Subject<IChangeSet<T>>();
 

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -33,6 +33,8 @@ namespace DynamicData
 
         private int _editLevel;
 
+        private bool _isDisposed;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SourceList{T}"/> class.
         /// </summary>
@@ -105,8 +107,28 @@ namespace DynamicData
         /// <inheritdoc />
         public void Dispose()
         {
-            _cleanUp.Dispose();
-            _changesPreview.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of managed and unmanaged responses.
+        /// </summary>
+        /// <param name="isDisposing">If being called by the Dispose method.</param>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+
+            if (isDisposing)
+            {
+                _cleanUp.Dispose();
+                _changesPreview.Dispose();
+            }
         }
 
         /// <inheritdoc />

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -111,26 +111,6 @@ namespace DynamicData
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// Disposes of managed and unmanaged responses.
-        /// </summary>
-        /// <param name="isDisposing">If being called by the Dispose method.</param>
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (_isDisposed)
-            {
-                return;
-            }
-
-            _isDisposed = true;
-
-            if (isDisposing)
-            {
-                _cleanUp.Dispose();
-                _changesPreview.Dispose();
-            }
-        }
-
         /// <inheritdoc />
         public void Edit(Action<IExtendedList<T>> updateAction)
         {
@@ -174,6 +154,26 @@ namespace DynamicData
             }
 
             return observable;
+        }
+
+        /// <summary>
+        /// Disposes of managed and unmanaged responses.
+        /// </summary>
+        /// <param name="isDisposing">If being called by the Dispose method.</param>
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+
+            if (isDisposing)
+            {
+                _cleanUp.Dispose();
+                _changesPreview.Dispose();
+            }
         }
 
         private void InvokeNext(IChangeSet<T> changes)


### PR DESCRIPTION
### Problem
SourceList is currently a sealed class, which disallows inheriting from it. This makes it unnecessarily complex to add behaviours to lists, that should be reused.

For example I wanted to have a Copy function for specific variants of the list, that would provide type specific deep / shallow copying of the items.

Btw, the SourceCache class is not sealed. There it is easy to add those behaviours.

### Solution
Simply remove the sealed attribute... and as it then is required add a Dispose(bool) method.

### Impact / Risk
none - all current code should still run. Users should be responsible themselves when inheriting from SourceList