### PR TITLE
fix order of actual and expected values in asserts

### DIFF
--- a/src/DynamicData.Tests/Binding/NotifyPropertyChangedExFixture.cs
+++ b/src/DynamicData.Tests/Binding/NotifyPropertyChangedExFixture.cs
@@ -25,20 +25,20 @@ namespace DynamicData.Tests.Binding
             if (notifyOnInitialValue)
             {
                 anotherPerson.Should().Be(lastChange.Sender);
-                10.Should().Be(lastChange.Value);
+                lastChange.Value.Should().Be(10);
             }
             else
             {
                 lastChange.Sender.Name.Should().Be("unknown");
-                (-1).Should().Be(lastChange.Value);
+                lastChange.Value.Should().Be(-1);
             }
 
             person.Age = 12;
-            person.Should().Be(lastChange.Sender);
-            12.Should().Be(lastChange.Value);
+            lastChange.Sender.Should().Be(person);
+            lastChange.Value.Should().Be(12);
             anotherPerson.Age = 13;
-            anotherPerson.Should().Be(lastChange.Sender);
-            13.Should().Be(lastChange.Value);
+            lastChange.Sender.Should().Be(anotherPerson);
+            lastChange.Value.Should().Be(13);
         }
 
         [Theory, InlineData(true), InlineData(false)]
@@ -50,21 +50,21 @@ namespace DynamicData.Tests.Binding
 
             if (notifyOnInitialValue)
             {
-                person.Should().Be(lastChange.Sender);
-                10.Should().Be(lastChange.Value);
+                lastChange.Sender.Should().Be(person);
+                lastChange.Value.Should().Be(10);
             }
             else
             {
                 lastChange.Sender.Name.Should().Be("unknown");
-                (-1).Should().Be(lastChange.Value);
+                lastChange.Value.Should().Be(-1);
             }
 
             person.Age = 12;
-            person.Should().Be(lastChange.Sender);
-            12.Should().Be(lastChange.Value);
+            lastChange.Sender.Should().Be(person);
+            lastChange.Value.Should().Be(12);
             person.Age = 13;
-            person.Should().Be(lastChange.Sender);
-            13.Should().Be(lastChange.Value);
+            lastChange.Sender.Should().Be(person);
+            lastChange.Value.Should().Be(13);
         }
 
         [Theory, InlineData(true), InlineData(false)]
@@ -76,9 +76,9 @@ namespace DynamicData.Tests.Binding
 
             (notifyOnInitialValue ? 10 : -1).Should().Be(age);
             person.Age = 12;
-            12.Should().Be(age);
+            age.Should().Be(12);
             person.Age = 13;
-            13.Should().Be(age);
+            age.Should().Be(13);
         }
 
         [Theory, InlineData(true), InlineData(false)]
@@ -94,9 +94,9 @@ namespace DynamicData.Tests.Binding
 
             (notifyOnInitialValue ? 10 : -1).Should().Be(lastAgeChange);
             person.Age = 12;
-            12.Should().Be(lastAgeChange);
+            lastAgeChange.Should().Be(12);
             anotherPerson.Age = 13;
-            13.Should().Be(lastAgeChange);
+            lastAgeChange.Should().Be(13);
         }
     }
 }

--- a/src/DynamicData.Tests/Cache/FilterOnPropertyFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterOnPropertyFixture.cs
@@ -33,8 +33,8 @@ namespace DynamicData.Tests.Cache
 
             people[20].Age = 10;
 
-            2.Should().Be(stub.Results.Messages.Count);
-            81.Should().Be(stub.Results.Data.Count);
+            stub.Results.Messages.Count.Should().Be(2);
+            stub.Results.Data.Count.Should().Be(81);
         }
 
         [Fact]
@@ -46,8 +46,8 @@ namespace DynamicData.Tests.Cache
 
             people[10].Age = 20;
 
-            2.Should().Be(stub.Results.Messages.Count);
-            83.Should().Be(stub.Results.Data.Count);
+            stub.Results.Messages.Count.Should().Be(2);
+            stub.Results.Data.Count.Should().Be(83);
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace DynamicData.Tests.Cache
             using var stub = new FilterPropertyStub();
             stub.Source.AddOrUpdate(people);
 
-            1.Should().Be(stub.Results.Messages.Count);
-            82.Should().Be(stub.Results.Data.Count);
+            stub.Results.Messages.Count.Should().Be(1);
+            stub.Results.Data.Count.Should().Be(82);
 
             stub.Results.Data.Items.Should().BeEquivalentTo(people.Skip(18));
         }

