### PR TITLE
Provide Bind() options to choose whether to Remove/Add or Update

### DIFF
--- a/src/DynamicData.Tests/Binding/ReadonlyCollectionBindCacheFixture.cs
+++ b/src/DynamicData.Tests/Binding/ReadonlyCollectionBindCacheFixture.cs
@@ -1,31 +1,26 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reactive.Linq;
-
 using DynamicData.Binding;
 using DynamicData.Tests.Domain;
-
 using FluentAssertions;
-
 using Xunit;
 
 namespace DynamicData.Tests.Binding;
 
-public class ObservableCollectionBindCacheFixture : IDisposable
+public class ReadonlyCollectionBindCacheFixture : IDisposable
 {
     private readonly IDisposable _binder;
-
-    private readonly ObservableCollectionExtended<Person> _collection = new();
-
+    private readonly ReadOnlyObservableCollection<Person> _collection;
     private readonly RandomPersonGenerator _generator = new();
-
     private readonly ISourceCache<Person, string> _source;
 
-    public ObservableCollectionBindCacheFixture()
+    public ReadonlyCollectionBindCacheFixture()
     {
         _source = new SourceCache<Person, string>(p => p.Name);
-        _binder = _source.Connect().Bind(_collection).Subscribe();
+        _binder = _source.Connect().Bind(out _collection).Subscribe();
     }
 
     [Fact]
@@ -82,11 +77,8 @@ public class ObservableCollectionBindCacheFixture : IDisposable
 
         void RunTest(bool useReplace)
         {
-            var collection = new ObservableCollectionExtended<Person>();
-
-            using var source =  new SourceCache<Person, string>(p => p.Name);
-            using var binder = source.Connect().Bind(collection, useReplaceForUpdates: useReplace).Subscribe();
-
+            using var source = new SourceCache<Person, string>(p => p.Name);
+            using var binder = source.Connect().Bind(out var collection, useReplaceForUpdates: useReplace).Subscribe();
 
             NotifyCollectionChangedAction action = default;
             source.AddOrUpdate(new Person("Adult1", 50));

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -585,9 +585,11 @@ public static class ObservableCacheEx
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <param name="source">The source.</param>
     /// <param name="destination">The destination.</param>
+    /// <param name="refreshThreshold">The number of changes before a reset notification is triggered.</param>
+    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates.  NB: Some platforms to not support replace notifications for binding.</param>
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination)
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, int refreshThreshold = 25, bool useReplaceForUpdates = false)
         where TKey : notnull
     {
         if (source is null)
@@ -600,7 +602,7 @@ public static class ObservableCacheEx
             throw new ArgumentNullException(nameof(destination));
         }
 
-        var updater = new ObservableCollectionAdaptor<TObject, TKey>();
+        var updater = new ObservableCollectionAdaptor<TObject, TKey>(refreshThreshold, useReplaceForUpdates);
         return source.Bind(destination, updater);
     }
 
@@ -745,11 +747,12 @@ public static class ObservableCacheEx
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <param name="source">The source.</param>
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
-    /// <param name="resetThreshold">The number of changes before a reset event is called on the observable collection.</param>
+    /// <param name="resetThreshold">The number of changes before a reset notification is triggered.</param>
+    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates.  NB: Some platforms to not support replace notifications for binding.</param>
     /// <param name="adaptor">Specify an adaptor to change the algorithm to update the target collection.</param>
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, IObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, bool useReplaceForUpdates = false, IObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
         where TKey : notnull
     {
         if (source is null)
@@ -759,7 +762,7 @@ public static class ObservableCacheEx
 
         var target = new ObservableCollectionExtended<TObject>();
         var result = new ReadOnlyObservableCollection<TObject>(target);
-        var updater = adaptor ?? new ObservableCollectionAdaptor<TObject, TKey>(resetThreshold);
+        var updater = adaptor ?? new ObservableCollectionAdaptor<TObject, TKey>(resetThreshold, useReplaceForUpdates);
         readOnlyObservableCollection = result;
         return source.Bind(target, updater);
     }

--- a/src/DynamicData/List/Change.cs
+++ b/src/DynamicData/List/Change.cs
@@ -2,12 +2,7 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 using DynamicData.Kernel;
-
-#pragma warning disable 1591
 
 // ReSharper disable once CheckNamespace
 namespace DynamicData;
@@ -103,12 +98,12 @@ public sealed class Change<T> : IEquatable<Change<T>>
 
         if (reason == ListChangeReason.Replace && !previous.HasValue)
         {
-            throw new ArgumentException("For ChangeReason.Change, must supply previous value");
+            throw new ArgumentException("For ChangeReason.Replace, must supply previous value");
         }
 
         if (reason == ListChangeReason.Refresh && currentIndex < 0)
         {
-            throw new ArgumentException("For ChangeReason.Refresh, must supply and index");
+            throw new ArgumentException("For ChangeReason.Refresh, must supply ad index");
         }
 
         Reason = reason;
@@ -193,8 +188,5 @@ public sealed class Change<T> : IEquatable<Change<T>>
     }
 
     /// <inheritdoc />
-    public override string ToString()
-    {
-        return $"{Reason}. {Range.Count} changes";
-    }
+    public override string ToString() => $"{Reason}. {Range.Count} changes";
 }

--- a/src/DynamicData/List/RangeChange.cs
+++ b/src/DynamicData/List/RangeChange.cs
@@ -60,35 +60,23 @@ public sealed class RangeChange<T> : IEnumerable<T>
     /// Adds the specified item to the range.
     /// </summary>
     /// <param name="item">The item.</param>
-    public void Add(T item)
-    {
-        _items.Add(item);
-    }
+    public void Add(T item) => _items.Add(item);
 
     /// <inheritdoc/>
-    public IEnumerator<T> GetEnumerator()
-    {
-        return _items.GetEnumerator();
-    }
+    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
 
     /// <summary>
     /// Inserts the  item in the range at the specified index.
     /// </summary>
     /// <param name="index">The index.</param>
     /// <param name="item">The item.</param>
-    public void Insert(int index, T item)
-    {
-        _items.Insert(index, item);
-    }
+    public void Insert(int index, T item) => _items.Insert(index, item);
 
     /// <summary>
     /// Sets the index of the starting index of the range.
     /// </summary>
     /// <param name="index">The index.</param>
-    public void SetStartingIndex(int index)
-    {
-        Index = index;
-    }
+    public void SetStartingIndex(int index) => Index = index;
 
     /// <summary>
     /// Returns a <see cref="string" /> that represents this instance.
@@ -99,8 +87,5 @@ public sealed class RangeChange<T> : IEnumerable<T>
     public override string ToString() => $"Range<{typeof(T).Name}>. Count={Count}";
 
     /// <inheritdoc/>
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.10",
+    "version": "7.11",
     "publicReleaseRefSpec": [
         "^refs/heads/main$", // we release out of master
         "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
Revert to original behaviour of unsorted bound list in Bind() operator which uses remove / add instead of replace. 

- Reverts #381 

Add an option  to use replace. 

- Fixes #641
- Fixes #640