### PR TITLE
Make BindingList adaptors replace the changed item instead of re-adding

### DIFF
--- a/src/DynamicData/Binding/BindingListAdaptor.cs
+++ b/src/DynamicData/Binding/BindingListAdaptor.cs
@@ -119,23 +119,18 @@ namespace DynamicData.Binding
                         break;
 
                     case ChangeReason.Update:
-                        var item = update.Previous.Value;
-
-                        if (item is not null)
-                        {
-                            list.Remove(item);
-                        }
-
-                        list.Add(update.Current);
+                        var previousIndex = list.IndexOf(update.Previous.Value);
+                        if (previousIndex >= 0)
+                            list[previousIndex] = update.Current;
+                        else
+                            list.Add(update.Current);
                         break;
 
                     case ChangeReason.Refresh:
-                        {
-                            var index = list.IndexOf(update.Current);
-                            if (index != -1)
-                                list.ResetItem(index);
-                            break;
-                        }
+                        var index = list.IndexOf(update.Current);
+                        if (index != -1)
+                            list.ResetItem(index);
+                        break;
                 }
             }
         }

--- a/src/DynamicData/Binding/SortedBindingListAdaptor.cs
+++ b/src/DynamicData/Binding/SortedBindingListAdaptor.cs
@@ -100,17 +100,27 @@ namespace DynamicData.Binding
                         break;
 
                     case ChangeReason.Update:
-                        _list.RemoveAt(change.PreviousIndex);
-                        _list.Insert(change.CurrentIndex, change.Current);
+                        if (change.CurrentIndex != change.PreviousIndex)
+                        {
+                            _list.RemoveAt(change.PreviousIndex);
+                            _list.Insert(change.CurrentIndex, change.Current);
+                        }
+                        else
+                        {
+                            var previousIndex = _list.IndexOf(change.Previous.Value);
+                            if (previousIndex >= 0)
+                                _list[previousIndex] = change.Current;
+                            else
+                                _list.Add(change.Current);
+                        }
+
                         break;
 
                     case ChangeReason.Refresh:
-                        {
-                            var index = _list.IndexOf(change.Current);
-                            if (index != -1)
-                                _list.ResetItem(index);
-                            break;
-                        }
+                        var index = _list.IndexOf(change.Current);
+                        if (index != -1)
+                            _list.ResetItem(index);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Before it was deleting and adding the item again, resulting in two notifications for deleting and adding an item. This resulted in UI deselecting the updated item if it was selected, which is an undesired behavior. After this change it doesn't do that anymore.