--- a/src/DynamicData.Tests/Cache/FullJoinFixture.cs
+++ b/src/DynamicData.Tests/Cache/FullJoinFixture.cs
@@ -36,7 +36,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
             _result.Data.Lookup("Device1").HasValue.Should().BeTrue();
             _result.Data.Lookup("Device2").HasValue.Should().BeTrue();
             _result.Data.Lookup("Device3").HasValue.Should().BeTrue();
@@ -64,7 +64,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().BeTrue();
         }
@@ -80,7 +80,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
             _result.Data.Lookup("Device1").HasValue.Should().BeTrue();
             _result.Data.Lookup("Device2").HasValue.Should().BeTrue();
             _result.Data.Lookup("Device3").HasValue.Should().BeTrue();
@@ -107,7 +107,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().BeTrue();
         }
@@ -143,8 +143,8 @@ namespace DynamicData.Tests.Cache
 
             _right.Remove("Device3");
 
-            3.Should().Be(_result.Data.Count);
-            2.Should().Be(_result.Data.Items.Count(dwm => dwm.MetaData != Optional<DeviceMetaData>.None));
+            _result.Data.Count.Should().Be(3);
+            _result.Data.Items.Count(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().Be(2);
 
             _left.Remove("Device1");
             _result.Data.Lookup("Device1").HasValue.Should().BeTrue();
@@ -171,7 +171,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().BeTrue();
         }

--- a/src/DynamicData.Tests/Cache/InnerJoinFixture.cs
+++ b/src/DynamicData.Tests/Cache/InnerJoinFixture.cs
@@ -36,7 +36,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            0.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(0);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(3,"Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(3,"Device3"));
                     });
 
-            0.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(0);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
         }
 
         public void Dispose()
@@ -129,10 +129,10 @@ namespace DynamicData.Tests.Cache
 
             _right.Remove(3);
 
-            2.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(2);
 
             _left.Remove("Device1");
-            1.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(1);
             _result.Data.Lookup(("Device1",1)).HasValue.Should().BeFalse();
             _result.Data.Lookup(("Device2",2)).HasValue.Should().BeTrue();
             _result.Data.Lookup(("Device3",3)).HasValue.Should().BeFalse();
@@ -157,7 +157,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
         }
 
 
@@ -180,7 +180,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(3,"Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
         }
 
         [Fact]
@@ -203,7 +203,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(4,"Device4"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Lookup(("Device4",4)).HasValue.Should().BeFalse();
 

--- a/src/DynamicData.Tests/Cache/LeftJoinFixture.cs
+++ b/src/DynamicData.Tests/Cache/LeftJoinFixture.cs
@@ -36,7 +36,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
             _result.Data.Lookup("Device1").HasValue.Should().BeTrue();
             _result.Data.Lookup("Device2").HasValue.Should().BeTrue();
             _result.Data.Lookup("Device3").HasValue.Should().BeTrue();
@@ -63,7 +63,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().BeTrue();
         }
@@ -79,7 +79,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData("Device3"));
                     });
 
-            0.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(0);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().BeTrue();
         }
@@ -134,8 +134,8 @@ namespace DynamicData.Tests.Cache
 
             _right.Remove("Device3");
 
-            3.Should().Be(_result.Data.Count);
-            2.Should().Be(_result.Data.Items.Count(dwm => dwm.MetaData != Optional<DeviceMetaData>.None));
+            _result.Data.Count.Should().Be(3);
+            _result.Data.Items.Count(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().Be(2);
 
             _left.Remove("Device1");
             _result.Data.Lookup("Device1").HasValue.Should().BeFalse();
@@ -160,7 +160,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.MetaData != Optional<DeviceMetaData>.None).Should().BeTrue();
         }

--- a/src/DynamicData.Tests/Cache/RightJoinFixture.cs
+++ b/src/DynamicData.Tests/Cache/RightJoinFixture.cs
@@ -36,7 +36,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            0.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(0);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(3,"Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.Device != Optional<Device>.None).Should().BeTrue();
         }
@@ -74,7 +74,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(3,"Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
             _result.Data.Lookup(1).HasValue.Should().BeTrue();
             _result.Data.Lookup(2).HasValue.Should().BeTrue();
             _result.Data.Lookup(3).HasValue.Should().BeTrue();
@@ -101,7 +101,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.Device != Optional<Device>.None).Should().BeTrue();
         }
@@ -134,12 +134,12 @@ namespace DynamicData.Tests.Cache
 
             _right.Remove(3);
 
