### PR TITLE
fix list sorting to replace without indexof

### DIFF
--- a/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
@@ -114,7 +114,7 @@ namespace DynamicData.Binding
                         }
                         else
                         {
-                            list.Replace(update.Previous.Value, update.Current);
+                            list[update.CurrentIndex] = update.Current;
                         }
 
                         break;


### PR DESCRIPTION
#392 introduced a change that slows down sorting.
The `list.Replace(...)` internally uses `IndexOf` to find the index of the item.
This is unnecessary as the index is known from the change