### PR TITLE
fix: Remove support for net5

### DIFF
--- a/src/DynamicData/DynamicData.csproj
+++ b/src/DynamicData/DynamicData.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;uap10.0.16299;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;uap10.0.16299;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>

--- a/src/DynamicData/DynamicData.csproj
+++ b/src/DynamicData/DynamicData.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;uap10.0.16299;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;uap10.0.16299;net6.0;net6.0-windows</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.4",
+  "version": "7.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of master
     "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
Net 5 support is being dropped in the near future. Remove support. https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

net461 support is being dropped https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/

Bump the version number