### PR TITLE
Housekeeping/revert sort

### DIFF
--- a/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheFixture.cs
@@ -85,7 +85,7 @@ public class ObservableCollectionBindCacheFixture : IDisposable
             var collection = new ObservableCollectionExtended<Person>();
 
             using var source =  new SourceCache<Person, string>(p => p.Name);
-            using var binder = source.Connect().Bind(collection, useReplaceForUpdates: useReplace).Subscribe();
+            using var binder = source.Connect().Bind(collection, new ObservableCollectionAdaptor<Person, string>(useReplaceForUpdates: useReplace)).Subscribe();
 
 
             NotifyCollectionChangedAction action = default;

--- a/src/DynamicData/Cache/Internal/AnonymousQuery.cs
+++ b/src/DynamicData/Cache/Internal/AnonymousQuery.cs
@@ -13,10 +13,7 @@ internal sealed class AnonymousQuery<TObject, TKey> : IQuery<TObject, TKey>
 {
     private readonly Cache<TObject, TKey> _cache;
 
-    public AnonymousQuery(Cache<TObject, TKey> cache)
-    {
-        _cache = cache.Clone();
-    }
+    public AnonymousQuery(Cache<TObject, TKey> cache) => _cache = cache.Clone();
 
     public int Count => _cache.Count;
 
@@ -26,8 +23,5 @@ internal sealed class AnonymousQuery<TObject, TKey> : IQuery<TObject, TKey>
 
     public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _cache.KeyValues;
 
-    public Optional<TObject> Lookup(TKey key)
-    {
-        return _cache.Lookup(key);
-    }
+    public Optional<TObject> Lookup(TKey key) => _cache.Lookup(key);
 }

--- a/src/DynamicData/Cache/Internal/Cache.cs
+++ b/src/DynamicData/Cache/Internal/Cache.cs
@@ -23,10 +23,7 @@ internal class Cache<TObject, TKey> : ICache<TObject, TKey>
         _data = capacity > 1 ? new Dictionary<TKey, TObject>(capacity) : new Dictionary<TKey, TObject>();
     }
 
-    public Cache(Dictionary<TKey, TObject> data)
-    {
-        _data = data;
-    }
+    public Cache(Dictionary<TKey, TObject> data) => _data = data;
 
     public int Count => _data.Count;
 
@@ -36,20 +33,11 @@ internal class Cache<TObject, TKey> : ICache<TObject, TKey>
 
     public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _data;
 
-    public void AddOrUpdate(TObject item, TKey key)
-    {
-        _data[key] = item;
-    }
+    public void AddOrUpdate(TObject item, TKey key) => _data[key] = item;
 
-    public void Clear()
-    {
-        _data.Clear();
-    }
+    public void Clear() => _data.Clear();
 
-    public Cache<TObject, TKey> Clone()
-    {
-        return new(new Dictionary<TKey, TObject>(_data));
-    }
+    public Cache<TObject, TKey> Clone() => new(new Dictionary<TKey, TObject>(_data));
 
     public void Clone(IChangeSet<TObject, TKey> changes)
     {

--- a/src/DynamicData/Cache/Internal/EditDiff.cs
+++ b/src/DynamicData/Cache/Internal/EditDiff.cs
@@ -2,10 +2,6 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using DynamicData.Kernel;
 
 namespace DynamicData.Cache.Internal;

--- a/src/DynamicData/Cache/Internal/FilterEx.cs
+++ b/src/DynamicData/Cache/Internal/FilterEx.cs
@@ -60,12 +60,9 @@ internal static class FilterEx
                                 cache.Refresh(key);
                             }
                         }
-                        else
+                        else if (existing.HasValue)
                         {
-                            if (existing.HasValue)
-                            {
-                                cache.Remove(key);
-                            }
+                            cache.Remove(key);
                         }
                     }
 

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -585,10 +585,9 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="destination">The destination.</param>
     /// <param name="refreshThreshold">The number of changes before a reset notification is triggered.</param>