-            2.Should().Be(_result.Data.Count);
-            2.Should().Be(_result.Data.Items.Count(dwm => dwm.Device != Optional<Device>.None));
+            _result.Data.Count.Should().Be(2);
+            _result.Data.Items.Count(dwm => dwm.Device != Optional<Device>.None).Should().Be(2);
 
             _left.Remove("Device1");
             _result.Data.Lookup(1).HasValue.Should().BeTrue();
-            1.Should().Be(_result.Data.Items.Count(dwm => dwm.Device == Optional<Device>.None));
+            _result.Data.Items.Count(dwm => dwm.Device == Optional<Device>.None).Should().Be(1);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new Device("Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.Device != Optional<Device>.None).Should().BeTrue();
         }
@@ -185,7 +185,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(3,"Device3"));
                     });
 
-            3.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(3);
 
             _result.Data.Items.All(dwm => dwm.Device != Optional<Device>.None).Should().BeTrue();
         }
@@ -210,7 +210,7 @@ namespace DynamicData.Tests.Cache
                         innerCache.AddOrUpdate(new DeviceMetaData(4,"Device4"));
                     });
 
-            4.Should().Be(_result.Data.Count);
+            _result.Data.Count.Should().Be(4);
 
             _result.Data.Lookup(4).HasValue.Should().BeTrue();
             _result.Data.Items.Count(dwm => dwm.Device == Optional<Device>.None).Should().Be(1);

--- a/src/DynamicData.Tests/Kernal/CacheUpdaterFixture.cs
+++ b/src/DynamicData.Tests/Kernal/CacheUpdaterFixture.cs
@@ -30,7 +30,7 @@ namespace DynamicData.Tests.Kernal
 
             _cache.Lookup("Adult1").Value.Should().Be(person);
             _cache.Count.Should().Be(1);
-            1.Should().Be(updates.Count, "Should be 1 updates");
+            updates.Count.Should().Be(1);
             updates.First().Should().Be(new Change<Person, string>(ChangeReason.Add, person.Name, person), "Should be 1 updates");
         }
 
@@ -57,9 +57,9 @@ namespace DynamicData.Tests.Kernal
             IChangeSet<Person, string> updates = _cache.CaptureChanges();
 
             _cache.Count.Should().Be(0);
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 1 add");
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Remove), "Should be 1 remove");
-            2.Should().Be(updates.Count, "Should be 2 updates");
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(1);
+            updates.Count(update => update.Reason == ChangeReason.Remove).Should().Be(1);
+            updates.Count.Should().Be(2);
         }
 
         [Fact]
@@ -75,9 +75,9 @@ namespace DynamicData.Tests.Kernal
 
             _cache.Lookup(key).Value.Should().Be(updated);
             _cache.Count.Should().Be(1);
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 1 adds");
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Update), "Should be 1 update");
-            2.Should().Be(updates.Count, "Should be 2 updates");
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(1);
+            updates.Count(update => update.Reason == ChangeReason.Update).Should().Be(1);
+            updates.Count.Should().Be(2);
         }
     }
 }

--- a/src/DynamicData.Tests/Kernal/SourceUpdaterFixture.cs
+++ b/src/DynamicData.Tests/Kernal/SourceUpdaterFixture.cs
@@ -30,7 +30,7 @@ namespace DynamicData.Tests.Kernal
 
             _cache.Lookup("Adult1").Value.Should().Be(person);
             _cache.Count.Should().Be(1);
-            1.Should().Be(updates.Count, "Should be 1 updates");
+            updates.Count.Should().Be(1);
             updates.First().Should().Be(new Change<Person, string>(ChangeReason.Add, person.Name, person), "Should be 1 updates");
         }
 
@@ -68,9 +68,9 @@ namespace DynamicData.Tests.Kernal
             IChangeSet<Person, string> updates = _cache.CaptureChanges();
 
             _cache.Count.Should().Be(0, "Everything should be removed");
-            100.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 100 adds");
-            100.Should().Be(updates.Count(update => update.Reason == ChangeReason.Remove), "Should be 100 removes");
-            200.Should().Be(updates.Count, "Should be 200 updates");
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(100);
+            updates.Count(update => update.Reason == ChangeReason.Remove).Should().Be(100);
+            updates.Count.Should().Be(200);
         }
 
         [Fact]
@@ -83,9 +83,9 @@ namespace DynamicData.Tests.Kernal
 
             _cache.Lookup("Name1").Value.Age.Should().Be(100);
             _cache.Count.Should().Be(1, "Successive updates should replace cache value");
-            99.Should().Be(updates.Count(update => update.Reason == ChangeReason.Update), "Should be 99 updates");
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 1 add");
-            100.Should().Be(updates.Count, "Should be 100 updates");
+            updates.Count(update => update.Reason == ChangeReason.Update).Should().Be(99);
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(1);
+            updates.Count.Should().Be(100);
         }
 
         [Fact]