-    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates.  NB: Some platforms to not support replace notifications for binding.</param>
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, int refreshThreshold = 25, bool useReplaceForUpdates = false)
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, int refreshThreshold = 25)
         where TKey : notnull
     {
         if (source is null)
@@ -601,8 +600,7 @@ public static class ObservableCacheEx
             throw new ArgumentNullException(nameof(destination));
         }
 
-        var updater = new ObservableCollectionAdaptor<TObject, TKey>(refreshThreshold, useReplaceForUpdates);
-        return source.Bind(destination, updater);
+        return source.Bind(destination, new ObservableCollectionAdaptor<TObject, TKey>(refreshThreshold));
     }
 
     /// <summary>

--- a/src/DynamicData/Kernel/Optional.cs
+++ b/src/DynamicData/Kernel/Optional.cs
@@ -78,60 +78,39 @@ public readonly struct Optional<T> : IEquatable<Optional<T>>
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>The optional value.</returns>
-    public static implicit operator Optional<T>(T? value)
-    {
-        return ToOptional(value);
-    }
+    public static implicit operator Optional<T>(T? value) => ToOptional(value);
 
     /// <summary>
     /// Explicit cast from option to value.
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>The optional value.</returns>
-    public static explicit operator T?(Optional<T> value)
-    {
-        return FromOptional(value);
-    }
+    public static explicit operator T?(Optional<T> value) => FromOptional(value);
 
-    public static bool operator ==(Optional<T> left, Optional<T> right)
-    {
-        return left.Equals(right);
-    }
+    public static bool operator ==(Optional<T> left, Optional<T> right) => left.Equals(right);
 
-    public static bool operator !=(Optional<T> left, Optional<T> right)
-    {
-        return !left.Equals(right);
-    }
+    public static bool operator !=(Optional<T> left, Optional<T> right) => !left.Equals(right);
 
     /// <summary>
     /// Creates the specified value.
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>The optional value.</returns>
-    public static Optional<T> Create(T? value)
-    {
-        return new(value);
-    }
+    public static Optional<T> Create(T? value) => new(value);
 
     /// <summary>
     /// Gets the value from the optional value.
     /// </summary>
     /// <param name="value">The optional value.</param>
     /// <returns>The value.</returns>
-    public static T? FromOptional(Optional<T> value)
-    {
-        return value.Value;
-    }
+    public static T? FromOptional(Optional<T> value) => value.Value;
 
     /// <summary>
     /// Gets the optional from a value.
     /// </summary>
     /// <param name="value">The value to get the optional for.</param>
     /// <returns>The optional.</returns>
-    public static Optional<T> ToOptional(T? value)
-    {
-        return new(value);
-    }
+    public static Optional<T> ToOptional(T? value) => new(value);
 
     /// <inheritdoc />
     public bool Equals(Optional<T> other)
@@ -206,10 +185,7 @@ public static class Optional
     /// </summary>
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <returns>The optional value.</returns>
-    public static Optional<T> None<T>()
-    {
-        return Optional<T>.None;
-    }
+    public static Optional<T> None<T>() => Optional<T>.None;
 
     /// <summary>
     /// Wraps the specified value in an Optional container.
@@ -217,8 +193,5 @@ public static class Optional
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <param name="value">The value.</param>
     /// <returns>The optional value.</returns>
-    public static Optional<T> Some<T>(T value)
-    {
-        return new(value);
-    }
+    public static Optional<T> Some<T>(T value) => new(value);
 }


### PR DESCRIPTION
Revert useReplaceForUpdates for ObservableCacheEx.Bind, which is not in prod anyway. To use, construct own ObservableCollectionAdaptor.

See https://github.com/reactivemarbles/DynamicData/issues/641 for details

Instead use:

```cs
// use replace for updates
var collection = new ObservableCollectionExtended<MyType>();
var binder = source.Connect()
    .Bind(collection,new ObservableCollectionAdaptor<Person, string>(refreshThreshold:25,  useReplaceForUpdates: false)))
    .Subscribe();
```