@@ -99,9 +99,9 @@ namespace DynamicData.Tests.Kernal
             IChangeSet<Person, string> updates = _cache.CaptureChanges();
 
             _cache.Count.Should().Be(0);
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 1 add");
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Remove), "Should be 1 remove");
-            2.Should().Be(updates.Count, "Should be 2 updates");
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(1);
+            updates.Count(update => update.Reason == ChangeReason.Remove).Should().Be(1);
+            updates.Count.Should().Be(2);
         }
 
         [Fact]
@@ -117,9 +117,9 @@ namespace DynamicData.Tests.Kernal
 
             _cache.Lookup(key).Value.Should().Be(updated);
             _cache.Count.Should().Be(1);
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 1 adds");
-            1.Should().Be(updates.Count(update => update.Reason == ChangeReason.Update), "Should be 1 update");
-            2.Should().Be(updates.Count, "Should be 2 updates");
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(1);
+            updates.Count(update => update.Reason == ChangeReason.Update).Should().Be(1);
+            updates.Count.Should().Be(2);
         }
 
         [Fact]
@@ -131,9 +131,9 @@ namespace DynamicData.Tests.Kernal
             IChangeSet<Person, string> updates = _cache.CaptureChanges();
 
             _cache.Count.Should().Be(0, "Everything should be removed");
-            100.Should().Be(updates.Count(update => update.Reason == ChangeReason.Add), "Should be 100 adds");
-            100.Should().Be(updates.Count(update => update.Reason == ChangeReason.Remove), "Should be 100 removes");
-            200.Should().Be(updates.Count, "Should be 200 updates");
+            updates.Count(update => update.Reason == ChangeReason.Add).Should().Be(100);
+            updates.Count(update => update.Reason == ChangeReason.Remove).Should().Be(100);
+            updates.Count.Should().Be(200);
         }
 
         [Fact]

--- a/src/DynamicData.Tests/List/FilterOnPropertyFixture.cs
+++ b/src/DynamicData.Tests/List/FilterOnPropertyFixture.cs
@@ -32,8 +32,8 @@ namespace DynamicData.Tests.List
 
             people[20].Age = 10;
 
-            2.Should().Be(stub.Results.Messages.Count);
-            81.Should().Be(stub.Results.Data.Count);
+            stub.Results.Messages.Count.Should().Be(2);
+            stub.Results.Data.Count.Should().Be(81);
         }
 
         [Fact]
@@ -45,8 +45,8 @@ namespace DynamicData.Tests.List
 
             people[10].Age = 20;
 
-            2.Should().Be(stub.Results.Messages.Count);
-            83.Should().Be(stub.Results.Data.Count);
+            stub.Results.Messages.Count.Should().Be(2);
+            stub.Results.Data.Count.Should().Be(83);
         }
 
         [Fact]
@@ -67,8 +67,8 @@ namespace DynamicData.Tests.List
             using var stub = new FilterPropertyStub();
             stub.Source.AddRange(people);
 
-            1.Should().Be(stub.Results.Messages.Count);
-            82.Should().Be(stub.Results.Data.Count);
+            stub.Results.Messages.Count.Should().Be(1);
+            stub.Results.Data.Count.Should().Be(82);
 
             stub.Results.Data.Items.Should().BeEquivalentTo(people.Skip(18));
         }

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsFixture.cs
@@ -20,24 +20,24 @@ namespace DynamicData.Tests.List
 
             var d = parent.Connect().MergeMany(e => e.Connect().RemoveIndex()).AsObservableList();
 
-            0.Should().Be(d.Count);
+            d.Count.Should().Be(0);
 
             a.Add(1);
 
-            1.Should().Be(d.Count);
+            d.Count.Should().Be(1);
             a.Add(2);
-            2.Should().Be(d.Count);
+            d.Count.Should().Be(2);
 
             b.Add(3);
-            3.Should().Be(d.Count);
+            d.Count.Should().Be(3);
             b.Add(5);
-            4.Should().Be(d.Count);
+            d.Count.Should().Be(4);
             new[] { 1, 2, 3, 5 }.Should().BeEquivalentTo(d.Items);
 
             b.Clear();
 
             // Fails below
-            2.Should().Be(d.Count);
+            d.Count.Should().Be(2);
             new[] { 1, 2 }.Should().BeEquivalentTo(d.Items);
         }
     }


### PR DESCRIPTION
some of unit tests have switched actual and expected values, like
`3.Should().Be(_result.Data.Count);`
so switching it to
`_result.Data.Count.Should().Be(3);`
for correct message when test fails