### PR TITLE
Bugfix/forbid null items

### DIFF
--- a/src/DynamicData.Tests/Cache/AutoRefreshFixture.cs
+++ b/src/DynamicData.Tests/Cache/AutoRefreshFixture.cs
@@ -89,13 +89,13 @@ public class AutoRefreshFixture
     [Fact]
     public void MakeSelectMagicWorkWithObservable()
     {
-        var initialItem = new IntHolder { Value = 1, Description = "Initial Description" };
+        var initialItem = new IntHolder(1, "Initial Description");
 
         var sourceList = new SourceList<IntHolder>();
         sourceList.Add(initialItem);
 
         var descriptionStream = sourceList.Connect().AutoRefresh(intHolder => intHolder!.Description).Transform(intHolder => intHolder!.Description, true).Do(x => { }) // <--- Add break point here to check the overload fixes it
-            .Bind(out ReadOnlyObservableCollection<string?> resultCollection);
+            .Bind(out ReadOnlyObservableCollection<string> resultCollection);
 
         using (descriptionStream.Subscribe())
         {
@@ -109,11 +109,17 @@ public class AutoRefreshFixture
 
     public class IntHolder : AbstractNotifyPropertyChanged
     {
-        public string? _description_;
+        public string _description_;
 
         public int _value;
 
-        public string? Description
+        public IntHolder(int value, string description)
+        {
+            _value = value;
+            _description_ = description;
+        }
+
+        public string Description
         {
             get => _description_;
             set => SetAndRaise(ref _description_, value);

--- a/src/DynamicData.Tests/Cache/ObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Cache/ObservableChangeSetFixture.cs
@@ -217,6 +217,7 @@ public class ObservableChangeSetFixture
 
     private void SubscribeAndAssert<TObject, TKey>(IObservable<IChangeSet<TObject, TKey>> observableChangeset, bool expectsError = false, Action<IObservableCache<TObject, TKey>>? checkContentAction = null)
         where TKey : notnull
+        where TObject : notnull
     {
         Exception? error = null;
         bool complete = false;

--- a/src/DynamicData.Tests/Cache/TransformFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformFixture.cs
@@ -136,18 +136,6 @@ public class TransformFixture
     }
 
     [Fact]
-    public void TransformToNull()
-    {
-        using var source = new SourceCache<Person, string>(p => p.Name);
-        using var results = new ChangeSetAggregator<PersonWithGender?, string>(source.Connect().Transform((Func<Person, PersonWithGender?>)(p => null)));
-        source.AddOrUpdate(new Person("Adult1", 50));
-
-        results.Messages.Count.Should().Be(1, "Should be 1 updates");
-        results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(null, "Should be same person");
-    }
-
-    [Fact]
     public void Update()
     {
         const string key = "Adult1";

--- a/src/DynamicData.Tests/Cache/TransformFixtureParallel.cs
+++ b/src/DynamicData.Tests/Cache/TransformFixtureParallel.cs
@@ -110,19 +110,6 @@ public class TransformFixtureParallel : IDisposable
     }
 
     [Fact]
-    public void TransformToNull()
-    {
-        using var source = new SourceCache<Person, string>(p => p.Name);
-        using var results = new ChangeSetAggregator<PersonWithGender?, string>(source.Connect()
-            .Transform((Func<Person, PersonWithGender?>)(p => null), new ParallelisationOptions(ParallelType.Parallelise)));
-        source.AddOrUpdate(new Person("Adult1", 50));
-
-        results.Messages.Count.Should().Be(1, "Should be 1 updates");
-        results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(null, "Should be same person");
-    }
-
-    [Fact]
     public void Update()
     {
         const string key = "Adult1";

--- a/src/DynamicData.Tests/List/CreationFixtures.cs
+++ b/src/DynamicData.Tests/List/CreationFixtures.cs
@@ -26,6 +26,7 @@ public class ListCreationFixtures
     }
 
     private void SubscribeAndAssert<T>(IObservable<IChangeSet<T>> observableChangeset, bool expectsError = false)
+        where T : notnull
     {
         Exception? error = null;
         bool complete = false;

--- a/src/DynamicData.Tests/List/SortFixture.cs
+++ b/src/DynamicData.Tests/List/SortFixture.cs
@@ -51,7 +51,7 @@ public class SortChangedFixture
             Number = number;
         }
 
-        public int CompareTo([AllowNull] ListItem other) => DefaultComparer.Compare(this, other);
+        public int CompareTo(ListItem? other) => DefaultComparer.Compare(this, other);
             
     }
 }

--- a/src/DynamicData.Tests/List/TransformFixture.cs
+++ b/src/DynamicData.Tests/List/TransformFixture.cs
@@ -118,19 +118,6 @@ public class TransformFixture : IDisposable
     }
 
     [Fact]
-    public void TransformToNull()
-    {
-        using var source = new SourceList<Person>();
-        using var results = new ChangeSetAggregator<PersonWithGender?>(source.Connect()
-            .Transform((Func<Person, PersonWithGender?>)(p => null)));
-        source.Add(new Person("Adult1", 50));
-
-        results.Messages.Count.Should().Be(1, "Should be 1 updates");
-        results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(null, "Should be same person");
-    }
-
-    [Fact]
     public void Update()
     {
         const string key = "Adult1";

--- a/src/DynamicData/Aggregation/AggregateEnumerator.cs
+++ b/src/DynamicData/Aggregation/AggregateEnumerator.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace DynamicData.Aggregation;
 
 internal class AggregateEnumerator<T> : IAggregateChangeSet<T>
+    where T : notnull
 {
     private readonly IChangeSet<T> _source;
 
@@ -64,6 +65,7 @@ internal class AggregateEnumerator<T> : IAggregateChangeSet<T>
 
 [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Same name, different generics.")]
 internal class AggregateEnumerator<TObject, TKey> : IAggregateChangeSet<TObject>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IChangeSet<TObject, TKey> _source;

--- a/src/DynamicData/Aggregation/AggregationEx.cs
+++ b/src/DynamicData/Aggregation/AggregationEx.cs
@@ -22,6 +22,7 @@ public static class AggregationEx
     /// <param name="source">The source.</param>
     /// <returns>The aggregated change set.</returns>
     public static IObservable<IAggregateChangeSet<TObject>> ForAggregation<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -39,6 +40,7 @@ public static class AggregationEx
     /// <param name="source">The source.</param>
     /// <returns>The aggregated change set.</returns>
     public static IObservable<IAggregateChangeSet<TObject>> ForAggregation<TObject>(this IObservable<IChangeSet<TObject>> source)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -87,6 +89,7 @@ public static class AggregationEx
     /// <param name="removeAction">The remove action.</param>
     /// <returns>An observable with the accumulated value.</returns>
     internal static IObservable<TResult> Accumulate<TObject, TResult>(this IObservable<IChangeSet<TObject>> source, TResult seed, Func<TObject, TResult> accessor, Func<TResult, TResult, TResult> addAction, Func<TResult, TResult, TResult> removeAction)
+        where TObject : notnull
     {
         return source.ForAggregation().Accumulate(seed, accessor, addAction, removeAction);
     }
@@ -105,6 +108,7 @@ public static class AggregationEx
     /// <param name="removeAction">The remove action.</param>
     /// <returns>An observable with the accumulated value.</returns>
     internal static IObservable<TResult> Accumulate<TObject, TKey, TResult>(this IObservable<IChangeSet<TObject, TKey>> source, TResult seed, Func<TObject, TResult> accessor, Func<TResult, TResult, TResult> addAction, Func<TResult, TResult, TResult> removeAction)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Accumulate(seed, accessor, addAction, removeAction);

--- a/src/DynamicData/Aggregation/AvgEx.cs
+++ b/src/DynamicData/Aggregation/AvgEx.cs
@@ -25,6 +25,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int> valueSelector, int emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -42,6 +43,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int?> valueSelector, int emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -59,6 +61,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long> valueSelector, long emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -76,6 +79,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long?> valueSelector, long emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -93,6 +97,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double> valueSelector, double emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -110,6 +115,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double?> valueSelector, double emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -127,6 +133,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<decimal> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal> valueSelector, decimal emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -144,6 +151,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<decimal> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal?> valueSelector, decimal emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -161,6 +169,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<float> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float> valueSelector, float emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -178,6 +187,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<float> Avg<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float?> valueSelector, float emptyValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
@@ -194,6 +204,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, int> valueSelector, int emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -209,6 +220,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, int?> valueSelector, int emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -224,6 +236,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, long> valueSelector, long emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -239,6 +252,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, long?> valueSelector, long emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -254,6 +268,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, double> valueSelector, double emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -269,6 +284,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<double> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, double?> valueSelector, double emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -284,6 +300,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<decimal> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal> valueSelector, decimal emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -299,6 +316,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<decimal> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal?> valueSelector, decimal emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -314,6 +332,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<float> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, float> valueSelector, float emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }
@@ -329,6 +348,7 @@ public static class AvgEx
     /// An observable of averages.
     /// </returns>
     public static IObservable<float> Avg<T>(this IObservable<IChangeSet<T>> source, Func<T, float?> valueSelector, float emptyValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().Avg(valueSelector, emptyValue);
     }

--- a/src/DynamicData/Aggregation/CountEx.cs
+++ b/src/DynamicData/Aggregation/CountEx.cs
@@ -20,6 +20,7 @@ public static class CountEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the count.</returns>
     public static IObservable<int> Count<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Count();
@@ -32,6 +33,7 @@ public static class CountEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the count.</returns>
     public static IObservable<int> Count<TObject>(this IObservable<IChangeSet<TObject>> source)
+        where TObject : notnull
     {
         return source.ForAggregation().Count();
     }
@@ -68,6 +70,7 @@ public static class CountEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the count.</returns>
     public static IObservable<bool> IsEmpty<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Count().StartWith(0).Select(count => count == 0);
@@ -81,6 +84,7 @@ public static class CountEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the count.</returns>
     public static IObservable<bool> IsEmpty<TObject>(this IObservable<IChangeSet<TObject>> source)
+        where TObject : notnull
     {
         return source.ForAggregation().Count().StartWith(0).Select(count => count == 0);
     }
@@ -94,6 +98,7 @@ public static class CountEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the count.</returns>
     public static IObservable<bool> IsNotEmpty<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Count().StartWith(0).Select(count => count > 0);
@@ -107,6 +112,7 @@ public static class CountEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the count.</returns>
     public static IObservable<bool> IsNotEmpty<TObject>(this IObservable<IChangeSet<TObject>> source)
+        where TObject : notnull
     {
         return source.ForAggregation().Count().StartWith(0).Select(count => count > 0);
     }

--- a/src/DynamicData/Aggregation/MaxEx.cs
+++ b/src/DynamicData/Aggregation/MaxEx.cs
@@ -33,6 +33,7 @@ public static class MaxEx
     /// A distinct observable of the maximum item.
     /// </returns>
     public static IObservable<TResult> Maximum<TObject, TResult>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TResult> valueSelector, TResult emptyValue = default)
+        where TObject : notnull
         where TResult : struct, IComparable<TResult>
     {
         return source.ToChangesAndCollection().Calculate(valueSelector, MaxOrMin.Max, emptyValue);
@@ -51,6 +52,7 @@ public static class MaxEx
     /// A distinct observable of the maximum item.
     /// </returns>
     public static IObservable<TResult> Maximum<TObject, TKey, TResult>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TResult> valueSelector, TResult emptyValue = default)
+        where TObject : notnull
         where TKey : notnull
         where TResult : struct, IComparable<TResult>
     {
@@ -67,6 +69,7 @@ public static class MaxEx
     /// <param name="emptyValue">The value to use when the underlying collection is empty.</param>
     /// <returns>A distinct observable of the minimums item.</returns>
     public static IObservable<TResult> Minimum<TObject, TResult>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TResult> valueSelector, TResult emptyValue = default)
+        where TObject : notnull
         where TResult : struct, IComparable<TResult>
     {
         return source.ToChangesAndCollection().Calculate(valueSelector, MaxOrMin.Min, emptyValue);
@@ -85,6 +88,7 @@ public static class MaxEx
     /// A distinct observable of the minimums item.
     /// </returns>
     public static IObservable<TResult> Minimum<TObject, TKey, TResult>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TResult> valueSelector, TResult emptyValue = default)
+        where TObject : notnull
         where TKey : notnull
         where TResult : struct, IComparable<TResult>
     {
@@ -162,6 +166,7 @@ public static class MaxEx
     }
 
     private static IObservable<ChangesAndCollection<TObject>> ToChangesAndCollection<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -179,6 +184,7 @@ public static class MaxEx
     }
 
     private static IObservable<ChangesAndCollection<TObject>> ToChangesAndCollection<TObject>(this IObservable<IChangeSet<TObject>> source)
+        where TObject : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/Aggregation/StdDevEx.cs
+++ b/src/DynamicData/Aggregation/StdDevEx.cs
@@ -22,6 +22,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<T>(this IObservable<IChangeSet<T>> source, Func<T, int> valueSelector, int fallbackValue)
+        where T : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
     }
@@ -35,6 +36,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<T>(this IObservable<IChangeSet<T>> source, Func<T, long> valueSelector, long fallbackValue)
+        where T : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
     }
@@ -48,6 +50,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<T>(this IObservable<IChangeSet<T>> source, Func<T, double> valueSelector, double fallbackValue)
+        where T : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
     }
@@ -61,6 +64,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal> valueSelector, decimal fallbackValue)
+        where T : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
     }
@@ -74,6 +78,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<T>(this IObservable<IChangeSet<T>> source, Func<T, float> valueSelector, float fallbackValue = 0)
+        where T : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
     }
@@ -88,6 +93,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int> valueSelector, int fallbackValue)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
@@ -103,6 +109,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long> valueSelector, long fallbackValue)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
@@ -118,6 +125,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double> valueSelector, double fallbackValue)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
@@ -133,6 +141,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal> valueSelector, decimal fallbackValue)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);
@@ -148,6 +157,7 @@ public static class StdDevEx
     /// <param name="fallbackValue">The fallback value.</param>
     /// <returns>An observable which emits the standard deviation value.</returns>
     public static IObservable<double> StdDev<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float> valueSelector, float fallbackValue = 0)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().StdDev(valueSelector, fallbackValue);

--- a/src/DynamicData/Aggregation/SumEx.cs
+++ b/src/DynamicData/Aggregation/SumEx.cs
@@ -22,6 +22,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -36,6 +37,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int?> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -50,6 +52,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -64,6 +67,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long?> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -78,6 +82,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -92,6 +97,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double?> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -106,6 +112,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -120,6 +127,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal?> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -134,6 +142,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -148,6 +157,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float?> valueSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
@@ -161,6 +171,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, int> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -173,6 +184,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, int?> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -185,6 +197,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, long> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -197,6 +210,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, long?> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -209,6 +223,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, double> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -221,6 +236,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, double?> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -233,6 +249,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -245,6 +262,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal?> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -257,6 +275,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, float> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }
@@ -269,6 +288,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, float?> valueSelector)
+        where T : notnull
     {
         return source.ForAggregation().Sum(valueSelector);
     }

--- a/src/DynamicData/Alias/ObservableCacheAlias.cs
+++ b/src/DynamicData/Alias/ObservableCacheAlias.cs
@@ -31,6 +31,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Select<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -67,6 +69,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Select<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         return source.Transform(transformFactory, forceTransform);
@@ -88,6 +92,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Select<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         return source.Transform(transformFactory, forceTransform);
@@ -109,6 +115,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Select<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, IObservable<Func<TSource, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -136,7 +144,9 @@ public static class ObservableCacheAlias
     /// <param name="keySelector">The key selector which must be unique across all.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination, TDestinationKey>> SelectMany<TDestination, TDestinationKey, TSource, TSourceKey>(this IObservable<IChangeSet<TSource, TSourceKey>> source, Func<TSource, IEnumerable<TDestination>> manySelector, Func<TDestination, TDestinationKey> keySelector)
+        where TDestination : notnull
         where TDestinationKey : notnull
+        where TSource : notnull
         where TSourceKey : notnull
     {
         return source.TransformMany(manySelector, keySelector);
@@ -162,6 +172,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> SelectSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -207,6 +219,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> SelectSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -247,6 +261,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> SelectSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -287,6 +303,8 @@ public static class ObservableCacheAlias
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> SelectSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         return source.TransformSafe(transformFactory, errorHandler, forceTransform);
@@ -301,8 +319,8 @@ public static class ObservableCacheAlias
     /// <param name="pivotOn">The pivot on.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<Node<TObject, TKey>, TKey>> SelectTree<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey> pivotOn)
-        where TKey : notnull
         where TObject : class
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -326,6 +344,7 @@ public static class ObservableCacheAlias
     /// <param name="filter">The filter.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Where<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, bool> filter)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -345,6 +364,7 @@ public static class ObservableCacheAlias
     /// <param name="predicateChanged">Observable to change the underlying predicate.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Where<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, bool>> predicateChanged)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -369,6 +389,7 @@ public static class ObservableCacheAlias
     /// <param name="reapplyFilter">Observable to re-evaluate whether the filter still matches items. Use when filtering on mutable values.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Where<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Unit> reapplyFilter)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -394,6 +415,7 @@ public static class ObservableCacheAlias
     /// <param name="reapplyFilter">Observable to re-evaluate whether the filter still matches items. Use when filtering on mutable values.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Where<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, bool>> predicateChanged, IObservable<Unit> reapplyFilter)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)

--- a/src/DynamicData/Alias/ObservableListAlias.cs
+++ b/src/DynamicData/Alias/ObservableListAlias.cs
@@ -26,6 +26,8 @@ public static class ObservableListAlias
     /// valueSelector.
     /// </exception>
     public static IObservable<IChangeSet<TDestination>> Select<TSource, TDestination>(this IObservable<IChangeSet<TSource>> source, Func<TSource, TDestination> transformFactory)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -50,6 +52,8 @@ public static class ObservableListAlias
     /// <param name="manySelector">The selector for the enumerable.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination>> SelectMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source, Func<TSource, IEnumerable<TDestination>> manySelector)
+        where TDestination : notnull
+        where TSource : notnull
     {
         if (source is null)
         {
@@ -73,6 +77,7 @@ public static class ObservableListAlias
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> Where<T>(this IObservable<IChangeSet<T>> source, Func<T, bool> predicate)
+        where T : notnull
     {
         if (source is null)
         {
@@ -98,6 +103,7 @@ public static class ObservableListAlias
     /// or
     /// filterController.</exception>
     public static IObservable<IChangeSet<T>> Where<T>(this IObservable<IChangeSet<T>> source, IObservable<Func<T, bool>> predicate)
+        where T : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/Binding/BindingListAdaptor.cs
+++ b/src/DynamicData/Binding/BindingListAdaptor.cs
@@ -15,6 +15,7 @@ namespace DynamicData.Binding
     /// </summary>
     /// <typeparam name="T">The type of items.</typeparam>
     public class BindingListAdaptor<T> : IChangeSetAdaptor<T>
+        where T : notnull
     {
         private readonly BindingList<T> _list;
 
@@ -63,6 +64,7 @@ namespace DynamicData.Binding
     /// <typeparam name="TKey">The type of the key.</typeparam>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Same class name, different generics")]
     public class BindingListAdaptor<TObject, TKey> : IChangeSetAdaptor<TObject, TKey>
+        where TObject : notnull
         where TKey : notnull
     {
         private readonly Cache<TObject, TKey> _cache = new();

--- a/src/DynamicData/Binding/BindingListEx.cs
+++ b/src/DynamicData/Binding/BindingListEx.cs
@@ -15,6 +15,7 @@ namespace DynamicData.Binding;
 public static class BindingListEx
 {
     internal static void Clone<T>(this BindingList<T> source, IEnumerable<Change<T>> changes)
+        where T : notnull
     {
         // ** Copied from ListEx for binding list specific changes
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -27,6 +28,7 @@ public static class BindingListEx
     }
 
     private static void Clone<T>(this BindingList<T> source, Change<T> item, IEqualityComparer<T> equalityComparer)
+        where T : notnull
     {
         switch (item.Reason)
         {
@@ -172,6 +174,7 @@ public static class BindingListEx
     /// <returns>An observable which emits change set values.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this BindingList<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -194,6 +197,7 @@ public static class BindingListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this BindingList<TObject> source, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -220,6 +224,7 @@ public static class BindingListEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<TCollection, T>(this TCollection source)
         where TCollection : IBindingList, IEnumerable<T>
+        where T : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/Binding/IObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/IObservableCollectionAdaptor.cs
@@ -11,6 +11,7 @@ namespace DynamicData.Binding;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IObservableCollectionAdaptor<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Binding/IObservableListEx.cs
+++ b/src/DynamicData/Binding/IObservableListEx.cs
@@ -26,6 +26,7 @@ public static class IObservableListEx
     /// <returns>The <paramref name="source"/> change set for continued chaining.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject>> BindToObservableList<TObject>(this IObservable<IChangeSet<TObject>> source, out IObservableList<TObject> observableList)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -56,6 +57,7 @@ public static class IObservableListEx
     /// <returns>The <paramref name="source"/> change set for continued chaining.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> BindToObservableList<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, out IObservableList<TObject> observableList)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -87,6 +89,7 @@ public static class IObservableListEx
     /// <returns>The <paramref name="source"/> change set for continued chaining.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<ISortedChangeSet<TObject, TKey>> BindToObservableList<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out IObservableList<TObject> observableList)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -143,6 +146,7 @@ public static class IObservableListEx
     /// <param name="list">The list needed to support refresh.</param>
     /// <returns>The down casted <see cref="IChangeSet{TObject}"/>.</returns>
     private static IChangeSet<TObject> RemoveKey<TObject, TKey>(this IChangeSet<TObject, TKey> changeSetWithKey, IExtendedList<TObject> list)
+        where TObject : notnull
         where TKey : notnull
     {
         var enumerator = new Cache.Internal.RemoveKeyEnumerator<TObject, TKey>(changeSetWithKey, list);

--- a/src/DynamicData/Binding/ISortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/ISortedObservableCollectionAdaptor.cs
@@ -11,6 +11,7 @@ namespace DynamicData.Binding;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface ISortedObservableCollectionAdaptor<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
@@ -15,6 +15,7 @@ namespace DynamicData.Binding;
 /// </summary>
 /// <typeparam name="T">The type of the item.</typeparam>
 public class ObservableCollectionAdaptor<T> : IChangeSetAdaptor<T>
+    where T : notnull
 {
     private readonly IObservableCollection<T> _collection;
 
@@ -68,6 +69,7 @@ public class ObservableCollectionAdaptor<T> : IChangeSetAdaptor<T>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Same class name, only generic difference.")]
 public class ObservableCollectionAdaptor<TObject, TKey> : IObservableCollectionAdaptor<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Cache<TObject, TKey> _cache = new();

--- a/src/DynamicData/Binding/ObservableCollectionEx.cs
+++ b/src/DynamicData/Binding/ObservableCollectionEx.cs
@@ -36,6 +36,7 @@ public static class ObservableCollectionEx
     /// <returns>An observable that emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this ObservableCollection<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -58,6 +59,7 @@ public static class ObservableCollectionEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this ObservableCollection<TObject> source, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -82,6 +84,7 @@ public static class ObservableCollectionEx
     /// <returns>An observable that emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this ReadOnlyObservableCollection<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -104,6 +107,7 @@ public static class ObservableCollectionEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this ReadOnlyObservableCollection<TObject> source, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -130,6 +134,7 @@ public static class ObservableCollectionEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<TCollection, T>(this TCollection source)
         where TCollection : INotifyCollectionChanged, IEnumerable<T>
+        where T : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/Binding/SortedBindingListAdaptor.cs
+++ b/src/DynamicData/Binding/SortedBindingListAdaptor.cs
@@ -17,6 +17,7 @@ namespace DynamicData.Binding
     /// <typeparam name="TObject">The type of object.</typeparam>
     /// <typeparam name="TKey">The type of key.</typeparam>
     public class SortedBindingListAdaptor<TObject, TKey> : ISortedChangeSetAdaptor<TObject, TKey>
+        where TObject : notnull
         where TKey : notnull
     {
         private readonly BindingList<TObject> _list;

--- a/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
@@ -14,6 +14,7 @@ namespace DynamicData.Binding;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class SortedObservableCollectionAdaptor<TObject, TKey> : ISortedObservableCollectionAdaptor<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly int _refreshThreshold;

--- a/src/DynamicData/Cache/CacheChangeSetEx.cs
+++ b/src/DynamicData/Cache/CacheChangeSetEx.cs
@@ -17,6 +17,6 @@ internal static class CacheChangeSetEx
     /// </summary>
     /// <param name="changeSet">The source change set.</param>
     public static ChangeSet<TObject, TKey> ToConcreteType<TObject, TKey>(this IChangeSet<TObject, TKey> changeSet)
-        where TKey : notnull
-        => (ChangeSet<TObject, TKey>)changeSet;
+        where TObject : notnull
+        where TKey : notnull => (ChangeSet<TObject, TKey>)changeSet;
 }

--- a/src/DynamicData/Cache/Change.cs
+++ b/src/DynamicData/Cache/Change.cs
@@ -16,6 +16,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public readonly struct Change<TObject, TKey> : IEquatable<Change<TObject, TKey>>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/ChangeAwareCache.cs
+++ b/src/DynamicData/Cache/ChangeAwareCache.cs
@@ -20,6 +20,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The value of the cache.</typeparam>
 /// <typeparam name="TKey">The key of the cache.</typeparam>
 public sealed class ChangeAwareCache<TObject, TKey> : ICache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Dictionary<TKey, TObject> _data;

--- a/src/DynamicData/Cache/ChangeSet.cs
+++ b/src/DynamicData/Cache/ChangeSet.cs
@@ -14,6 +14,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class ChangeSet<TObject, TKey> : List<Change<TObject, TKey>>, IChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/GroupChangeSet.cs
+++ b/src/DynamicData/Cache/GroupChangeSet.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace DynamicData;
 
 internal sealed class GroupChangeSet<TObject, TKey, TGroupKey> : ChangeSet<IGroup<TObject, TKey, TGroupKey>, TGroupKey>, IGroupChangeSet<TObject, TKey, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/ICache.cs
+++ b/src/DynamicData/Cache/ICache.cs
@@ -16,6 +16,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 /// <seealso cref="DynamicData.IQuery{TObject, TKey}" />
 public interface ICache<TObject, TKey> : IQuery<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/ICacheUpdater.cs
+++ b/src/DynamicData/Cache/ICacheUpdater.cs
@@ -21,6 +21,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface ICacheUpdater<TObject, TKey> : IQuery<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IChangeSet.cs
+++ b/src/DynamicData/Cache/IChangeSet.cs
@@ -15,6 +15,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IChangeSet<TObject, TKey> : IChangeSet, IEnumerable<Change<TObject, TKey>>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IChangeSetAdaptor.cs
+++ b/src/DynamicData/Cache/IChangeSetAdaptor.cs
@@ -11,6 +11,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IChangeSetAdaptor<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IConnectableCache.cs
+++ b/src/DynamicData/Cache/IConnectableCache.cs
@@ -13,6 +13,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IConnectableCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IGroup.cs
+++ b/src/DynamicData/Cache/IGroup.cs
@@ -12,6 +12,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 /// <typeparam name="TGroupKey">The type of value used to group the original stream.</typeparam>
 public interface IGroup<TObject, TKey, out TGroupKey> : IKey<TGroupKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IGroupChangeSet.cs
+++ b/src/DynamicData/Cache/IGroupChangeSet.cs
@@ -12,6 +12,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>s
 /// <typeparam name="TGroupKey">The value on which the stream has been grouped.</typeparam>
 public interface IGroupChangeSet<TObject, TKey, TGroupKey> : IChangeSet<IGroup<TObject, TKey, TGroupKey>, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/IGrouping.cs
+++ b/src/DynamicData/Cache/IGrouping.cs
@@ -16,6 +16,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 /// <typeparam name="TGroupKey">The type of the group key.</typeparam>
 public interface IGrouping<TObject, TKey, out TGroupKey>
+    where TObject : notnull
 {
     /// <summary>
     /// Gets the count.

--- a/src/DynamicData/Cache/IImmutableGroupChangeSet.cs
+++ b/src/DynamicData/Cache/IImmutableGroupChangeSet.cs
@@ -11,6 +11,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>s
 /// <typeparam name="TGroupKey">The value on which the stream has been grouped.</typeparam>
 public interface IImmutableGroupChangeSet<TObject, TKey, TGroupKey> : IChangeSet<IGrouping<TObject, TKey, TGroupKey>, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/IIntermediateCache.cs
+++ b/src/DynamicData/Cache/IIntermediateCache.cs
@@ -15,6 +15,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IIntermediateCache<TObject, TKey> : IObservableCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IObservableCache.cs
+++ b/src/DynamicData/Cache/IObservableCache.cs
@@ -16,6 +16,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IObservableCache<TObject, TKey> : IConnectableCache<TObject, TKey>, IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IPagedChangeSet.cs
+++ b/src/DynamicData/Cache/IPagedChangeSet.cs
@@ -13,6 +13,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IPagedChangeSet<TObject, TKey> : ISortedChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IQuery.cs
+++ b/src/DynamicData/Cache/IQuery.cs
@@ -15,6 +15,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IQuery<TObject, TKey>
+    where TObject : notnull
 {
     /// <summary>
     /// Gets the count.

--- a/src/DynamicData/Cache/ISortedChangeSet.cs
+++ b/src/DynamicData/Cache/ISortedChangeSet.cs
@@ -10,6 +10,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface ISortedChangeSet<TObject, TKey> : IChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/ISortedChangeSetAdaptor.cs
+++ b/src/DynamicData/Cache/ISortedChangeSetAdaptor.cs
@@ -10,6 +10,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface ISortedChangeSetAdaptor<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/ISourceCache.cs
+++ b/src/DynamicData/Cache/ISourceCache.cs
@@ -14,6 +14,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface ISourceCache<TObject, TKey> : IObservableCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/ISourceUpdater.cs
+++ b/src/DynamicData/Cache/ISourceUpdater.cs
@@ -21,6 +21,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface ISourceUpdater<TObject, TKey> : ICacheUpdater<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IVirtualChangeSet.cs
+++ b/src/DynamicData/Cache/IVirtualChangeSet.cs
@@ -10,6 +10,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IVirtualChangeSet<TObject, TKey> : ISortedChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/IntermediateCache.cs
+++ b/src/DynamicData/Cache/IntermediateCache.cs
@@ -18,6 +18,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 [DebuggerDisplay("IntermediateCache<{typeof(TObject).Name}, {typeof(TKey).Name}> ({Count} Items)")]
 public sealed class IntermediateCache<TObject, TKey> : IIntermediateCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly ObservableCache<TObject, TKey> _innerCache;

--- a/src/DynamicData/Cache/Internal/AbstractFilter.cs
+++ b/src/DynamicData/Cache/Internal/AbstractFilter.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal abstract class AbstractFilter<TObject, TKey> : IFilter<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly ChangeAwareCache<TObject, TKey> _cache;

--- a/src/DynamicData/Cache/Internal/AnonymousObservableCache.cs
+++ b/src/DynamicData/Cache/Internal/AnonymousObservableCache.cs
@@ -10,6 +10,7 @@ namespace DynamicData.Cache.Internal;
 
 [DebuggerDisplay("AnonymousObservableCache<{typeof(TObject).Name}, {typeof(TKey).Name}> ({Count} Items)")]
 internal sealed class AnonymousObservableCache<TObject, TKey> : IObservableCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservableCache<TObject, TKey> _cache;

--- a/src/DynamicData/Cache/Internal/AnonymousQuery.cs
+++ b/src/DynamicData/Cache/Internal/AnonymousQuery.cs
@@ -9,6 +9,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class AnonymousQuery<TObject, TKey> : IQuery<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Cache<TObject, TKey> _cache;

--- a/src/DynamicData/Cache/Internal/AutoRefresh.cs
+++ b/src/DynamicData/Cache/Internal/AutoRefresh.cs
@@ -10,6 +10,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class AutoRefresh<TObject, TKey, TAny>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly TimeSpan? _buffer;

--- a/src/DynamicData/Cache/Internal/BatchIf.cs
+++ b/src/DynamicData/Cache/Internal/BatchIf.cs
@@ -13,6 +13,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class BatchIf<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly bool _initialPauseState;

--- a/src/DynamicData/Cache/Internal/Cache.cs
+++ b/src/DynamicData/Cache/Internal/Cache.cs
@@ -12,6 +12,7 @@ namespace DynamicData.Cache.Internal;
 
 [DebuggerDisplay("Cache<{typeof(TObject).Name}, {typeof(TKey).Name}> ({Count} Items)")]
 internal class Cache<TObject, TKey> : ICache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     public static readonly Cache<TObject, TKey> Empty = new();

--- a/src/DynamicData/Cache/Internal/CacheEx.cs
+++ b/src/DynamicData/Cache/Internal/CacheEx.cs
@@ -12,6 +12,7 @@ internal static class CacheEx
 {
     public static void Clone<TKey, TObject>(this IDictionary<TKey, TObject> source, IChangeSet<TObject, TKey> changes)
         where TKey : notnull
+        where TObject : notnull
     {
         foreach (var item in changes.ToConcreteType())
         {
@@ -30,6 +31,7 @@ internal static class CacheEx
     }
 
     public static IChangeSet<TObject, TKey> GetInitialUpdates<TObject, TKey>(this ChangeAwareCache<TObject, TKey> source, Func<TObject, bool>? filter = null)
+        where TObject : notnull
         where TKey : notnull
     {
         var filtered = filter is null ? source.KeyValues : source.KeyValues.Where(kv => filter(kv.Value));

--- a/src/DynamicData/Cache/Internal/CacheUpdater.cs
+++ b/src/DynamicData/Cache/Internal/CacheUpdater.cs
@@ -11,6 +11,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class CacheUpdater<TObject, TKey> : ISourceUpdater<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly ICache<TObject, TKey> _cache;

--- a/src/DynamicData/Cache/Internal/Cast.cs
+++ b/src/DynamicData/Cache/Internal/Cast.cs
@@ -11,7 +11,9 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class Cast<TSource, TKey, TDestination>
+    where TSource : notnull
     where TKey : notnull
+    where TDestination : notnull
 {
     private readonly Func<TSource, TDestination> _converter;
 

--- a/src/DynamicData/Cache/Internal/Combiner.cs
+++ b/src/DynamicData/Cache/Internal/Combiner.cs
@@ -15,6 +15,7 @@ namespace DynamicData.Cache.Internal;
 ///     Combines multiple caches using logical operators.
 /// </summary>
 internal sealed class Combiner<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly ChangeAwareCache<TObject, TKey> _combinedCache = new();

--- a/src/DynamicData/Cache/Internal/DeferUntilLoaded.cs
+++ b/src/DynamicData/Cache/Internal/DeferUntilLoaded.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class DeferUntilLoaded<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<IChangeSet<TObject, TKey>> _result;

--- a/src/DynamicData/Cache/Internal/DisposeMany.cs
+++ b/src/DynamicData/Cache/Internal/DisposeMany.cs
@@ -11,6 +11,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class DisposeMany<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Action<TObject> _removeAction;

--- a/src/DynamicData/Cache/Internal/DistinctCalculator.cs
+++ b/src/DynamicData/Cache/Internal/DistinctCalculator.cs
@@ -11,8 +11,9 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class DistinctCalculator<TObject, TKey, TValue>
-    where TValue : notnull
+    where TObject : notnull
     where TKey : notnull
+    where TValue : notnull
 {
     private readonly IDictionary<TKey, TValue> _itemCache = new Dictionary<TKey, TValue>();
 

--- a/src/DynamicData/Cache/Internal/DynamicCombiner.cs
+++ b/src/DynamicData/Cache/Internal/DynamicCombiner.cs
@@ -13,6 +13,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class DynamicCombiner<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservableList<IObservable<IChangeSet<TObject, TKey>>> _source;

--- a/src/DynamicData/Cache/Internal/DynamicFilter.cs
+++ b/src/DynamicData/Cache/Internal/DynamicFilter.cs
@@ -10,6 +10,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class DynamicFilter<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<Func<TObject, bool>> _predicateChanged;

--- a/src/DynamicData/Cache/Internal/EditDiff.cs
+++ b/src/DynamicData/Cache/Internal/EditDiff.cs
@@ -7,6 +7,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class EditDiff<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, TObject, bool> _areEqual;

--- a/src/DynamicData/Cache/Internal/FilterEx.cs
+++ b/src/DynamicData/Cache/Internal/FilterEx.cs
@@ -9,6 +9,7 @@ namespace DynamicData.Cache.Internal;
 internal static class FilterEx
 {
     public static void FilterChanges<TObject, TKey>(this ChangeAwareCache<TObject, TKey> cache, IChangeSet<TObject, TKey> changes, Func<TObject, bool> predicate)
+        where TObject : notnull
         where TKey : notnull
     {
         foreach (var change in changes.ToConcreteType())
@@ -72,6 +73,7 @@ internal static class FilterEx
     }
 
     public static IChangeSet<TObject, TKey> RefreshFilteredFrom<TObject, TKey>(this ChangeAwareCache<TObject, TKey> filtered, Cache<TObject, TKey> allData, Func<TObject, bool> predicate)
+        where TObject : notnull
         where TKey : notnull
     {
         if (allData.Count == 0)

--- a/src/DynamicData/Cache/Internal/FilterOnProperty.cs
+++ b/src/DynamicData/Cache/Internal/FilterOnProperty.cs
@@ -11,8 +11,8 @@ namespace DynamicData.Cache.Internal;
 
 [Obsolete("Use AutoRefresh(), followed by Filter() instead")]
 internal class FilterOnProperty<TObject, TKey, TProperty>
-    where TKey : notnull
     where TObject : INotifyPropertyChanged
+    where TKey : notnull
 {
     private readonly Func<TObject, bool> _predicate;
 

--- a/src/DynamicData/Cache/Internal/FilteredIndexCalculator.cs
+++ b/src/DynamicData/Cache/Internal/FilteredIndexCalculator.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal static class FilteredIndexCalculator<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     public static IList<Change<TObject, TKey>> Calculate(IKeyValueCollection<TObject, TKey> currentItems, IKeyValueCollection<TObject, TKey> previousItems, IChangeSet<TObject, TKey>? sourceUpdates)

--- a/src/DynamicData/Cache/Internal/FullJoin.cs
+++ b/src/DynamicData/Cache/Internal/FullJoin.cs
@@ -11,8 +11,11 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class FullJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/FullJoinMany.cs
+++ b/src/DynamicData/Cache/Internal/FullJoinMany.cs
@@ -9,8 +9,11 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class FullJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/GroupOn.cs
+++ b/src/DynamicData/Cache/Internal/GroupOn.cs
@@ -14,6 +14,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class GroupOn<TObject, TKey, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/Internal/GroupOnImmutable.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnImmutable.cs
@@ -13,6 +13,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class GroupOnImmutable<TObject, TKey, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/Internal/GroupOnPropertyWithImmutableState.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnPropertyWithImmutableState.cs
@@ -13,9 +13,9 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class GroupOnPropertyWithImmutableState<TObject, TKey, TGroup>
+    where TObject : INotifyPropertyChanged
     where TKey : notnull
     where TGroup : notnull
-    where TObject : INotifyPropertyChanged
 {
     private readonly Func<TObject, TGroup> _groupSelector;
 

--- a/src/DynamicData/Cache/Internal/IFilter.cs
+++ b/src/DynamicData/Cache/Internal/IFilter.cs
@@ -13,6 +13,7 @@ namespace DynamicData.Cache.Internal;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the field.</typeparam>
 internal interface IFilter<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Cache/Internal/ImmutableGroup.cs
+++ b/src/DynamicData/Cache/Internal/ImmutableGroup.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class ImmutableGroup<TObject, TKey, TGroupKey> : IGrouping<TObject, TKey, TGroupKey>, IEquatable<ImmutableGroup<TObject, TKey, TGroupKey>>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/Internal/ImmutableGroupChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ImmutableGroupChangeSet.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class ImmutableGroupChangeSet<TObject, TKey, TGroupKey> : ChangeSet<IGrouping<TObject, TKey, TGroupKey>, TGroupKey>, IImmutableGroupChangeSet<TObject, TKey, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/Internal/IndexCalculator.cs
+++ b/src/DynamicData/Cache/Internal/IndexCalculator.cs
@@ -14,6 +14,7 @@ namespace DynamicData.Cache.Internal;
 /// and apply indexed changes with no need to apply ant expensive IndexOf() operations.
 /// </summary>
 internal sealed class IndexCalculator<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly SortOptimisations _optimisations;

--- a/src/DynamicData/Cache/Internal/InnerJoin.cs
+++ b/src/DynamicData/Cache/Internal/InnerJoin.cs
@@ -9,8 +9,11 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class InnerJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/InnerJoinMany.cs
+++ b/src/DynamicData/Cache/Internal/InnerJoinMany.cs
@@ -7,8 +7,11 @@ using System;
 namespace DynamicData.Cache.Internal;
 
 internal class InnerJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/LeftJoin.cs
+++ b/src/DynamicData/Cache/Internal/LeftJoin.cs
@@ -11,8 +11,11 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class LeftJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/LeftJoinMany.cs
+++ b/src/DynamicData/Cache/Internal/LeftJoinMany.cs
@@ -9,8 +9,11 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class LeftJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/LockFreeObservableCache.cs
+++ b/src/DynamicData/Cache/Internal/LockFreeObservableCache.cs
@@ -22,6 +22,7 @@ namespace DynamicData.Cache.Internal;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 [DebuggerDisplay("LockFreeObservableCache<{typeof(TObject).Name}, {typeof(TKey).Name}> ({Count} Items)")]
 public sealed class LockFreeObservableCache<TObject, TKey> : IObservableCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed with _cleanUp")]

--- a/src/DynamicData/Cache/Internal/ManagedGroup.cs
+++ b/src/DynamicData/Cache/Internal/ManagedGroup.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class ManagedGroup<TObject, TKey, TGroupKey> : IGroup<TObject, TKey, TGroupKey>, IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IntermediateCache<TObject, TKey> _cache = new();

--- a/src/DynamicData/Cache/Internal/MergeMany.cs
+++ b/src/DynamicData/Cache/Internal/MergeMany.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class MergeMany<TObject, TKey, TDestination>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, TKey, IObservable<TDestination>> _observableSelector;

--- a/src/DynamicData/Cache/Internal/MergeManyItems.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyItems.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class MergeManyItems<TObject, TKey, TDestination>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, TKey, IObservable<TDestination>> _observableSelector;

--- a/src/DynamicData/Cache/Internal/ObservableWithValue.cs
+++ b/src/DynamicData/Cache/Internal/ObservableWithValue.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class ObservableWithValue<TObject, TValue>
+    where TValue : notnull
 {
     public ObservableWithValue(TObject item, IObservable<TValue> source)
     {

--- a/src/DynamicData/Cache/Internal/OnBeingRemoved.cs
+++ b/src/DynamicData/Cache/Internal/OnBeingRemoved.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class OnBeingRemoved<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Action<TObject> _removeAction;

--- a/src/DynamicData/Cache/Internal/Page.cs
+++ b/src/DynamicData/Cache/Internal/Page.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class Page<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<IPageRequest> _pageRequests;

--- a/src/DynamicData/Cache/Internal/QueryWhenChanged.cs
+++ b/src/DynamicData/Cache/Internal/QueryWhenChanged.cs
@@ -8,6 +8,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class QueryWhenChanged<TObject, TKey, TValue>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, IObservable<TValue>>? _itemChangedTrigger;

--- a/src/DynamicData/Cache/Internal/ReaderWriter.cs
+++ b/src/DynamicData/Cache/Internal/ReaderWriter.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class ReaderWriter<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, TKey>? _keySelector;

--- a/src/DynamicData/Cache/Internal/RefCount.cs
+++ b/src/DynamicData/Cache/Internal/RefCount.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class RefCount<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly object _locker = new();

--- a/src/DynamicData/Cache/Internal/RemoveKeyEnumerator.cs
+++ b/src/DynamicData/Cache/Internal/RemoveKeyEnumerator.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 namespace DynamicData.Cache.Internal;
 
 internal class RemoveKeyEnumerator<TObject, TKey> : IEnumerable<Change<TObject>>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IExtendedList<TObject>? _list;

--- a/src/DynamicData/Cache/Internal/RightJoin.cs
+++ b/src/DynamicData/Cache/Internal/RightJoin.cs
@@ -11,8 +11,11 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class RightJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/RightJoinMany.cs
+++ b/src/DynamicData/Cache/Internal/RightJoinMany.cs
@@ -9,8 +9,11 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class RightJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>
+    where TLeft : notnull
     where TLeftKey : notnull
+    where TRight : notnull
     where TRightKey : notnull
+    where TDestination : notnull
 {
     private readonly IObservable<IChangeSet<TLeft, TLeftKey>> _left;
 

--- a/src/DynamicData/Cache/Internal/SizeExpirer.cs
+++ b/src/DynamicData/Cache/Internal/SizeExpirer.cs
@@ -12,6 +12,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class SizeExpirer<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly int _size;

--- a/src/DynamicData/Cache/Internal/SizeLimiter.cs
+++ b/src/DynamicData/Cache/Internal/SizeLimiter.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class SizeLimiter<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly ChangeAwareCache<ExpirableItem<TObject, TKey>, TKey> _cache = new();

--- a/src/DynamicData/Cache/Internal/Sort.cs
+++ b/src/DynamicData/Cache/Internal/Sort.cs
@@ -11,6 +11,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class Sort<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IComparer<TObject>? _comparer;

--- a/src/DynamicData/Cache/Internal/SpecifiedGrouper.cs
+++ b/src/DynamicData/Cache/Internal/SpecifiedGrouper.cs
@@ -10,6 +10,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class SpecifiedGrouper<TObject, TKey, TGroupKey>
+    where TObject : notnull
     where TKey : notnull
     where TGroupKey : notnull
 {

--- a/src/DynamicData/Cache/Internal/StaticFilter.cs
+++ b/src/DynamicData/Cache/Internal/StaticFilter.cs
@@ -8,6 +8,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class StaticFilter<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, bool> _filter;

--- a/src/DynamicData/Cache/Internal/SubscribeMany.cs
+++ b/src/DynamicData/Cache/Internal/SubscribeMany.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class SubscribeMany<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<IChangeSet<TObject, TKey>> _source;

--- a/src/DynamicData/Cache/Internal/Switch.cs
+++ b/src/DynamicData/Cache/Internal/Switch.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class Switch<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<IObservable<IChangeSet<TObject, TKey>>> _sources;

--- a/src/DynamicData/Cache/Internal/TimeExpirer.cs
+++ b/src/DynamicData/Cache/Internal/TimeExpirer.cs
@@ -14,6 +14,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class TimeExpirer<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly TimeSpan? _interval;

--- a/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class ToObservableChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<IEnumerable<TObject>> _source;

--- a/src/DynamicData/Cache/Internal/Transform.cs
+++ b/src/DynamicData/Cache/Internal/Transform.cs
@@ -10,6 +10,8 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class Transform<TDestination, TSource, TKey>
+    where TDestination : notnull
+    where TSource : notnull
     where TKey : notnull
 {
     private readonly Action<Error<TSource, TKey>>? _exceptionCallback;

--- a/src/DynamicData/Cache/Internal/TransformAsync.cs
+++ b/src/DynamicData/Cache/Internal/TransformAsync.cs
@@ -9,6 +9,8 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class TransformAsync<TDestination, TSource, TKey>
+    where TDestination : notnull
+    where TSource : notnull
     where TKey : notnull
 {
     private readonly Action<Error<TSource, TKey>>? _exceptionCallback;

--- a/src/DynamicData/Cache/Internal/TransformMany.cs
+++ b/src/DynamicData/Cache/Internal/TransformMany.cs
@@ -16,8 +16,10 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>
-    where TSourceKey : notnull
+    where TDestination : notnull
     where TDestinationKey : notnull
+    where TSource : notnull
+    where TSourceKey : notnull
 {
     private readonly Func<TSource, IObservable<IChangeSet<TDestination, TDestinationKey>>>? _childChanges;
 

--- a/src/DynamicData/Cache/Internal/TransformWithForcedTransform.cs
+++ b/src/DynamicData/Cache/Internal/TransformWithForcedTransform.cs
@@ -12,6 +12,8 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class TransformWithForcedTransform<TDestination, TSource, TKey>
+    where TDestination : notnull
+    where TSource : notnull
     where TKey : notnull
 {
     private readonly Action<Error<TSource, TKey>>? _exceptionCallback;

--- a/src/DynamicData/Cache/Internal/TransformWithInlineUpdate.cs
+++ b/src/DynamicData/Cache/Internal/TransformWithInlineUpdate.cs
@@ -10,8 +10,9 @@ using DynamicData.List.Internal;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class TransformWithInlineUpdate<TDestination, TSource, TKey>
-    where TKey : notnull
     where TDestination : class
+    where TSource : notnull
+    where TKey : notnull
 {
     private readonly Action<Error<TSource, TKey>>? _exceptionCallback;
 

--- a/src/DynamicData/Cache/Internal/TreeBuilder.cs
+++ b/src/DynamicData/Cache/Internal/TreeBuilder.cs
@@ -14,8 +14,8 @@ using DynamicData.Kernel;
 namespace DynamicData.Cache.Internal;
 
 internal class TreeBuilder<TObject, TKey>
-    where TKey : notnull
     where TObject : class
+    where TKey : notnull
 {
     private readonly Func<TObject, TKey> _pivotOn;
 

--- a/src/DynamicData/Cache/Internal/TrueFor.cs
+++ b/src/DynamicData/Cache/Internal/TrueFor.cs
@@ -10,7 +10,9 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class TrueFor<TObject, TKey, TValue>
+    where TObject : notnull
     where TKey : notnull
+    where TValue : notnull
 {
     private readonly Func<IEnumerable<ObservableWithValue<TObject, TValue>>, bool> _collectionMatcher;
 

--- a/src/DynamicData/Cache/Internal/UniquenessEnforcer.cs
+++ b/src/DynamicData/Cache/Internal/UniquenessEnforcer.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal class UniquenessEnforcer<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<IChangeSet<TObject, TKey>> _source;

--- a/src/DynamicData/Cache/Internal/Virtualise.cs
+++ b/src/DynamicData/Cache/Internal/Virtualise.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.Cache.Internal;
 
 internal sealed class Virtualise<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IObservable<ISortedChangeSet<TObject, TKey>> _source;

--- a/src/DynamicData/Cache/Node.cs
+++ b/src/DynamicData/Cache/Node.cs
@@ -17,8 +17,8 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class Node<TObject, TKey> : IDisposable, IEquatable<Node<TObject, TKey>>
-    where TKey : notnull
     where TObject : class
+    where TKey : notnull
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed with _cleanUp")]
     private readonly ISourceCache<Node<TObject, TKey>, TKey> _children = new SourceCache<Node<TObject, TKey>, TKey>(n => n.Key);

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -15,6 +15,7 @@ namespace DynamicData;
 
 [DebuggerDisplay("ObservableCache<{typeof(TObject).Name}, {typeof(TKey).Name}> ({Count} Items)")]
 internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed with _cleanUp")]

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -40,6 +40,7 @@ public static class ObservableCacheEx
     /// destination.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Adapt<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IChangeSetAdaptor<TObject, TKey> adaptor)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -69,6 +70,7 @@ public static class ObservableCacheEx
     /// destination.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Adapt<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, ISortedChangeSetAdaptor<TObject, TKey> adaptor)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -93,6 +95,7 @@ public static class ObservableCacheEx
     /// <param name="item">The item.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void AddOrUpdate<TObject, TKey>(this ISourceCache<TObject, TKey> source, TObject item)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -113,6 +116,7 @@ public static class ObservableCacheEx
     /// <param name="equalityComparer">The equality comparer used to determine whether a new item is the same as an existing cached item.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void AddOrUpdate<TObject, TKey>(this ISourceCache<TObject, TKey> source, TObject item, IEqualityComparer<TObject> equalityComparer)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -134,6 +138,7 @@ public static class ObservableCacheEx
     /// <param name="items">The items.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void AddOrUpdate<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> items)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -156,6 +161,7 @@ public static class ObservableCacheEx
     /// <param name="equalityComparer">The equality comparer used to determine whether a new item is the same as an existing cached item.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void AddOrUpdate<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> items, IEqualityComparer<TObject> equalityComparer)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -176,6 +182,7 @@ public static class ObservableCacheEx
     /// <param name="key">The key to add or update.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void AddOrUpdate<TObject, TKey>(this IIntermediateCache<TObject, TKey> source, TObject item, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -202,6 +209,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source or others.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> And<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params IObservable<IChangeSet<TObject, TKey>>[] others)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -230,6 +238,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> And<TObject, TKey>(this ICollection<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -249,6 +258,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> And<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -268,6 +278,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> And<TObject, TKey>(this IObservableList<IObservableCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -287,6 +298,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> And<TObject, TKey>(this IObservableList<ISourceCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -306,6 +318,7 @@ public static class ObservableCacheEx
     /// <returns>An observable cache.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservableCache<TObject, TKey> AsObservableCache<TObject, TKey>(this IObservableCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -326,6 +339,7 @@ public static class ObservableCacheEx
     /// <returns>An observable cache.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservableCache<TObject, TKey> AsObservableCache<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, bool applyLocking = true)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -352,8 +366,8 @@ public static class ObservableCacheEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable change set with additional refresh changes.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> AutoRefresh<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, TimeSpan? changeSetBuffer = null, TimeSpan? propertyChangeThrottle = null, IScheduler? scheduler = null)
-        where TKey : notnull
         where TObject : INotifyPropertyChanged
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -387,8 +401,8 @@ public static class ObservableCacheEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable change set with additional refresh changes.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> AutoRefresh<TObject, TKey, TProperty>(this IObservable<IChangeSet<TObject, TKey>> source, Expression<Func<TObject, TProperty>> propertyAccessor, TimeSpan? changeSetBuffer = null, TimeSpan? propertyChangeThrottle = null, IScheduler? scheduler = null)
-        where TKey : notnull
         where TObject : INotifyPropertyChanged
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -421,6 +435,7 @@ public static class ObservableCacheEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable change set with additional refresh changes.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> AutoRefreshOnObservable<TObject, TKey, TAny>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TAny>> reevaluator, TimeSpan? changeSetBuffer = null, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.AutoRefreshOnObservable((t, _) => reevaluator(t), changeSetBuffer, scheduler);
@@ -438,6 +453,7 @@ public static class ObservableCacheEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable change set with additional refresh changes.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> AutoRefreshOnObservable<TObject, TKey, TAny>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<TAny>> reevaluator, TimeSpan? changeSetBuffer = null, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -466,6 +482,7 @@ public static class ObservableCacheEx
     /// or
     /// scheduler.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> Batch<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, TimeSpan timeSpan, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -488,6 +505,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<bool> pauseIfTrueSelector, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return BatchIf(source, pauseIfTrueSelector, false, scheduler);
@@ -506,6 +524,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<bool> pauseIfTrueSelector, bool initialPauseState = false, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return new BatchIf<TObject, TKey>(source, pauseIfTrueSelector, null, initialPauseState, scheduler: scheduler).Run();
@@ -524,6 +543,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<bool> pauseIfTrueSelector, TimeSpan? timeOut = null, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return BatchIf(source, pauseIfTrueSelector, false, timeOut, scheduler);
@@ -543,6 +563,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<bool> pauseIfTrueSelector, bool initialPauseState = false, TimeSpan? timeOut = null, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -572,6 +593,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<bool> pauseIfTrueSelector, bool initialPauseState = false, IObservable<Unit>? timer = null, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return new BatchIf<TObject, TKey>(source, pauseIfTrueSelector, null, initialPauseState, timer, scheduler).Run();
@@ -588,6 +610,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, int refreshThreshold = 25)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -614,6 +637,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, IObservableCollectionAdaptor<TObject, TKey> updater)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -654,6 +678,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -681,6 +706,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, ISortedObservableCollectionAdaptor<TObject, TKey> updater)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -723,6 +749,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, ISortedObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -750,6 +777,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, bool useReplaceForUpdates = false, IObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -781,6 +809,7 @@ public static class ObservableCacheEx
     /// targetCollection.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, BindingList<TObject> bindingList, int resetThreshold = 25)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -815,6 +844,7 @@ public static class ObservableCacheEx
     /// targetCollection.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, BindingList<TObject> bindingList, int resetThreshold = 25)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -842,6 +872,7 @@ public static class ObservableCacheEx
     /// <param name="scheduler">The scheduler to buffer on.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> BufferInitial<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, TimeSpan initialBuffer, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.DeferUntilLoaded().Publish(
@@ -864,7 +895,9 @@ public static class ObservableCacheEx
     /// <param name="converter">The conversion factory.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TKey>> Cast<TSource, TKey, TDestination>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> converter)
+        where TSource : notnull
         where TKey : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -884,6 +917,7 @@ public static class ObservableCacheEx
     /// <param name="keySelector">The key selector eg. (item) => newKey.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TDestinationKey>> ChangeKey<TObject, TSourceKey, TDestinationKey>(this IObservable<IChangeSet<TObject, TSourceKey>> source, Func<TObject, TDestinationKey> keySelector)
+        where TObject : notnull
         where TSourceKey : notnull
         where TDestinationKey : notnull
     {
@@ -916,6 +950,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TDestinationKey>> ChangeKey<TObject, TSourceKey, TDestinationKey>(this IObservable<IChangeSet<TObject, TSourceKey>> source, Func<TSourceKey, TObject, TDestinationKey> keySelector)
+        where TObject : notnull
         where TSourceKey : notnull
         where TDestinationKey : notnull
     {
@@ -945,6 +980,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Clear<TObject, TKey>(this ISourceCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -963,6 +999,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Clear<TObject, TKey>(this IIntermediateCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -981,6 +1018,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Clear<TObject, TKey>(this LockFreeObservableCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1000,6 +1038,7 @@ public static class ObservableCacheEx
     /// <param name="target">The target.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Clone<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, ICollection<TObject> target)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1054,7 +1093,9 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     [Obsolete("This was an experiment that did not work. Use Transform instead")]
     public static IObservable<IChangeSet<TDestination, TKey>> Convert<TObject, TKey, TDestination>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TDestination> conversionFactory)
+        where TObject : notnull
         where TKey : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1082,6 +1123,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> DeferUntilLoaded<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1100,6 +1142,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> DeferUntilLoaded<TObject, TKey>(this IObservableCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1122,6 +1165,7 @@ public static class ObservableCacheEx
     /// <returns>A continuation of the original stream.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> DisposeMany<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1152,6 +1196,7 @@ public static class ObservableCacheEx
     /// </remarks>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IDistinctChangeSet<TValue>> DistinctValues<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TValue> valueSelector)
+        where TObject : notnull
         where TKey : notnull
         where TValue : notnull
     {
@@ -1179,6 +1224,7 @@ public static class ObservableCacheEx
     /// <param name="equalityComparer">The equality comparer used to determine whether a new item is the same as an existing cached item.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void EditDiff<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> allItems, IEqualityComparer<TObject> equalityComparer)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1210,6 +1256,7 @@ public static class ObservableCacheEx
     /// <param name="areItemsEqual">Expression to determine whether an item's value is equal to the old value (current, previous) => current.Version == previous.Version.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void EditDiff<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> allItems, Func<TObject, TObject, bool> areItemsEqual)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1241,6 +1288,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     [Obsolete(Constants.EvaluateIsDead)]
     public static void Evaluate<TObject, TKey>(this ISourceCache<TObject, TKey> source, TObject item)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1261,6 +1309,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     [Obsolete(Constants.EvaluateIsDead)]
     public static void Evaluate<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> items)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1280,6 +1329,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     [Obsolete(Constants.EvaluateIsDead)]
     public static void Evaluate<TObject, TKey>(this ISourceCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1305,6 +1355,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Except<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params IObservable<IChangeSet<TObject, TKey>>[] others)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1334,6 +1385,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Except<TObject, TKey>(this ICollection<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -1353,6 +1405,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Except<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -1372,6 +1425,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Except<TObject, TKey>(this IObservableList<IObservableCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -1391,6 +1445,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Except<TObject, TKey>(this IObservableList<ISourceCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -1416,6 +1471,7 @@ public static class ObservableCacheEx
     /// timeSelector.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TimeSpan?> timeSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         return ExpireAfter(source, timeSelector, Scheduler.Default);
@@ -1437,6 +1493,7 @@ public static class ObservableCacheEx
     /// timeSelector.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TimeSpan?> timeSelector, IScheduler scheduler)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1468,6 +1525,7 @@ public static class ObservableCacheEx
     /// or
     /// timeSelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TimeSpan?> timeSelector, TimeSpan? pollingInterval)
+        where TObject : notnull
         where TKey : notnull
     {
         return ExpireAfter(source, timeSelector, pollingInterval, Scheduler.Default);
@@ -1490,6 +1548,7 @@ public static class ObservableCacheEx
     /// or
     /// timeSelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TimeSpan?> timeSelector, TimeSpan? pollingInterval, IScheduler scheduler)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1519,6 +1578,7 @@ public static class ObservableCacheEx
     /// or
     /// timeSelector.</exception>
     public static IObservable<IEnumerable<KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this ISourceCache<TObject, TKey> source, Func<TObject, TimeSpan?> timeSelector, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.ExpireAfter(timeSelector, null, scheduler);
@@ -1540,6 +1600,7 @@ public static class ObservableCacheEx
     /// or
     /// timeSelector.</exception>
     public static IObservable<IEnumerable<KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this ISourceCache<TObject, TKey> source, Func<TObject, TimeSpan?> timeSelector, TimeSpan? interval = null)
+        where TObject : notnull
         where TKey : notnull
     {
         return ExpireAfter(source, timeSelector, interval, Scheduler.Default);
@@ -1553,6 +1614,7 @@ public static class ObservableCacheEx
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <returns>A changeset which guarantees a key is only present at most once in the changeset.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> EnsureUniqueKeys<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source == null)
@@ -1581,6 +1643,7 @@ public static class ObservableCacheEx
     /// timeSelector.</exception>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Deliberate capture.")]
     public static IObservable<IEnumerable<KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this ISourceCache<TObject, TKey> source, Func<TObject, TimeSpan?> timeSelector, TimeSpan? pollingInterval, IScheduler? scheduler)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1631,6 +1694,7 @@ public static class ObservableCacheEx
     /// <param name="suppressEmptyChangeSets">By default empty changeset notifications are suppressed for performance reasons.  Set to false to publish empty changesets.  Doing so can be useful for monitoring loading status.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, bool> filter, bool suppressEmptyChangeSets = true)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -1648,6 +1712,7 @@ public static class ObservableCacheEx
     /// <param name="suppressEmptyChangeSets">By default empty changeset notifications are suppressed for performance reasons.  Set to false to publish empty changesets.  Doing so can be useful for monitoring loading status.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, bool>> predicateChanged, bool suppressEmptyChangeSets = true)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -1666,6 +1731,7 @@ public static class ObservableCacheEx
     /// <param name="suppressEmptyChangeSets">By default empty changeset notifications are suppressed for performance reasons.  Set to false to publish empty changesets.  Doing so can be useful for monitoring loading status.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Unit> reapplyFilter, bool suppressEmptyChangeSets = true)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -1685,6 +1751,7 @@ public static class ObservableCacheEx
     /// <param name="suppressEmptyChangeSets">By default empty changeset notifications are suppressed for performance reasons.  Set to false to publish empty changesets.  Doing so can be useful for monitoring loading status.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, bool>> predicateChanged, IObservable<Unit> reapplyFilter, bool suppressEmptyChangeSets = true)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -1710,8 +1777,8 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     [Obsolete("Use AutoRefresh(), followed by Filter() instead")]
     public static IObservable<IChangeSet<TObject, TKey>> FilterOnProperty<TObject, TKey, TProperty>(this IObservable<IChangeSet<TObject, TKey>> source, Expression<Func<TObject, TProperty>> propertySelector, Func<TObject, bool> predicate, TimeSpan? propertyChangedThrottle = null, IScheduler? scheduler = null)
-        where TKey : notnull
         where TObject : INotifyPropertyChanged
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -1764,6 +1831,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change set values on a flatten result.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<Change<TObject, TKey>> Flatten<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1782,6 +1850,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> FlattenBufferResult<TObject, TKey>(this IObservable<IList<IChangeSet<TObject, TKey>>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1801,6 +1870,7 @@ public static class ObservableCacheEx
     /// <param name="action">The action.</param>
     /// <returns>An observable which will perform the action on each item.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> ForEachChange<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Action<Change<TObject, TKey>> action)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -1831,8 +1901,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> FullJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<Optional<TLeft>, Optional<TRight>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -1872,8 +1945,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> FullJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeftKey, Optional<TLeft>, Optional<TRight>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -1913,8 +1989,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> FullJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<Optional<TLeft>, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -1954,8 +2033,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> FullJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeftKey, Optional<TLeft>, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -1997,6 +2079,7 @@ public static class ObservableCacheEx
     /// </remarks>
     /// <returns>An observable which will emit group change sets.</returns>
     public static IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TGroupKey> groupSelector, IObservable<IDistinctChangeSet<TGroupKey>> resultGroupSource)
+        where TObject : notnull
         where TKey : notnull
         where TGroupKey : notnull
     {
@@ -2028,6 +2111,7 @@ public static class ObservableCacheEx
     /// <param name="groupSelectorKey">The group selector key.</param>
     /// <returns>An observable which will emit group change sets.</returns>
     public static IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TGroupKey> groupSelectorKey)
+        where TObject : notnull
         where TKey : notnull
         where TGroupKey : notnull
     {
@@ -2062,6 +2146,7 @@ public static class ObservableCacheEx
     /// groupController.
     /// </exception>
     public static IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TGroupKey> groupSelectorKey, IObservable<Unit> regrouper)
+        where TObject : notnull
         where TKey : notnull
         where TGroupKey : notnull
     {
@@ -2163,6 +2248,7 @@ public static class ObservableCacheEx
     /// groupController.
     /// </exception>
     public static IObservable<IImmutableGroupChangeSet<TObject, TKey, TGroupKey>> GroupWithImmutableState<TObject, TKey, TGroupKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TGroupKey> groupSelectorKey, IObservable<Unit>? regrouper = null)
+        where TObject : notnull
         where TKey : notnull
         where TGroupKey : notnull
     {
@@ -2187,6 +2273,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable which emits change sets.</param>
     /// <returns>An observable which emits change sets and ignores equal value changes.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> IgnoreSameReferenceUpdate<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.IgnoreUpdateWhen((c, p) => ReferenceEquals(c, p));
@@ -2202,6 +2289,7 @@ public static class ObservableCacheEx
     /// <param name="ignoreFunction">The ignore function (current,previous)=>{ return true to ignore }.</param>
     /// <returns>An observable which emits change sets and ignores updates equal to the lambda.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> IgnoreUpdateWhen<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TObject, bool> ignoreFunction)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.Select(
@@ -2231,6 +2319,7 @@ public static class ObservableCacheEx
     /// <param name="includeFunction">The include function (current,previous)=>{ return true to include }.</param>
     /// <returns>An observable which emits change sets and ignores updates equal to the lambda.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> IncludeUpdateWhen<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TObject, bool> includeFunction)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2266,8 +2355,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, (TLeftKey leftKey, TRightKey rightKey)>> InnerJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeft, TRight, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2307,8 +2399,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, (TLeftKey leftKey, TRightKey rightKey)>> InnerJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<(TLeftKey leftKey, TRightKey rightKey), TLeft, TRight, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2348,8 +2443,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> InnerJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeft, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2389,8 +2487,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> InnerJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeftKey, TLeft, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2443,8 +2544,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> LeftJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeft, Optional<TRight>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2483,8 +2587,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> LeftJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeftKey, TLeft, Optional<TRight>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2524,8 +2631,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> LeftJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeft, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2565,8 +2675,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> LeftJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeftKey, TLeft, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -2603,6 +2716,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     /// <exception cref="System.ArgumentException">size cannot be zero.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> LimitSizeTo<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, int size)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2631,6 +2745,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     /// <exception cref="System.ArgumentException">Size limit must be greater than zero.</exception>
     public static IObservable<IEnumerable<KeyValuePair<TKey, TObject>>> LimitSizeTo<TObject, TKey>(this ISourceCache<TObject, TKey> source, int sizeLimit, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2679,6 +2794,7 @@ public static class ObservableCacheEx
     /// or
     /// observableSelector.</exception>
     public static IObservable<TDestination> MergeMany<TObject, TKey, TDestination>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TDestination>> observableSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2708,6 +2824,7 @@ public static class ObservableCacheEx
     /// or
     /// observableSelector.</exception>
     public static IObservable<TDestination> MergeMany<TObject, TKey, TDestination>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<TDestination>> observableSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2737,6 +2854,7 @@ public static class ObservableCacheEx
     /// or
     /// observableSelector.</exception>
     public static IObservable<ItemWithValue<TObject, TDestination>> MergeManyItems<TObject, TKey, TDestination>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TDestination>> observableSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2766,6 +2884,7 @@ public static class ObservableCacheEx
     /// or
     /// observableSelector.</exception>
     public static IObservable<ItemWithValue<TObject, TDestination>> MergeManyItems<TObject, TKey, TDestination>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<TDestination>> observableSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2802,6 +2921,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change set values when not empty.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> NotEmpty<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2821,6 +2941,7 @@ public static class ObservableCacheEx
     /// <param name="addAction">The add action.</param>
     /// <returns>An observable which emits a change set with items being added.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> OnItemAdded<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Action<TObject> addAction)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2845,6 +2966,7 @@ public static class ObservableCacheEx
     /// <param name="refreshAction">The refresh action.</param>
     /// <returns>An observable which emits a change set with items being added.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> OnItemRefreshed<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Action<TObject> refreshAction)
+        where TObject : notnull
         where TKey : notnull
     {
         Action<TObject> refreshAction2 = refreshAction;
@@ -2882,6 +3004,7 @@ public static class ObservableCacheEx
     /// removeAction.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> OnItemRemoved<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Action<TObject> removeAction, bool invokeOnUnsubscribe = true)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -2899,6 +3022,7 @@ public static class ObservableCacheEx
     /// <param name="updateAction">The update action.</param>
     /// <returns>An observable which emits a change set with items being updated.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> OnItemUpdated<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Action<TObject, TObject> updateAction)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2928,6 +3052,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Or<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params IObservable<IChangeSet<TObject, TKey>>[] others)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -2956,6 +3081,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Or<TObject, TKey>(this ICollection<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -2975,6 +3101,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Or<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -2994,6 +3121,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Or<TObject, TKey>(this IObservableList<IObservableCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -3013,6 +3141,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Or<TObject, TKey>(this IObservableList<ISourceCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -3032,6 +3161,7 @@ public static class ObservableCacheEx
     /// <param name="pageRequests">The page requests.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IPagedChangeSet<TObject, TKey>> Page<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservable<IPageRequest> pageRequests)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3061,6 +3191,7 @@ public static class ObservableCacheEx
     /// keySelector.
     /// </exception>
     public static IDisposable PopulateFrom<TObject, TKey>(this ISourceCache<TObject, TKey> source, IObservable<IEnumerable<TObject>> observable)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3085,6 +3216,7 @@ public static class ObservableCacheEx
     /// keySelector.
     /// </exception>
     public static IDisposable PopulateFrom<TObject, TKey>(this ISourceCache<TObject, TKey> source, IObservable<TObject> observable)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3109,6 +3241,7 @@ public static class ObservableCacheEx
     /// destination.
     /// </exception>
     public static IDisposable PopulateInto<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, ISourceCache<TObject, TKey> destination)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3136,6 +3269,7 @@ public static class ObservableCacheEx
     /// or
     /// destination.</exception>
     public static IDisposable PopulateInto<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IIntermediateCache<TObject, TKey> destination)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3160,6 +3294,7 @@ public static class ObservableCacheEx
     /// <param name="destination">The destination.</param>
     /// <returns>A disposable which will unsubscribe from the source.</returns>
     public static IDisposable PopulateInto<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, LockFreeObservableCache<TObject, TKey> destination)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3190,6 +3325,7 @@ public static class ObservableCacheEx
     /// resultSelector.
     /// </exception>
     public static IObservable<TDestination> QueryWhenChanged<TObject, TKey, TDestination>(this IObservable<IChangeSet<TObject, TKey>> source, Func<IQuery<TObject, TKey>, TDestination> resultSelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3214,6 +3350,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits the query.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IQuery<TObject, TKey>> QueryWhenChanged<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3235,6 +3372,7 @@ public static class ObservableCacheEx
     /// <returns>An observable that emits the query.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IQuery<TObject, TKey>> QueryWhenChanged<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TValue>> itemChangedTrigger)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3258,6 +3396,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits change sets that are ref counted.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> RefCount<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3277,6 +3416,7 @@ public static class ObservableCacheEx
     /// <param name="item">The item.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Refresh<TObject, TKey>(this ISourceCache<TObject, TKey> source, TObject item)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3296,6 +3436,7 @@ public static class ObservableCacheEx
     /// <param name="items">The items.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Refresh<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> items)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3314,6 +3455,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Refresh<TObject, TKey>(this ISourceCache<TObject, TKey> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3335,6 +3477,7 @@ public static class ObservableCacheEx
     /// <param name="item">The item.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Remove<TObject, TKey>(this ISourceCache<TObject, TKey> source, TObject item)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3355,6 +3498,7 @@ public static class ObservableCacheEx
     /// <param name="key">The key.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Remove<TObject, TKey>(this ISourceCache<TObject, TKey> source, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3376,6 +3520,7 @@ public static class ObservableCacheEx
     /// <param name="items">The items.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Remove<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TObject> items)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3397,6 +3542,7 @@ public static class ObservableCacheEx
     /// <param name="keys">The keys.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Remove<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TKey> keys)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3417,6 +3563,7 @@ public static class ObservableCacheEx
     /// <param name="key">The key.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Remove<TObject, TKey>(this IIntermediateCache<TObject, TKey> source, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3438,6 +3585,7 @@ public static class ObservableCacheEx
     /// <param name="keys">The keys.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void Remove<TObject, TKey>(this IIntermediateCache<TObject, TKey> source, IEnumerable<TKey> keys)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3459,6 +3607,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject>> RemoveKey<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3484,6 +3633,7 @@ public static class ObservableCacheEx
     /// <param name="key">The key.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void RemoveKey<TObject, TKey>(this ISourceCache<TObject, TKey> source, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3504,6 +3654,7 @@ public static class ObservableCacheEx
     /// <param name="keys">The keys.</param>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static void RemoveKeys<TObject, TKey>(this ISourceCache<TObject, TKey> source, IEnumerable<TKey> keys)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3528,8 +3679,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TRightKey>> RightJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<Optional<TLeft>, TRight, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -3568,8 +3722,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TRightKey>> RightJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TRightKey, Optional<TLeft>, TRight, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -3609,8 +3766,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (left, right) =&gt; new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> RightJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<Optional<TLeft>, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -3650,8 +3810,11 @@ public static class ObservableCacheEx
     /// <param name="resultSelector">The result selector.used to transform the combined data into. Example (key, left, right) => new CustomObject(key, left, right).</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<TDestination, TLeftKey>> RightJoinMany<TLeft, TLeftKey, TRight, TRightKey, TDestination>(this IObservable<IChangeSet<TLeft, TLeftKey>> left, IObservable<IChangeSet<TRight, TRightKey>> right, Func<TRight, TLeftKey> rightKeySelector, Func<TLeftKey, Optional<TLeft>, IGrouping<TRight, TRightKey, TLeftKey>, TDestination> resultSelector)
+        where TLeft : notnull
         where TLeftKey : notnull
+        where TRight : notnull
         where TRightKey : notnull
+        where TDestination : notnull
     {
         if (left is null)
         {
@@ -3685,6 +3848,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> SkipInitial<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3713,6 +3877,7 @@ public static class ObservableCacheEx
     /// comparer.
     /// </exception>
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IComparer<TObject> comparer, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3739,6 +3904,7 @@ public static class ObservableCacheEx
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<IComparer<TObject>> comparerObservable, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3766,6 +3932,7 @@ public static class ObservableCacheEx
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<IComparer<TObject>> comparerObservable, IObservable<Unit> resorter, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3793,6 +3960,7 @@ public static class ObservableCacheEx
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IComparer<TObject> comparer, IObservable<Unit> resorter, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3825,6 +3993,7 @@ public static class ObservableCacheEx
         SortDirection sortOrder = SortDirection.Ascending,
         SortOptimisations sortOptimisations = SortOptimisations.None,
         int resetThreshold = DefaultSortResetThreshold)
+        where TObject : notnull
         where TKey : notnull
     {
         source = source ?? throw new ArgumentNullException(nameof(source));
@@ -3848,6 +4017,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> StartWithEmpty<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.StartWith(ChangeSet<TObject, TKey>.Empty);
@@ -3861,6 +4031,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits sorted change sets.</returns>
     public static IObservable<ISortedChangeSet<TObject, TKey>> StartWithEmpty<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.StartWith(SortedChangeSet<TObject, TKey>.Empty);
@@ -3874,6 +4045,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits virtual change sets.</returns>
     public static IObservable<IVirtualChangeSet<TObject, TKey>> StartWithEmpty<TObject, TKey>(this IObservable<IVirtualChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.StartWith(VirtualChangeSet<TObject, TKey>.Empty);
@@ -3887,6 +4059,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits paged change sets.</returns>
     public static IObservable<IPagedChangeSet<TObject, TKey>> StartWithEmpty<TObject, TKey>(this IObservable<IPagedChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.StartWith(PagedChangeSet<TObject, TKey>.Empty);
@@ -3901,6 +4074,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits group change sets.</returns>
     public static IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> StartWithEmpty<TObject, TKey, TGroupKey>(this IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> source)
+        where TObject : notnull
         where TKey : notnull
         where TGroupKey : notnull
     {
@@ -3916,6 +4090,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits immutable group change sets.</returns>
     public static IObservable<IImmutableGroupChangeSet<TObject, TKey, TGroupKey>> StartWithEmpty<TObject, TKey, TGroupKey>(this IObservable<IImmutableGroupChangeSet<TObject, TKey, TGroupKey>> source)
+        where TObject : notnull
         where TKey : notnull
         where TGroupKey : notnull
     {
@@ -3963,6 +4138,7 @@ public static class ObservableCacheEx
     /// <param name="key">The key.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> StartWithItem<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, TObject item, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -3989,6 +4165,7 @@ public static class ObservableCacheEx
     /// Subscribes to each item when it is added or updates and un-subscribes when it is removed.
     /// </remarks>
     public static IObservable<IChangeSet<TObject, TKey>> SubscribeMany<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IDisposable> subscriptionFactory)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4019,6 +4196,7 @@ public static class ObservableCacheEx
     /// Subscribes to each item when it is added or updates and unsubscribes when it is removed.
     /// </remarks>
     public static IObservable<IChangeSet<TObject, TKey>> SubscribeMany<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IDisposable> subscriptionFactory)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4042,6 +4220,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits change sets.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> SuppressRefresh<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.WhereReasonsAreNot(ChangeReason.Refresh);
@@ -4060,6 +4239,7 @@ public static class ObservableCacheEx
     /// The observable sequence that at any point in time produces the elements of the most recent inner observable sequence that has been received.
     /// </returns>
     public static IObservable<IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this IObservable<IObservableCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -4083,6 +4263,7 @@ public static class ObservableCacheEx
     /// The observable sequence that at any point in time produces the elements of the most recent inner observable sequence that has been received.
     /// </returns>
     public static IObservable<IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this IObservable<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -4101,6 +4282,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the read only collection.</returns>
     public static IObservable<IReadOnlyCollection<TObject>> ToCollection<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.QueryWhenChanged(query => new ReadOnlyCollectionLight<TObject>(query.Items));
@@ -4122,6 +4304,7 @@ public static class ObservableCacheEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this IObservable<TObject> source, Func<TObject, TKey> keySelector, Func<TObject, TimeSpan?>? expireAfter = null, int limitSizeTo = -1, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4153,6 +4336,7 @@ public static class ObservableCacheEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this IObservable<IEnumerable<TObject>> source, Func<TObject, TKey> keySelector, Func<TObject, TimeSpan?>? expireAfter = null, int limitSizeTo = -1, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4179,6 +4363,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     /// <exception cref="System.ArgumentOutOfRangeException">size;Size should be greater than zero.</exception>
     public static IObservable<IVirtualChangeSet<TObject, TKey>> Top<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, int size)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4206,6 +4391,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">source.</exception>
     /// <exception cref="System.ArgumentOutOfRangeException">size;Size should be greater than zero.</exception>
     public static IObservable<IVirtualChangeSet<TObject, TKey>> Top<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IComparer<TObject> comparer, int size)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4237,6 +4423,7 @@ public static class ObservableCacheEx
     /// <param name="sortOrder">The sort order. Defaults to ascending.</param>
     /// <returns>An observable which emits the read only collection.</returns>
     public static IObservable<IReadOnlyCollection<TObject>> ToSortedCollection<TObject, TKey, TSortKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TSortKey> sort, SortDirection sortOrder = SortDirection.Ascending)
+        where TObject : notnull
         where TKey : notnull
         where TSortKey : notnull
     {
@@ -4252,6 +4439,7 @@ public static class ObservableCacheEx
     /// <param name="comparer">The sort comparer.</param>
     /// <returns>An observable which emits the read only collection.</returns>
     public static IObservable<IReadOnlyCollection<TObject>> ToSortedCollection<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IComparer<TObject> comparer)
+        where TObject : notnull
         where TKey : notnull
     {
         return source.QueryWhenChanged(
@@ -4279,6 +4467,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, bool transformOnRefresh)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4310,6 +4500,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, bool transformOnRefresh)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4341,6 +4533,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, TDestination> transformFactory, bool transformOnRefresh)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4372,6 +4566,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, IObservable<Func<TSource, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4403,6 +4599,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4434,6 +4632,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, TDestination> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4470,6 +4670,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         return source.Transform((cur, _, _) => transformFactory(cur), forceTransform.ForForced<TSource, TKey>());
@@ -4491,6 +4693,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4527,6 +4731,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, TDestination> transformFactory, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4563,6 +4769,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Task<TDestination>> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4594,6 +4802,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<TDestination>> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4625,6 +4835,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4652,8 +4864,10 @@ public static class ObservableCacheEx
     /// <param name="manySelector">Will select a enumerable of values.</param>
     /// <param name="keySelector">The key selector which must be unique across all.</param>
     public static IObservable<IChangeSet<TDestination, TDestinationKey>> TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(this IObservable<IChangeSet<TSource, TSourceKey>> source, Func<TSource, IEnumerable<TDestination>> manySelector, Func<TDestination, TDestinationKey> keySelector)
-        where TSourceKey : notnull
+        where TDestination : notnull
         where TDestinationKey : notnull
+        where TSource : notnull
+        where TSourceKey : notnull
     {
         return new TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(source, manySelector, keySelector).Run();
     }
@@ -4670,8 +4884,10 @@ public static class ObservableCacheEx
     /// <param name="manySelector">Will select a enumerable of values.</param>
     /// <param name="keySelector">The key selector which must be unique across all.</param>
     public static IObservable<IChangeSet<TDestination, TDestinationKey>> TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(this IObservable<IChangeSet<TSource, TSourceKey>> source, Func<TSource, ObservableCollection<TDestination>> manySelector, Func<TDestination, TDestinationKey> keySelector)
-        where TSourceKey : notnull
+        where TDestination : notnull
         where TDestinationKey : notnull
+        where TSource : notnull
+        where TSourceKey : notnull
     {
         return new TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(source, manySelector, keySelector).Run();
     }
@@ -4688,8 +4904,10 @@ public static class ObservableCacheEx
     /// <param name="manySelector">Will select a enumerable of values.</param>
     /// <param name="keySelector">The key selector which must be unique across all.</param>
     public static IObservable<IChangeSet<TDestination, TDestinationKey>> TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(this IObservable<IChangeSet<TSource, TSourceKey>> source, Func<TSource, ReadOnlyObservableCollection<TDestination>> manySelector, Func<TDestination, TDestinationKey> keySelector)
-        where TSourceKey : notnull
+        where TDestination : notnull
         where TDestinationKey : notnull
+        where TSource : notnull
+        where TSourceKey : notnull
     {
         return new TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(source, manySelector, keySelector).Run();
     }
@@ -4706,8 +4924,10 @@ public static class ObservableCacheEx
     /// <param name="manySelector">Will select an observable cache of values.</param>
     /// <param name="keySelector">The key selector which must be unique across all.</param>
     public static IObservable<IChangeSet<TDestination, TDestinationKey>> TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(this IObservable<IChangeSet<TSource, TSourceKey>> source, Func<TSource, IObservableCache<TDestination, TDestinationKey>> manySelector, Func<TDestination, TDestinationKey> keySelector)
-        where TSourceKey : notnull
+        where TDestination : notnull
         where TDestinationKey : notnull
+        where TSource : notnull
+        where TSourceKey : notnull
     {
         return new TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(source, manySelector, keySelector).Run();
     }
@@ -4730,6 +4950,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4768,6 +4990,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4806,6 +5030,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4849,6 +5075,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         return source.TransformSafe((cur, _, _) => transformFactory(cur), errorHandler, forceTransform.ForForced<TSource, TKey>());
@@ -4872,6 +5100,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4910,6 +5140,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Unit> forceTransform)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4947,6 +5179,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -4984,6 +5218,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5021,6 +5257,8 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5051,8 +5289,8 @@ public static class ObservableCacheEx
     /// <param name="predicateChanged">Observable to change the underlying predicate.</param>
     /// <returns>An observable which will emit change sets.</returns>
     public static IObservable<IChangeSet<Node<TObject, TKey>, TKey>> TransformToTree<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey> pivotOn, IObservable<Func<Node<TObject, TKey>, bool>>? predicateChanged = null)
-        where TKey : notnull
         where TObject : class
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -5083,8 +5321,9 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformWithInlineUpdate<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<TDestination, TSource> updateAction)
-        where TKey : notnull
         where TDestination : class
+        where TSource : notnull
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -5121,8 +5360,9 @@ public static class ObservableCacheEx
     /// or
     /// transformFactory.</exception>
     public static IObservable<IChangeSet<TDestination, TKey>> TransformWithInlineUpdate<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<TDestination, TSource> updateAction, Action<Error<TSource, TKey>> errorHandler)
-        where TKey : notnull
         where TDestination : class
+        where TSource : notnull
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -5155,6 +5395,7 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>the same SortedChangeSets, except all moves are replaced with remove + add.</returns>
     public static IObservable<ISortedChangeSet<TObject, TKey>> TreatMovesAsRemoveAdd<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5198,7 +5439,9 @@ public static class ObservableCacheEx
     /// <returns>An observable which boolean values indicating if true.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<bool> TrueForAll<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TValue>> observableSelector, Func<TValue, bool> equalityCondition)
+        where TObject : notnull
         where TKey : notnull
+        where TValue : notnull
     {
         return source.TrueFor(observableSelector, items => items.All(o => o.LatestValue.HasValue && equalityCondition(o.LatestValue.Value)));
     }
@@ -5219,7 +5462,9 @@ public static class ObservableCacheEx
     /// <returns>An observable which boolean values indicating if true.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<bool> TrueForAll<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TValue>> observableSelector, Func<TObject, TValue, bool> equalityCondition)
+        where TObject : notnull
         where TKey : notnull
+        where TValue : notnull
     {
         return source.TrueFor(observableSelector, items => items.All(o => o.LatestValue.HasValue && equalityCondition(o.Item, o.LatestValue.Value)));
     }
@@ -5245,7 +5490,9 @@ public static class ObservableCacheEx
     /// equalityCondition.
     /// </exception>
     public static IObservable<bool> TrueForAny<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TValue>> observableSelector, Func<TObject, TValue, bool> equalityCondition)
+        where TObject : notnull
         where TKey : notnull
+        where TValue : notnull
     {
         return source.TrueFor(observableSelector, items => items.Any(o => o.LatestValue.HasValue && equalityCondition(o.Item, o.LatestValue.Value)));
     }
@@ -5271,7 +5518,9 @@ public static class ObservableCacheEx
     /// equalityCondition.
     /// </exception>
     public static IObservable<bool> TrueForAny<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TValue>> observableSelector, Func<TValue, bool> equalityCondition)
+        where TObject : notnull
         where TKey : notnull
+        where TValue : notnull
     {
         if (source is null)
         {
@@ -5299,8 +5548,8 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the sorted change set.</returns>
     public static IObservable<ISortedChangeSet<TObject, TKey>> UpdateIndex<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source)
-        where TKey : notnull
         where TObject : IIndexAware
+        where TKey : notnull
     {
         return source.Do(changes => changes.SortedItems.Select((update, index) => new { update, index }).ForEach(u => u.update.Value.Index = u.index));
     }
@@ -5315,6 +5564,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which will emit virtual change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IVirtualChangeSet<TObject, TKey>> Virtualise<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservable<IVirtualRequest> virtualRequests)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5339,6 +5589,7 @@ public static class ObservableCacheEx
     /// <param name="key">The key.</param>
     /// <returns>An observable which emits the change.</returns>
     public static IObservable<Change<TObject, TKey>> Watch<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5359,6 +5610,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits the object value.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<TObject> WatchValue<TObject, TKey>(this IObservableCache<TObject, TKey> source, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5379,6 +5631,7 @@ public static class ObservableCacheEx
     /// <returns>An observable which emits the object value.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<TObject> WatchValue<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, TKey key)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5398,8 +5651,8 @@ public static class ObservableCacheEx
     /// <param name="propertiesToMonitor">specify properties to Monitor, or omit to monitor all property changes.</param>
     /// <returns>An observable which emits the object which has had a property changed.</returns>
     public static IObservable<TObject?> WhenAnyPropertyChanged<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params string[] propertiesToMonitor)
-        where TKey : notnull
         where TObject : INotifyPropertyChanged
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -5420,8 +5673,8 @@ public static class ObservableCacheEx
     /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
     /// <returns>An observable which emits a property when it has changed.</returns>
     public static IObservable<PropertyValue<TObject, TValue>> WhenPropertyChanged<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Expression<Func<TObject, TValue>> propertyAccessor, bool notifyOnInitialValue = true)
-        where TKey : notnull
         where TObject : INotifyPropertyChanged
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -5447,8 +5700,8 @@ public static class ObservableCacheEx
     /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
     /// <returns>An observable which emits a value when it has changed.</returns>
     public static IObservable<TValue?> WhenValueChanged<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Expression<Func<TObject, TValue>> propertyAccessor, bool notifyOnInitialValue = true)
-        where TKey : notnull
         where TObject : INotifyPropertyChanged
+        where TKey : notnull
     {
         if (source is null)
         {
@@ -5474,6 +5727,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">reasons.</exception>
     /// <exception cref="System.ArgumentException">Must select at least on reason.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> WhereReasonsAre<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params ChangeReason[] reasons)
+        where TObject : notnull
         where TKey : notnull
     {
         if (reasons is null)
@@ -5502,6 +5756,7 @@ public static class ObservableCacheEx
     /// <exception cref="System.ArgumentNullException">reasons.</exception>
     /// <exception cref="System.ArgumentException">Must select at least on reason.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> WhereReasonsAreNot<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params ChangeReason[] reasons)
+        where TObject : notnull
         where TKey : notnull
     {
         if (reasons is null)
@@ -5534,6 +5789,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Xor<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, params IObservable<IChangeSet<TObject, TKey>>[] others)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5563,6 +5819,7 @@ public static class ObservableCacheEx
     /// others.
     /// </exception>
     public static IObservable<IChangeSet<TObject, TKey>> Xor<TObject, TKey>(this ICollection<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -5582,6 +5839,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits a change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Xor<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -5601,6 +5859,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits a change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Xor<TObject, TKey>(this IObservableList<IObservableCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -5620,6 +5879,7 @@ public static class ObservableCacheEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits a change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Xor<TObject, TKey>(this IObservableList<ISourceCache<TObject, TKey>> sources)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -5647,12 +5907,14 @@ public static class ObservableCacheEx
     /// or
     /// timeSelector.</exception>
     internal static IObservable<IEnumerable<KeyValuePair<TKey, TObject>>> ForExpiry<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TimeSpan?> timeSelector, TimeSpan? interval, IScheduler scheduler)
+        where TObject : notnull
         where TKey : notnull
     {
         return new TimeExpirer<TObject, TKey>(source, timeSelector, interval, scheduler).ForExpiry();
     }
 
     private static IObservable<IChangeSet<TObject, TKey>> Combine<TObject, TKey>(this IObservableList<IObservableCache<TObject, TKey>> source, CombineOperator type)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5670,6 +5932,7 @@ public static class ObservableCacheEx
     }
 
     private static IObservable<IChangeSet<TObject, TKey>> Combine<TObject, TKey>(this IObservableList<ISourceCache<TObject, TKey>> source, CombineOperator type)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5687,6 +5950,7 @@ public static class ObservableCacheEx
     }
 
     private static IObservable<IChangeSet<TObject, TKey>> Combine<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> source, CombineOperator type)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -5698,6 +5962,7 @@ public static class ObservableCacheEx
     }
 
     private static IObservable<IChangeSet<TObject, TKey>> Combine<TObject, TKey>(this ICollection<IObservable<IChangeSet<TObject, TKey>>> sources, CombineOperator type)
+        where TObject : notnull
         where TKey : notnull
     {
         if (sources is null)
@@ -5737,6 +6002,7 @@ public static class ObservableCacheEx
     }
 
     private static IObservable<IChangeSet<TObject, TKey>> Combine<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, CombineOperator type, params IObservable<IChangeSet<TObject, TKey>>[] combineTarget)
+        where TObject : notnull
         where TKey : notnull
     {
         if (combineTarget is null)
@@ -5802,7 +6068,9 @@ public static class ObservableCacheEx
     }
 
     private static IObservable<bool> TrueFor<TObject, TKey, TValue>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<TValue>> observableSelector, Func<IEnumerable<ObservableWithValue<TObject, TValue>>, bool> collectionMatcher)
+        where TObject : notnull
         where TKey : notnull
+        where TValue : notnull
     {
         return new TrueFor<TObject, TKey, TValue>(source, observableSelector, collectionMatcher).Run();
     }

--- a/src/DynamicData/Cache/PagedChangeSet.cs
+++ b/src/DynamicData/Cache/PagedChangeSet.cs
@@ -12,6 +12,7 @@ using DynamicData.Operators;
 namespace DynamicData;
 
 internal sealed class PagedChangeSet<TObject, TKey> : ChangeSet<TObject, TKey>, IPagedChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     public static readonly new IPagedChangeSet<TObject, TKey> Empty = new PagedChangeSet<TObject, TKey>();

--- a/src/DynamicData/Cache/SortedChangeSet.cs
+++ b/src/DynamicData/Cache/SortedChangeSet.cs
@@ -11,6 +11,7 @@ using DynamicData.Cache.Internal;
 namespace DynamicData;
 
 internal class SortedChangeSet<TObject, TKey> : ChangeSet<TObject, TKey>, ISortedChangeSet<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     public static readonly new ISortedChangeSet<TObject, TKey> Empty = new SortedChangeSet<TObject, TKey>();

--- a/src/DynamicData/Cache/SourceCache.cs
+++ b/src/DynamicData/Cache/SourceCache.cs
@@ -16,6 +16,7 @@ namespace DynamicData;
 /// <typeparam name="TKey">The type of the key.</typeparam>
 [DebuggerDisplay("SourceCache<{typeof(TObject).Name}, {typeof(TKey).Name}> ({Count} Items)")]
 public sealed class SourceCache<TObject, TKey> : ISourceCache<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly ObservableCache<TObject, TKey> _innerCache;

--- a/src/DynamicData/Cache/SourceCacheEx.cs
+++ b/src/DynamicData/Cache/SourceCacheEx.cs
@@ -23,7 +23,9 @@ public static class SourceCacheEx
     /// <param name="converter">The conversion factory.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination, TKey>> Cast<TSource, TKey, TDestination>(this IObservableCache<TSource, TKey> source, Func<TSource, TDestination> converter)
+        where TSource : notnull
         where TKey : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/Cache/Tests/ChangeSetAggregator.cs
+++ b/src/DynamicData/Cache/Tests/ChangeSetAggregator.cs
@@ -18,6 +18,7 @@ namespace DynamicData.Tests;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class ChangeSetAggregator<TObject, TKey> : IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IDisposable _disposer;

--- a/src/DynamicData/Cache/Tests/PagedChangeSetAggregator.cs
+++ b/src/DynamicData/Cache/Tests/PagedChangeSetAggregator.cs
@@ -18,6 +18,7 @@ namespace DynamicData.Tests;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class PagedChangeSetAggregator<TObject, TKey> : IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IDisposable _disposer;

--- a/src/DynamicData/Cache/Tests/SortedChangeSetAggregator.cs
+++ b/src/DynamicData/Cache/Tests/SortedChangeSetAggregator.cs
@@ -18,6 +18,7 @@ namespace DynamicData.Tests;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class SortedChangeSetAggregator<TObject, TKey> : IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IDisposable _disposer;

--- a/src/DynamicData/Cache/Tests/TestEx.cs
+++ b/src/DynamicData/Cache/Tests/TestEx.cs
@@ -20,6 +20,7 @@ public static class TestEx
     /// <param name="source">The source.</param>
     /// <returns>The change set aggregator.</returns>
     public static ChangeSetAggregator<TObject, TKey> AsAggregator<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         return new(source);
@@ -52,6 +53,7 @@ public static class TestEx
     /// <returns>The sorted change set aggregator.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static SortedChangeSetAggregator<TObject, TKey> AsAggregator<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -71,6 +73,7 @@ public static class TestEx
     /// <returns>The virtual change set aggregator.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static VirtualChangeSetAggregator<TObject, TKey> AsAggregator<TObject, TKey>(this IObservable<IVirtualChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -89,6 +92,7 @@ public static class TestEx
     /// <param name="source">The source.</param>
     /// <returns>The paged change set aggregator.</returns>
     public static PagedChangeSetAggregator<TObject, TKey> AsAggregator<TObject, TKey>(this IObservable<IPagedChangeSet<TObject, TKey>> source)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)

--- a/src/DynamicData/Cache/Tests/VirtualChangeSetAggregator.cs
+++ b/src/DynamicData/Cache/Tests/VirtualChangeSetAggregator.cs
@@ -18,6 +18,7 @@ namespace DynamicData.Tests;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public class VirtualChangeSetAggregator<TObject, TKey> : IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IDisposable _disposer;

--- a/src/DynamicData/Cache/VirtualChangeSet.cs
+++ b/src/DynamicData/Cache/VirtualChangeSet.cs
@@ -11,6 +11,7 @@ using DynamicData.Cache.Internal;
 namespace DynamicData;
 
 internal sealed class VirtualChangeSet<TObject, TKey> : ChangeSet<TObject, TKey>, IVirtualChangeSet<TObject, TKey>, IEquatable<VirtualChangeSet<TObject, TKey>>
+    where TObject : notnull
     where TKey : notnull
 {
     public static readonly new IVirtualChangeSet<TObject, TKey> Empty = new VirtualChangeSet<TObject, TKey>();

--- a/src/DynamicData/Diagnostics/DiagnosticOperators.cs
+++ b/src/DynamicData/Diagnostics/DiagnosticOperators.cs
@@ -21,6 +21,7 @@ public static class DiagnosticOperators
     /// <returns>An observable which emits the change summary.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<ChangeSummary> CollectUpdateStats<TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source)
+        where TSource : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -54,6 +55,7 @@ public static class DiagnosticOperators
     /// <returns>An observable which emits the change summary.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<ChangeSummary> CollectUpdateStats<TSource>(this IObservable<IChangeSet<TSource>> source)
+        where TSource : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/EnumerableEx.cs
+++ b/src/DynamicData/EnumerableEx.cs
@@ -29,6 +29,7 @@ public static class EnumerableEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> AsObservableChangeSet<TObject, TKey>(this IEnumerable<TObject> source, Func<TObject, TKey> keySelector, bool completable = false)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -66,6 +67,7 @@ public static class EnumerableEx
     /// <returns>An observable change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<TObject>> AsObservableChangeSet<TObject>(this IEnumerable<TObject> source, bool completable = false)
+        where TObject : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/Experimental/ExperimentalEx.cs
+++ b/src/DynamicData/Experimental/ExperimentalEx.cs
@@ -22,6 +22,7 @@ public static class ExperimentalEx
     /// <returns>The watcher.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IWatcher<TObject, TKey> AsWatcher<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IScheduler? scheduler = null)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)

--- a/src/DynamicData/Experimental/IWatcher.cs
+++ b/src/DynamicData/Experimental/IWatcher.cs
@@ -12,6 +12,7 @@ namespace DynamicData.Experimental;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 public interface IWatcher<TObject, TKey> : IDisposable
+    where TObject : notnull
     where TKey : notnull
 {
     /// <summary>

--- a/src/DynamicData/Experimental/Watcher.cs
+++ b/src/DynamicData/Experimental/Watcher.cs
@@ -13,6 +13,7 @@ using DynamicData.Kernel;
 namespace DynamicData.Experimental;
 
 internal sealed class Watcher<TObject, TKey> : IWatcher<TObject, TKey>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly IDisposable _disposer;

--- a/src/DynamicData/Kernel/EnumerableIList.cs
+++ b/src/DynamicData/Kernel/EnumerableIList.cs
@@ -74,6 +74,7 @@ internal static class EnumerableIList
     public static EnumerableIList<T> Create<T>(IList<T> list) => new(list);
 
     public static EnumerableIList<Change<TObject, TKey>> Create<TObject, TKey>(IChangeSet<TObject, TKey> changeSet)
+        where TObject : notnull
         where TKey : notnull =>
         Create((IList<Change<TObject, TKey>>)changeSet);
 }

--- a/src/DynamicData/Kernel/OptionExtensions.cs
+++ b/src/DynamicData/Kernel/OptionExtensions.cs
@@ -23,6 +23,8 @@ public static class OptionExtensions
     /// <returns>The converted value.</returns>
     /// <exception cref="System.ArgumentNullException">converter.</exception>
     public static Optional<TDestination> Convert<TSource, TDestination>(this Optional<TSource> source, Func<TSource, TDestination> converter)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (converter is null)
         {
@@ -47,6 +49,7 @@ public static class OptionExtensions
     /// fallbackConverter.
     /// </exception>
     public static TDestination? ConvertOr<TSource, TDestination>(this Optional<TSource> source, Func<TSource?, TDestination?> converter, Func<TDestination?> fallbackConverter)
+        where TSource : notnull
     {
         if (converter is null)
         {
@@ -71,6 +74,7 @@ public static class OptionExtensions
     /// <param name="selector">The selector.</param>
     /// <returns>The first value or none.</returns>
     public static Optional<T> FirstOrOptional<T>(this IEnumerable<T> source, Func<T, bool> selector)
+        where T : notnull
     {
         if (source is null)
         {
@@ -96,6 +100,7 @@ public static class OptionExtensions
     /// <param name="action">The action.</param>
     /// <returns>The optional else extension.</returns>
     public static OptionElse IfHasValue<T>(this Optional<T> source, Action<T> action)
+        where T : notnull
     {
         if (!source.HasValue || source.Value is null)
         {
@@ -119,6 +124,7 @@ public static class OptionExtensions
     /// <param name="action">The action.</param>
     /// <returns>The optional else extension.</returns>
     public static OptionElse IfHasValue<T>(this Optional<T>? source, Action<T> action)
+        where T : notnull
     {
         if (!source.HasValue)
         {
@@ -150,6 +156,7 @@ public static class OptionExtensions
     /// <param name="key">The key.</param>
     /// <returns>The option of the looked up value.</returns>
     public static Optional<TValue> Lookup<TValue, TKey>(this IDictionary<TKey, TValue> source, TKey key)
+        where TValue : notnull
     {
         if (source is null)
         {
@@ -186,6 +193,7 @@ public static class OptionExtensions
     /// <param name="source">The source.</param>
     /// <returns>An enumerable of the selected items.</returns>
     public static IEnumerable<T> SelectValues<T>(this IEnumerable<Optional<T>> source)
+        where T : notnull
     {
         return source.Where(t => t.HasValue && t.Value is not null).Select(t => t.Value!);
     }
@@ -212,6 +220,7 @@ public static class OptionExtensions
     /// <returns>If the value or a provided default.</returns>
     /// <exception cref="System.ArgumentNullException">valueSelector.</exception>
     public static T ValueOr<T>(this Optional<T> source, Func<T> valueSelector)
+        where T : notnull
     {
         if (valueSelector is null)
         {
@@ -228,6 +237,7 @@ public static class OptionExtensions
     /// <param name="source">The source.</param>
     /// <returns>The value or default.</returns>
     public static T? ValueOrDefault<T>(this Optional<T> source)
+        where T : notnull
     {
         if (source.HasValue)
         {
@@ -246,6 +256,7 @@ public static class OptionExtensions
     /// <returns>The value.</returns>
     /// <exception cref="System.ArgumentNullException">exceptionGenerator.</exception>
     public static T ValueOrThrow<T>(this Optional<T> source, Func<Exception> exceptionGenerator)
+        where T : notnull
     {
         if (exceptionGenerator is null)
         {

--- a/src/DynamicData/Kernel/Optional.cs
+++ b/src/DynamicData/Kernel/Optional.cs
@@ -17,6 +17,7 @@ namespace DynamicData.Kernel;
 [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Deliberate usage.")]
 [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Class names the same, generic differences.")]
 public readonly struct Optional<T> : IEquatable<Optional<T>>
+    where T : notnull
 {
     private readonly T? _value;
 
@@ -185,7 +186,9 @@ public static class Optional
     /// </summary>
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <returns>The optional value.</returns>
-    public static Optional<T> None<T>() => Optional<T>.None;
+    public static Optional<T> None<T>()
+        where T : notnull
+        => Optional<T>.None;
 
     /// <summary>
     /// Wraps the specified value in an Optional container.
@@ -193,5 +196,7 @@ public static class Optional
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <param name="value">The value.</param>
     /// <returns>The optional value.</returns>
-    public static Optional<T> Some<T>(T value) => new(value);
+    public static Optional<T> Some<T>(T? value)
+        where T : notnull
+        => new(value);
 }

--- a/src/DynamicData/List/Change.cs
+++ b/src/DynamicData/List/Change.cs
@@ -12,6 +12,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the item.</typeparam>
 public sealed class Change<T> : IEquatable<Change<T>>
+    where T : notnull
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Change{T}"/> class.

--- a/src/DynamicData/List/ChangeAwareList.cs
+++ b/src/DynamicData/List/ChangeAwareList.cs
@@ -19,6 +19,7 @@ namespace DynamicData;
 /// <typeparam name="T">The item type.</typeparam>
 /// <seealso cref="DynamicData.IExtendedList{T}" />
 public class ChangeAwareList<T> : IExtendedList<T>
+    where T : notnull
 {
     private readonly List<T> _innerList;
 

--- a/src/DynamicData/List/ChangeAwareListWithRefCounts.cs
+++ b/src/DynamicData/List/ChangeAwareListWithRefCounts.cs
@@ -11,6 +11,7 @@ using DynamicData.List.Internal;
 namespace DynamicData;
 
 internal class ChangeAwareListWithRefCounts<T> : ChangeAwareList<T>
+    where T : notnull
 {
     private readonly ReferenceCountTracker<T> _tracker = new();
 

--- a/src/DynamicData/List/ChangeSet.cs
+++ b/src/DynamicData/List/ChangeSet.cs
@@ -13,6 +13,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the object.</typeparam>
 public class ChangeSet<T> : List<Change<T>>, IChangeSet<T>
+    where T : notnull
 {
     /// <summary>
     /// An empty change set.

--- a/src/DynamicData/List/ChangeSetEx.cs
+++ b/src/DynamicData/List/ChangeSetEx.cs
@@ -22,6 +22,7 @@ public static class ChangeSetEx
     /// <returns>An enumerable of change sets.</returns>
     /// <exception cref="ArgumentNullException">source.</exception>
     public static IEnumerable<ItemChange<T>> Flatten<T>(this IChangeSet<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -71,6 +72,8 @@ public static class ChangeSetEx
     /// transformer.
     /// </exception>
     public static IChangeSet<TDestination> Transform<TSource, TDestination>(this IChangeSet<TSource> source, Func<TSource, TDestination> transformer)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -103,6 +106,7 @@ public static class ChangeSetEx
     /// <param name="source">The source.</param>
     /// <returns>An enumerable of changes.</returns>
     public static IEnumerable<Change<T>> YieldWithoutIndex<T>(this IEnumerable<Change<T>> source)
+        where T : notnull
     {
         return new WithoutIndexEnumerator<T>(source);
     }
@@ -115,6 +119,7 @@ public static class ChangeSetEx
     /// <returns>An enumerable of changes.</returns>
     /// <exception cref="ArgumentNullException">source.</exception>
     internal static IEnumerable<UnifiedChange<T>> Unified<T>(this IChangeSet<T> source)
+        where T : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/List/IChangeSet.cs
+++ b/src/DynamicData/List/IChangeSet.cs
@@ -14,6 +14,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="TObject">The type of the object.</typeparam>
 public interface IChangeSet<TObject> : IEnumerable<Change<TObject>>, IChangeSet
+    where TObject : notnull
 {
     /// <summary>
     ///     Gets the number of updates.

--- a/src/DynamicData/List/IChangeSetAdaptor.cs
+++ b/src/DynamicData/List/IChangeSetAdaptor.cs
@@ -9,6 +9,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the object.</typeparam>
 public interface IChangeSetAdaptor<T>
+    where T : notnull
 {
     /// <summary>
     /// Adapts the specified change.

--- a/src/DynamicData/List/IGroup.cs
+++ b/src/DynamicData/List/IGroup.cs
@@ -10,6 +10,7 @@ namespace DynamicData;
 /// <typeparam name="TObject">The type of the object.</typeparam>
 /// <typeparam name="TGroup">The type of the group.</typeparam>
 public interface IGroup<TObject, out TGroup>
+    where TObject : notnull
 {
     /// <summary>
     /// Gets the group key.

--- a/src/DynamicData/List/IObservableList.cs
+++ b/src/DynamicData/List/IObservableList.cs
@@ -14,6 +14,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of item.</typeparam>
 public interface IObservableList<T> : IDisposable
+    where T : notnull
 {
     /// <summary>
     /// Gets the count.

--- a/src/DynamicData/List/IPageChangeSet.cs
+++ b/src/DynamicData/List/IPageChangeSet.cs
@@ -13,6 +13,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the object.</typeparam>
 public interface IPageChangeSet<T> : IChangeSet<T>
+    where T : notnull
 {
     /// <summary>
     /// Gets the parameters used to virtualise the stream.

--- a/src/DynamicData/List/ISourceList.cs
+++ b/src/DynamicData/List/ISourceList.cs
@@ -13,6 +13,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the item.</typeparam>
 public interface ISourceList<T> : IObservableList<T>
+    where T : notnull
 {
     /// <summary>
     /// Edit the inner list within the list's internal locking mechanism.

--- a/src/DynamicData/List/IVirtualChangeSet.cs
+++ b/src/DynamicData/List/IVirtualChangeSet.cs
@@ -10,6 +10,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the object.</typeparam>
 public interface IVirtualChangeSet<T> : IChangeSet<T>
+    where T : notnull
 {
     /// <summary>
     /// Gets the parameters used to virtualise the stream.

--- a/src/DynamicData/List/Internal/AnonymousObservableList.cs
+++ b/src/DynamicData/List/Internal/AnonymousObservableList.cs
@@ -9,6 +9,7 @@ namespace DynamicData.List.Internal;
 
 [DebuggerDisplay("AnonymousObservableList<{typeof(T).Name}> ({Count} Items)")]
 internal sealed class AnonymousObservableList<T> : IObservableList<T>
+    where T : notnull
 {
     private readonly ISourceList<T> _sourceList;
     private readonly IDisposable _cleanUp;

--- a/src/DynamicData/List/Internal/AutoRefresh.cs
+++ b/src/DynamicData/List/Internal/AutoRefresh.cs
@@ -13,6 +13,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class AutoRefresh<TObject, TAny>
+    where TObject : notnull
 {
     private readonly TimeSpan? _buffer;
 

--- a/src/DynamicData/List/Internal/BufferIf.cs
+++ b/src/DynamicData/List/Internal/BufferIf.cs
@@ -11,6 +11,7 @@ using System.Reactive.Subjects;
 namespace DynamicData.List.Internal;
 
 internal sealed class BufferIf<T>
+    where T : notnull
 {
     private readonly bool _initialPauseState;
 

--- a/src/DynamicData/List/Internal/Combiner.cs
+++ b/src/DynamicData/List/Internal/Combiner.cs
@@ -13,6 +13,7 @@ using DynamicData.Cache.Internal;
 namespace DynamicData.List.Internal;
 
 internal sealed class Combiner<T>
+    where T : notnull
 {
     private readonly object _locker = new();
 

--- a/src/DynamicData/List/Internal/DeferUntilLoaded.cs
+++ b/src/DynamicData/List/Internal/DeferUntilLoaded.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class DeferUntilLoaded<T>
+    where T : notnull
 {
     private readonly IObservable<IChangeSet<T>> _source;
 

--- a/src/DynamicData/List/Internal/Distinct.cs
+++ b/src/DynamicData/List/Internal/Distinct.cs
@@ -12,6 +12,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class Distinct<T, TValue>
+    where T : notnull
     where TValue : notnull
 {
     private readonly IObservable<IChangeSet<T>> _source;

--- a/src/DynamicData/List/Internal/DynamicCombiner.cs
+++ b/src/DynamicData/List/Internal/DynamicCombiner.cs
@@ -14,6 +14,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class DynamicCombiner<T>
+    where T : notnull
 {
     private readonly object _locker = new();
 

--- a/src/DynamicData/List/Internal/EditDiff.cs
+++ b/src/DynamicData/List/Internal/EditDiff.cs
@@ -11,6 +11,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class EditDiff<T>
+    where T : notnull
 {
     private readonly IEqualityComparer<T> _equalityComparer;
 

--- a/src/DynamicData/List/Internal/ExpireAfter.cs
+++ b/src/DynamicData/List/Internal/ExpireAfter.cs
@@ -15,6 +15,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class ExpireAfter<T>
+    where T : notnull
 {
     private readonly Func<T, TimeSpan?> _expireAfter;
 

--- a/src/DynamicData/List/Internal/Filter.cs
+++ b/src/DynamicData/List/Internal/Filter.cs
@@ -12,6 +12,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class Filter<T>
+    where T : notnull
 {
     private readonly ListFilterPolicy _policy;
 

--- a/src/DynamicData/List/Internal/FilterOnObservable.cs
+++ b/src/DynamicData/List/Internal/FilterOnObservable.cs
@@ -12,6 +12,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal class FilterOnObservable<TObject>
+    where TObject : notnull
 {
     private readonly TimeSpan? _buffer;
 

--- a/src/DynamicData/List/Internal/FilterStatic.cs
+++ b/src/DynamicData/List/Internal/FilterStatic.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal class FilterStatic<T>
+    where T : notnull
 {
     private readonly Func<T, bool> _predicate;
 

--- a/src/DynamicData/List/Internal/Group.cs
+++ b/src/DynamicData/List/Internal/Group.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace DynamicData.List.Internal;
 
 internal class Group<TObject, TGroup> : IGroup<TObject, TGroup>, IDisposable, IEquatable<Group<TObject, TGroup>>
+    where TObject : notnull
 {
     public Group(TGroup groupKey) => GroupKey = groupKey;
 

--- a/src/DynamicData/List/Internal/GroupOn.cs
+++ b/src/DynamicData/List/Internal/GroupOn.cs
@@ -14,6 +14,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class GroupOn<TObject, TGroupKey>
+    where TObject : notnull
     where TGroupKey : notnull
 {
     private readonly Func<TObject, TGroupKey> _groupSelector;

--- a/src/DynamicData/List/Internal/GroupOnImmutable.cs
+++ b/src/DynamicData/List/Internal/GroupOnImmutable.cs
@@ -14,6 +14,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class GroupOnImmutable<TObject, TGroupKey>
+    where TObject : notnull
     where TGroupKey : notnull
 {
     private readonly Func<TObject, TGroupKey> _groupSelector;

--- a/src/DynamicData/List/Internal/GroupOnProperty.cs
+++ b/src/DynamicData/List/Internal/GroupOnProperty.cs
@@ -13,8 +13,8 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class GroupOnProperty<TObject, TGroup>
-    where TGroup : notnull
     where TObject : INotifyPropertyChanged
+    where TGroup : notnull
 {
     private readonly Func<TObject, TGroup> _groupSelector;
 

--- a/src/DynamicData/List/Internal/GroupOnPropertyWithImmutableState.cs
+++ b/src/DynamicData/List/Internal/GroupOnPropertyWithImmutableState.cs
@@ -13,8 +13,8 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class GroupOnPropertyWithImmutableState<TObject, TGroup>
-    where TGroup : notnull
     where TObject : INotifyPropertyChanged
+    where TGroup : notnull
 {
     private readonly Func<TObject, TGroup> _groupSelector;
 

--- a/src/DynamicData/List/Internal/LimitSizeTo.cs
+++ b/src/DynamicData/List/Internal/LimitSizeTo.cs
@@ -12,6 +12,7 @@ using System.Threading;
 namespace DynamicData.List.Internal;
 
 internal sealed class LimitSizeTo<T>
+    where T : notnull
 {
     private readonly object _locker;
 

--- a/src/DynamicData/List/Internal/MergeMany.cs
+++ b/src/DynamicData/List/Internal/MergeMany.cs
@@ -8,6 +8,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal sealed class MergeMany<T, TDestination>
+    where T : notnull
 {
     private readonly Func<T, IObservable<TDestination>> _observableSelector;
 

--- a/src/DynamicData/List/Internal/OnBeingAdded.cs
+++ b/src/DynamicData/List/Internal/OnBeingAdded.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class OnBeingAdded<T>
+    where T : notnull
 {
     private readonly Action<T> _callback;
 

--- a/src/DynamicData/List/Internal/OnBeingRemoved.cs
+++ b/src/DynamicData/List/Internal/OnBeingRemoved.cs
@@ -12,6 +12,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class OnBeingRemoved<T>
+    where T : notnull
 {
     private readonly Action<T> _callback;
     private readonly bool _invokeOnUnsubscribe;

--- a/src/DynamicData/List/Internal/Pager.cs
+++ b/src/DynamicData/List/Internal/Pager.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class Pager<T>
+    where T : notnull
 {
     private readonly IObservable<IPageRequest> _requests;
 

--- a/src/DynamicData/List/Internal/QueryWhenChanged.cs
+++ b/src/DynamicData/List/Internal/QueryWhenChanged.cs
@@ -11,6 +11,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class QueryWhenChanged<T>
+    where T : notnull
 {
     private readonly IObservable<IChangeSet<T>> _source;
 

--- a/src/DynamicData/List/Internal/ReaderWriter.cs
+++ b/src/DynamicData/List/Internal/ReaderWriter.cs
@@ -9,6 +9,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class ReaderWriter<T>
+    where T : notnull
 {
     private readonly object _locker = new();
 

--- a/src/DynamicData/List/Internal/RefCount.cs
+++ b/src/DynamicData/List/Internal/RefCount.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal class RefCount<T>
+    where T : notnull
 {
     private readonly object _locker = new();
 

--- a/src/DynamicData/List/Internal/Sort.cs
+++ b/src/DynamicData/List/Internal/Sort.cs
@@ -13,6 +13,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class Sort<T>
+    where T : notnull
 {
     private readonly IObservable<IComparer<T>> _comparerObservable;
 

--- a/src/DynamicData/List/Internal/SubscribeMany.cs
+++ b/src/DynamicData/List/Internal/SubscribeMany.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal sealed class SubscribeMany<T>
+    where T : notnull
 {
     private readonly IObservable<IChangeSet<T>> _source;
 

--- a/src/DynamicData/List/Internal/Switch.cs
+++ b/src/DynamicData/List/Internal/Switch.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal sealed class Switch<T>
+    where T : notnull
 {
     private readonly IObservable<IObservable<IChangeSet<T>>> _sources;
 

--- a/src/DynamicData/List/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/List/Internal/ToObservableChangeSet.cs
@@ -9,6 +9,7 @@ using System.Reactive.Linq;
 namespace DynamicData.List.Internal;
 
 internal class ToObservableChangeSet<T>
+    where T : notnull
 {
     private readonly Func<T, TimeSpan?>? _expireAfter;
 

--- a/src/DynamicData/List/Internal/TransformAsync.cs
+++ b/src/DynamicData/List/Internal/TransformAsync.cs
@@ -10,6 +10,8 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal class TransformAsync<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
 {
     private readonly Func<TSource, Optional<TDestination>, int, Task<Transformer<TSource, TDestination>.TransformedItemContainer>> _containerFactory;
 

--- a/src/DynamicData/List/Internal/TransformMany.cs
+++ b/src/DynamicData/List/Internal/TransformMany.cs
@@ -13,6 +13,8 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class TransformMany<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
 {
     private readonly Func<TSource, IObservable<IChangeSet<TDestination>>>? _childChanges;
 

--- a/src/DynamicData/List/Internal/Transformer.cs
+++ b/src/DynamicData/List/Internal/Transformer.cs
@@ -12,6 +12,8 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class Transformer<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
 {
     private readonly Func<TSource, Optional<TDestination>, int, TransformedItemContainer> _containerFactory;
 

--- a/src/DynamicData/List/Internal/UnifiedChange.cs
+++ b/src/DynamicData/List/Internal/UnifiedChange.cs
@@ -10,6 +10,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal readonly struct UnifiedChange<T> : IEquatable<UnifiedChange<T>>
+    where T : notnull
 {
     public UnifiedChange(ListChangeReason reason, T current)
         : this(reason, current, Optional.None<T>())

--- a/src/DynamicData/List/Internal/Virtualiser.cs
+++ b/src/DynamicData/List/Internal/Virtualiser.cs
@@ -8,6 +8,7 @@ using DynamicData.Kernel;
 namespace DynamicData.List.Internal;
 
 internal sealed class Virtualiser<T>
+    where T : notnull
 {
     private readonly IObservable<IVirtualRequest> _requests;
 

--- a/src/DynamicData/List/ItemChange.cs
+++ b/src/DynamicData/List/ItemChange.cs
@@ -15,6 +15,7 @@ namespace DynamicData;
 /// </summary>
 /// <typeparam name="T">The type of the item.</typeparam>
 public readonly struct ItemChange<T> : IEquatable<ItemChange<T>>
+    where T : notnull
 {
     /// <summary>
     /// An empty change.

--- a/src/DynamicData/List/Linq/AddKeyEnumerator.cs
+++ b/src/DynamicData/List/Linq/AddKeyEnumerator.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 namespace DynamicData.List.Linq;
 
 internal class AddKeyEnumerator<TObject, TKey> : IEnumerable<Change<TObject, TKey>>
+    where TObject : notnull
     where TKey : notnull
 {
     private readonly Func<TObject, TKey> _keySelector;

--- a/src/DynamicData/List/Linq/ItemChangeEnumerator.cs
+++ b/src/DynamicData/List/Linq/ItemChangeEnumerator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace DynamicData.List.Linq;
 
 internal class ItemChangeEnumerator<T> : IEnumerable<ItemChange<T>>
+    where T : notnull
 {
     private readonly IChangeSet<T> _changeSet;
 

--- a/src/DynamicData/List/Linq/Reverser.cs
+++ b/src/DynamicData/List/Linq/Reverser.cs
@@ -8,6 +8,7 @@ using System.Linq;
 namespace DynamicData.List.Linq;
 
 internal class Reverser<T>
+    where T : notnull
 {
     private int _length;
 

--- a/src/DynamicData/List/Linq/UnifiedChangeEnumerator.cs
+++ b/src/DynamicData/List/Linq/UnifiedChangeEnumerator.cs
@@ -10,6 +10,7 @@ using DynamicData.List.Internal;
 namespace DynamicData.List.Linq;
 
 internal class UnifiedChangeEnumerator<T> : IEnumerable<UnifiedChange<T>>
+    where T : notnull
 {
     private readonly IChangeSet<T> _changeSet;
 

--- a/src/DynamicData/List/Linq/WithoutIndexEnumerator.cs
+++ b/src/DynamicData/List/Linq/WithoutIndexEnumerator.cs
@@ -13,6 +13,7 @@ namespace DynamicData.List.Linq;
 /// </summary>
 /// <typeparam name="T">The type of the item.</typeparam>
 internal class WithoutIndexEnumerator<T> : IEnumerable<Change<T>>
+    where T : notnull
 {
     private readonly IEnumerable<Change<T>> _changeSet;
 

--- a/src/DynamicData/List/ListEx.cs
+++ b/src/DynamicData/List/ListEx.cs
@@ -251,7 +251,8 @@ public static class ListEx
     /// or
     /// changes.
     /// </exception>
-    public static void Clone<T>(this IList<T> source, IChangeSet<T> changes) => Clone(source, changes, null);
+    public static void Clone<T>(this IList<T> source, IChangeSet<T> changes)
+        where T : notnull => Clone(source, changes, null);
 
     /// <summary>
     /// Clones the list from the specified change set.
@@ -265,7 +266,8 @@ public static class ListEx
     /// or
     /// changes.
     /// </exception>
-    public static void Clone<T>(this IList<T> source, IChangeSet<T> changes, IEqualityComparer<T>? equalityComparer) => Clone(source, (IEnumerable<Change<T>>)changes, equalityComparer);
+    public static void Clone<T>(this IList<T> source, IChangeSet<T> changes, IEqualityComparer<T>? equalityComparer)
+        where T : notnull => Clone(source, (IEnumerable<Change<T>>)changes, equalityComparer);
 
     /// <summary>
     /// Clones the list from the specified enumerable of changes.
@@ -280,6 +282,7 @@ public static class ListEx
     /// changes.
     /// </exception>
     public static void Clone<T>(this IList<T> source, IEnumerable<Change<T>> changes, IEqualityComparer<T>? equalityComparer)
+        where T : notnull
     {
         if (source is null)
         {
@@ -554,6 +557,7 @@ public static class ListEx
     /// <param name="source">The source.</param>
     /// <param name="change">The change.</param>
     internal static void ClearOrRemoveMany<T>(this IList<T> source, Change<T> change)
+        where T : notnull
     {
         // apply this to other operators
         if (source.Count == change.Range.Count)
@@ -567,6 +571,7 @@ public static class ListEx
     }
 
     internal static bool MovedWithinRange<T>(this Change<T> source, int startIndex, int endIndex)
+        where T : notnull
     {
         if (source.Reason != ListChangeReason.Moved)
         {
@@ -580,6 +585,7 @@ public static class ListEx
     }
 
     private static void Clone<T>(this IList<T> source, Change<T> item, IEqualityComparer<T> equalityComparer)
+        where T : notnull
     {
         var changeAware = source as ChangeAwareList<T>;
 

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -37,6 +37,7 @@ public static class ObservableListEx
     /// adaptor.
     /// </exception>
     public static IObservable<IChangeSet<T>> Adapt<T>(this IObservable<IChangeSet<T>> source, IChangeSetAdaptor<T> adaptor)
+        where T : notnull
     {
         if (source is null)
         {
@@ -73,6 +74,7 @@ public static class ObservableListEx
     /// <param name="keySelector">The key selector.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> AddKey<TObject, TKey>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (source is null)
@@ -97,6 +99,7 @@ public static class ObservableListEx
     /// <param name="others">The others.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> And<T>(this IObservable<IChangeSet<T>> source, params IObservable<IChangeSet<T>>[] others)
+        where T : notnull
     {
         return source.Combine(CombineOperator.And, others);
     }
@@ -109,6 +112,7 @@ public static class ObservableListEx
     /// <param name="sources">The sources.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> And<T>(this ICollection<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.And);
     }
@@ -121,6 +125,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> And<T>(this IObservableList<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.And);
     }
@@ -133,6 +138,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> And<T>(this IObservableList<IObservableList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.And);
     }
@@ -145,6 +151,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> And<T>(this IObservableList<ISourceList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.And);
     }
@@ -157,6 +164,7 @@ public static class ObservableListEx
     /// <returns>An observable list.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservableList<T> AsObservableList<T>(this ISourceList<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -174,6 +182,7 @@ public static class ObservableListEx
     /// <returns>An observable list.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservableList<T> AsObservableList<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -263,6 +272,7 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable change set with additional refresh changes.</returns>
     public static IObservable<IChangeSet<TObject>> AutoRefreshOnObservable<TObject, TAny>(this IObservable<IChangeSet<TObject>> source, Func<TObject, IObservable<TAny>> reevaluator, TimeSpan? changeSetBuffer = null, IScheduler? scheduler = null)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -291,6 +301,7 @@ public static class ObservableListEx
     /// targetCollection.
     /// </exception>
     public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, IObservableCollection<T> targetCollection, int resetThreshold = 25)
+        where T : notnull
     {
         if (source is null)
         {
@@ -315,6 +326,7 @@ public static class ObservableListEx
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>A continuation of the source stream.</returns>
     public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, out ReadOnlyObservableCollection<T> readOnlyObservableCollection, int resetThreshold = 25)
+        where T : notnull
     {
         if (source is null)
         {
@@ -344,6 +356,7 @@ public static class ObservableListEx
     /// </exception>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, BindingList<T> bindingList, int resetThreshold = 25)
+        where T : notnull
     {
         if (source is null)
         {
@@ -371,6 +384,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source, IObservable<bool> pauseIfTrueSelector, IScheduler? scheduler = null)
+        where T : notnull
     {
         return BufferIf(source, pauseIfTrueSelector, false, scheduler);
     }
@@ -387,6 +401,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source, IObservable<bool> pauseIfTrueSelector, bool initialPauseState, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -413,6 +428,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source, IObservable<bool> pauseIfTrueSelector, TimeSpan? timeOut, IScheduler? scheduler = null)
+        where T : notnull
     {
         return BufferIf(source, pauseIfTrueSelector, false, timeOut, scheduler);
     }
@@ -430,6 +446,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> BufferIf<T>(this IObservable<IChangeSet<T>> source, IObservable<bool> pauseIfTrueSelector, bool initialPauseState, TimeSpan? timeOut, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -453,6 +470,7 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler to buffer on.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject>> BufferInitial<TObject>(this IObservable<IChangeSet<TObject>> source, TimeSpan initialBuffer, IScheduler? scheduler = null)
+        where TObject : notnull
     {
         return source.DeferUntilLoaded().Publish(
             shared =>
@@ -470,6 +488,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination>> Cast<TDestination>(this IObservable<IChangeSet<object>> source)
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -490,6 +509,8 @@ public static class ObservableListEx
     /// <param name="conversionFactory">The conversion factory.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination>> Cast<TSource, TDestination>(this IObservable<IChangeSet<TSource>> source, Func<TSource, TDestination> conversionFactory)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -510,9 +531,10 @@ public static class ObservableListEx
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
-    public static IObservable<IChangeSet<object?>> CastToObject<T>(this IObservable<IChangeSet<T>> source)
+    public static IObservable<IChangeSet<object>> CastToObject<T>(this IObservable<IChangeSet<T>> source)
+        where T : class
     {
-        return source.Select(changes => changes.Transform(t => (object?)t));
+        return source.Select(changes => changes.Transform(t => (object)t));
     }
 
     /// <summary>
@@ -524,6 +546,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> Clone<T>(this IObservable<IChangeSet<T>> source, IList<T> target)
+        where T : notnull
     {
         if (source is null)
         {
@@ -545,6 +568,8 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     [Obsolete("Prefer Cast as it is does the same thing but is semantically correct")]
     public static IObservable<IChangeSet<TDestination>> Convert<TObject, TDestination>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TDestination> conversionFactory)
+        where TObject : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -566,6 +591,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> DeferUntilLoaded<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -582,6 +608,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> DeferUntilLoaded<T>(this IObservableList<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -602,6 +629,7 @@ public static class ObservableListEx
     /// <returns>A continuation of the original stream.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> DisposeMany<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         return source.OnItemRemoved(
             t =>
@@ -625,6 +653,7 @@ public static class ObservableListEx
     /// valueSelector.
     /// </exception>
     public static IObservable<IChangeSet<TValue>> DistinctValues<TObject, TValue>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TValue> valueSelector)
+        where TObject : notnull
         where TValue : notnull
     {
         if (source is null)
@@ -649,6 +678,7 @@ public static class ObservableListEx
     /// <param name="others">The others.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Except<T>(this IObservable<IChangeSet<T>> source, params IObservable<IChangeSet<T>>[] others)
+        where T : notnull
     {
         return source.Combine(CombineOperator.Except, others);
     }
@@ -661,6 +691,7 @@ public static class ObservableListEx
     /// <param name="sources">The sources.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Except<T>(this ICollection<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Except);
     }
@@ -672,6 +703,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Except<T>(this IObservableList<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Except);
     }
@@ -683,6 +715,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Except<T>(this IObservableList<IObservableList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Except);
     }
@@ -694,6 +727,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Except<T>(this IObservableList<ISourceList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Except);
     }
@@ -707,6 +741,7 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable which emits the enumerable of items.</returns>
     public static IObservable<IEnumerable<T>> ExpireAfter<T>(this ISourceList<T> source, Func<T, TimeSpan?> timeSelector, IScheduler? scheduler = null)
+        where T : notnull
     {
         return source.ExpireAfter(timeSelector, null, scheduler);
     }
@@ -721,6 +756,7 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable which emits the enumerable of items.</returns>
     public static IObservable<IEnumerable<T>> ExpireAfter<T>(this ISourceList<T> source, Func<T, TimeSpan?> timeSelector, TimeSpan? pollingInterval = null, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -747,6 +783,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> Filter<T>(this IObservable<IChangeSet<T>> source, Func<T, bool> predicate)
+        where T : notnull
     {
         if (source is null)
         {
@@ -773,6 +810,7 @@ public static class ObservableListEx
     /// or
     /// filterController.</exception>
     public static IObservable<IChangeSet<T>> Filter<T>(this IObservable<IChangeSet<T>> source, IObservable<Func<T, bool>> predicate, ListFilterPolicy filterPolicy = ListFilterPolicy.CalculateDiff)
+        where T : notnull
     {
         if (source is null)
         {
@@ -799,6 +837,7 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler used when throttling.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject>> FilterOnObservable<TObject>(this IObservable<IChangeSet<TObject>> source, Func<TObject, IObservable<bool>> objectFilterObservable, TimeSpan? propertyChangedThrottle = null, IScheduler? scheduler = null)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -850,6 +889,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> FlattenBufferResult<T>(this IObservable<IList<IChangeSet<T>>> source)
+        where T : notnull
     {
         return source.Where(x => x.Count != 0).Select(updates => new ChangeSet<T>(updates.SelectMany(u => u)));
     }
@@ -862,6 +902,7 @@ public static class ObservableListEx
     /// <param name="action">The action.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject>> ForEachChange<TObject>(this IObservable<IChangeSet<TObject>> source, Action<Change<TObject>> action)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -886,6 +927,7 @@ public static class ObservableListEx
     /// <param name="action">The action.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TObject>> ForEachItemChange<TObject>(this IObservable<IChangeSet<TObject>> source, Action<ItemChange<TObject>> action)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -916,6 +958,7 @@ public static class ObservableListEx
     /// groupSelector.
     /// </exception>
     public static IObservable<IChangeSet<IGroup<TObject, TGroup>>> GroupOn<TObject, TGroup>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TGroup> groupSelector, IObservable<Unit>? regrouper = null)
+        where TObject : notnull
         where TGroup : notnull
     {
         if (source is null)
@@ -944,8 +987,8 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<IGroup<TObject, TGroup>>> GroupOnProperty<TObject, TGroup>(this IObservable<IChangeSet<TObject>> source, Expression<Func<TObject, TGroup>> propertySelector, TimeSpan? propertyChangedThrottle = null, IScheduler? scheduler = null)
-        where TGroup : notnull
         where TObject : INotifyPropertyChanged
+        where TGroup : notnull
     {
         if (source is null)
         {
@@ -973,8 +1016,8 @@ public static class ObservableListEx
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<List.IGrouping<TObject, TGroup>>> GroupOnPropertyWithImmutableState<TObject, TGroup>(this IObservable<IChangeSet<TObject>> source, Expression<Func<TObject, TGroup>> propertySelector, TimeSpan? propertyChangedThrottle = null, IScheduler? scheduler = null)
-        where TGroup : notnull
         where TObject : INotifyPropertyChanged
+        where TGroup : notnull
     {
         if (source is null)
         {
@@ -1005,6 +1048,7 @@ public static class ObservableListEx
     /// groupSelectorKey.
     /// </exception>
     public static IObservable<IChangeSet<List.IGrouping<TObject, TGroupKey>>> GroupWithImmutableState<TObject, TGroupKey>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TGroupKey> groupSelectorKey, IObservable<Unit>? regrouper = null)
+        where TObject : notnull
         where TGroupKey : notnull
     {
         if (source is null)
@@ -1032,6 +1076,7 @@ public static class ObservableListEx
     /// <exception cref="ArgumentNullException">source.</exception>
     /// <exception cref="ArgumentException">sizeLimit cannot be zero.</exception>
     public static IObservable<IEnumerable<T>> LimitSizeTo<T>(this ISourceList<T> source, int sizeLimit, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1062,6 +1107,7 @@ public static class ObservableListEx
     /// or
     /// observableSelector.</exception>
     public static IObservable<TDestination> MergeMany<T, TDestination>(this IObservable<IChangeSet<T>> source, Func<T, IObservable<TDestination>> observableSelector)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1084,6 +1130,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> NotEmpty<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1101,6 +1148,7 @@ public static class ObservableListEx
     /// <param name="addAction">The add action.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> OnItemAdded<T>(this IObservable<IChangeSet<T>> source, Action<T> addAction)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1123,6 +1171,7 @@ public static class ObservableListEx
     /// <param name="refreshAction">The refresh action.</param>
     /// <returns>An observable which emits a change set with items being added.</returns>
     public static IObservable<IChangeSet<TObject>> OnItemRefreshed<TObject>(this IObservable<IChangeSet<TObject>> source, Action<TObject> refreshAction)
+        where TObject : notnull
     {
         Action<TObject> refreshAction2 = refreshAction;
         if (source == null)
@@ -1158,6 +1207,7 @@ public static class ObservableListEx
     /// removeAction.
     /// </exception>
     public static IObservable<IChangeSet<T>> OnItemRemoved<T>(this IObservable<IChangeSet<T>> source, Action<T> removeAction, bool invokeOnUnsubscribe = true)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1180,6 +1230,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Or<T>(this ICollection<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Or);
     }
@@ -1193,6 +1244,7 @@ public static class ObservableListEx
     /// <param name="others">The others.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Or<T>(this IObservable<IChangeSet<T>> source, params IObservable<IChangeSet<T>>[] others)
+        where T : notnull
     {
         return source.Combine(CombineOperator.Or, others);
     }
@@ -1205,6 +1257,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Or<T>(this IObservableList<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Or);
     }
@@ -1217,6 +1270,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Or<T>(this IObservableList<IObservableList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Or);
     }
@@ -1229,6 +1283,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Or<T>(this IObservableList<ISourceList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Or);
     }
@@ -1241,6 +1296,7 @@ public static class ObservableListEx
     /// <param name="requests">Observable to control page requests.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IPageChangeSet<T>> Page<T>(this IObservable<IChangeSet<T>> source, IObservable<IPageRequest> requests)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1268,6 +1324,7 @@ public static class ObservableListEx
     /// destination.
     /// </exception>
     public static IDisposable PopulateInto<T>(this IObservable<IChangeSet<T>> source, ISourceList<T> destination)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1296,6 +1353,7 @@ public static class ObservableListEx
     /// resultSelector.
     /// </exception>
     public static IObservable<TDestination> QueryWhenChanged<TObject, TDestination>(this IObservable<IChangeSet<TObject>> source, Func<IReadOnlyCollection<TObject>, TDestination> resultSelector)
+        where TObject : notnull
     {
         if (source is null)
         {
@@ -1318,6 +1376,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the read only collection.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IReadOnlyCollection<T>> QueryWhenChanged<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1334,6 +1393,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> RefCount<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1352,6 +1412,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> RemoveIndex<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1373,6 +1434,7 @@ public static class ObservableListEx
     /// comparer.
     /// </exception>
     public static IObservable<IChangeSet<T>> Reverse<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         var reverser = new Reverser<T>();
         if (source is null)
@@ -1391,6 +1453,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
     public static IObservable<IChangeSet<T>> SkipInitial<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1415,6 +1478,7 @@ public static class ObservableListEx
     /// or
     /// comparer.</exception>
     public static IObservable<IChangeSet<T>> Sort<T>(this IObservable<IChangeSet<T>> source, IComparer<T> comparer, SortOptions options = SortOptions.None, IObservable<Unit>? resort = null, IObservable<IComparer<T>>? comparerChanged = null, int resetThreshold = 50)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1443,6 +1507,7 @@ public static class ObservableListEx
     /// or
     /// comparer.</exception>
     public static IObservable<IChangeSet<T>> Sort<T>(this IObservable<IChangeSet<T>> source, IObservable<IComparer<T>> comparerChanged, SortOptions options = SortOptions.None, IObservable<Unit>? resort = null, int resetThreshold = 50)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1464,6 +1529,7 @@ public static class ObservableListEx
     /// <param name="source">The source observable of change set values.</param>
     /// <returns>An observable which emits a change set.</returns>
     public static IObservable<IChangeSet<T>> StartWithEmpty<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         return source.StartWith(ChangeSet<T>.Empty);
     }
@@ -1482,6 +1548,7 @@ public static class ObservableListEx
     /// Subscribes to each item when it is added or updates and unsubscribes when it is removed.
     /// </remarks>
     public static IObservable<IChangeSet<T>> SubscribeMany<T>(this IObservable<IChangeSet<T>> source, Func<T, IDisposable> subscriptionFactory)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1503,6 +1570,7 @@ public static class ObservableListEx
     /// <param name="source">The source observable change set.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> SuppressRefresh<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         if (source == null)
         {
@@ -1529,6 +1597,7 @@ public static class ObservableListEx
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources" /> is null.</exception>
     public static IObservable<IChangeSet<T>> Switch<T>(this IObservable<IObservableList<T>> sources)
+        where T : notnull
     {
         if (sources is null)
         {
@@ -1551,6 +1620,7 @@ public static class ObservableListEx
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources" /> is null.</exception>
     public static IObservable<IChangeSet<T>> Switch<T>(this IObservable<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         if (sources is null)
         {
@@ -1567,6 +1637,7 @@ public static class ObservableListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits the read only collection.</returns>
     public static IObservable<IReadOnlyCollection<TObject>> ToCollection<TObject>(this IObservable<IChangeSet<TObject>> source)
+        where TObject : notnull
     {
         return source.QueryWhenChanged(items => items);
     }
@@ -1583,6 +1654,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<T> source, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1605,6 +1677,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<T> source, Func<T, TimeSpan?> expireAfter, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1632,6 +1705,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<T> source, int limitSizeTo, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1655,6 +1729,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<T> source, Func<T, TimeSpan?>? expireAfter, int limitSizeTo, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1676,6 +1751,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<IEnumerable<T>> source, IScheduler? scheduler = null)
+        where T : notnull
     {
         return ToObservableChangeSet<T>(source, null, -1, scheduler);
     }
@@ -1693,6 +1769,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<IEnumerable<T>> source, int limitSizeTo, IScheduler? scheduler = null)
+        where T : notnull
     {
         return ToObservableChangeSet<T>(source, null, limitSizeTo, scheduler);
     }
@@ -1710,6 +1787,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<IEnumerable<T>> source, Func<T, TimeSpan?> expireAfter, IScheduler? scheduler = null)
+        where T : notnull
     {
         return ToObservableChangeSet(source, expireAfter, 0, scheduler);
     }
@@ -1728,6 +1806,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<IEnumerable<T>> source, Func<T, TimeSpan?>? expireAfter, int limitSizeTo, IScheduler? scheduler = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1745,6 +1824,7 @@ public static class ObservableListEx
     /// <param name="numberOfItems">The number of items.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Top<T>(this IObservable<IChangeSet<T>> source, int numberOfItems)
+        where T : notnull
     {
         if (source is null)
         {
@@ -1769,6 +1849,7 @@ public static class ObservableListEx
     /// <param name="sortOrder">The sort order. Defaults to ascending.</param>
     /// <returns>An observable which emits the read only collection.</returns>
     public static IObservable<IReadOnlyCollection<TObject>> ToSortedCollection<TObject, TSortKey>(this IObservable<IChangeSet<TObject>> source, Func<TObject, TSortKey> sort, SortDirection sortOrder = SortDirection.Ascending)
+        where TObject : notnull
     {
         return source.QueryWhenChanged(query => sortOrder == SortDirection.Ascending ? new ReadOnlyCollectionLight<TObject>(query.OrderBy(sort)) : new ReadOnlyCollectionLight<TObject>(query.OrderByDescending(sort)));
     }
@@ -1781,6 +1862,7 @@ public static class ObservableListEx
     /// <param name="comparer">The sort comparer.</param>
     /// <returns>An observable which emits the read only collection.</returns>
     public static IObservable<IReadOnlyCollection<TObject>> ToSortedCollection<TObject>(this IObservable<IChangeSet<TObject>> source, IComparer<TObject> comparer)
+        where TObject : notnull
     {
         return source.QueryWhenChanged(
             query =>
@@ -1806,6 +1888,8 @@ public static class ObservableListEx
     /// valueSelector.
     /// </exception>
     public static IObservable<IChangeSet<TDestination>> Transform<TSource, TDestination>(this IObservable<IChangeSet<TSource>> source, Func<TSource, TDestination> transformFactory, bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1835,6 +1919,8 @@ public static class ObservableListEx
     /// valueSelector.
     /// </exception>
     public static IObservable<IChangeSet<TDestination>> Transform<TSource, TDestination>(this IObservable<IChangeSet<TSource>> source, Func<TSource, int, TDestination> transformFactory, bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1866,6 +1952,8 @@ public static class ObservableListEx
     /// valueSelector.
     /// </exception>
     public static IObservable<IChangeSet<TDestination>> Transform<TSource, TDestination>(this IObservable<IChangeSet<TSource>> source, Func<TSource, Optional<TDestination>, TDestination> transformFactory, bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1897,6 +1985,8 @@ public static class ObservableListEx
     /// valueSelector.
     /// </exception>
     public static IObservable<IChangeSet<TDestination>> Transform<TSource, TDestination>(this IObservable<IChangeSet<TSource>> source, Func<TSource, Optional<TDestination>, int, TDestination> transformFactory, bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1928,6 +2018,8 @@ public static class ObservableListEx
     public static IObservable<IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(
         this IObservable<IChangeSet<TSource>> source, Func<TSource, Task<TDestination>> transformFactory,
         bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1959,6 +2051,8 @@ public static class ObservableListEx
     public static IObservable<IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(
         this IObservable<IChangeSet<TSource>> source, Func<TSource, int, Task<TDestination>> transformFactory,
         bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -1990,6 +2084,8 @@ public static class ObservableListEx
     public static IObservable<IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(
         this IObservable<IChangeSet<TSource>> source, Func<TSource, Optional<TDestination>, Task<TDestination>> transformFactory,
         bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -2021,6 +2117,8 @@ public static class ObservableListEx
     public static IObservable<IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(
         this IObservable<IChangeSet<TSource>> source, Func<TSource, Optional<TDestination>, int, Task<TDestination>> transformFactory,
         bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {
@@ -2050,6 +2148,8 @@ public static class ObservableListEx
     /// manySelector.
     /// </exception>
     public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source, Func<TSource, IEnumerable<TDestination>> manySelector, IEqualityComparer<TDestination>? equalityComparer = null)
+        where TDestination : notnull
+        where TSource : notnull
     {
         if (source is null)
         {
@@ -2074,6 +2174,8 @@ public static class ObservableListEx
     /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source, Func<TSource, ObservableCollection<TDestination>> manySelector, IEqualityComparer<TDestination>? equalityComparer = null)
+        where TDestination : notnull
+        where TSource : notnull
     {
         return new TransformMany<TSource, TDestination>(source, manySelector, equalityComparer).Run();
     }
@@ -2088,6 +2190,8 @@ public static class ObservableListEx
     /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source, Func<TSource, ReadOnlyObservableCollection<TDestination>> manySelector, IEqualityComparer<TDestination>? equalityComparer = null)
+        where TDestination : notnull
+        where TSource : notnull
     {
         return new TransformMany<TSource, TDestination>(source, manySelector, equalityComparer).Run();
     }
@@ -2102,6 +2206,8 @@ public static class ObservableListEx
     /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source, Func<TSource, IObservableList<TDestination>> manySelector, IEqualityComparer<TDestination>? equalityComparer = null)
+        where TDestination : notnull
+        where TSource : notnull
     {
         return new TransformMany<TSource, TDestination>(source, manySelector, equalityComparer).Run();
     }
@@ -2114,6 +2220,7 @@ public static class ObservableListEx
     /// <param name="requests">The requests.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IVirtualChangeSet<T>> Virtualise<T>(this IObservable<IChangeSet<T>> source, IObservable<IVirtualRequest> requests)
+        where T : notnull
     {
         if (source is null)
         {
@@ -2207,6 +2314,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentException">Must enter at least 1 reason.</exception>
     public static IObservable<IChangeSet<T>> WhereReasonsAre<T>(this IObservable<IChangeSet<T>> source, params ListChangeReason[] reasons)
+        where T : notnull
     {
         if (reasons is null)
         {
@@ -2236,6 +2344,7 @@ public static class ObservableListEx
     /// <returns>An observable which emits the change set.</returns>
     /// <exception cref="System.ArgumentException">Must enter at least 1 reason.</exception>
     public static IObservable<IChangeSet<T>> WhereReasonsAreNot<T>(this IObservable<IChangeSet<T>> source, params ListChangeReason[] reasons)
+        where T : notnull
     {
         if (reasons is null)
         {
@@ -2265,6 +2374,7 @@ public static class ObservableListEx
     /// <param name="others">The others.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Xor<T>(this IObservable<IChangeSet<T>> source, params IObservable<IChangeSet<T>>[] others)
+        where T : notnull
     {
         return source.Combine(CombineOperator.Xor, others);
     }
@@ -2277,6 +2387,7 @@ public static class ObservableListEx
     /// <param name="sources">The sources.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Xor<T>(this ICollection<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Xor);
     }
@@ -2289,6 +2400,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Xor<T>(this IObservableList<IObservable<IChangeSet<T>>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Xor);
     }
@@ -2301,6 +2413,7 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Xor<T>(this IObservableList<IObservableList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Xor);
     }
@@ -2313,11 +2426,13 @@ public static class ObservableListEx
     /// <param name="sources">The source.</param>
     /// <returns>An observable which emits the change set.</returns>
     public static IObservable<IChangeSet<T>> Xor<T>(this IObservableList<ISourceList<T>> sources)
+        where T : notnull
     {
         return sources.Combine(CombineOperator.Xor);
     }
 
     private static IObservable<IChangeSet<T>> Combine<T>(this ICollection<IObservable<IChangeSet<T>>> sources, CombineOperator type)
+        where T : notnull
     {
         if (sources is null)
         {
@@ -2328,6 +2443,7 @@ public static class ObservableListEx
     }
 
     private static IObservable<IChangeSet<T>> Combine<T>(this IObservable<IChangeSet<T>> source, CombineOperator type, params IObservable<IChangeSet<T>>[] others)
+        where T : notnull
     {
         if (source is null)
         {
@@ -2349,6 +2465,7 @@ public static class ObservableListEx
     }
 
     private static IObservable<IChangeSet<T>> Combine<T>(this IObservableList<ISourceList<T>> sources, CombineOperator type)
+        where T : notnull
     {
         if (sources is null)
         {
@@ -2365,6 +2482,7 @@ public static class ObservableListEx
     }
 
     private static IObservable<IChangeSet<T>> Combine<T>(this IObservableList<IObservableList<T>> sources, CombineOperator type)
+        where T : notnull
     {
         if (sources is null)
         {
@@ -2381,6 +2499,7 @@ public static class ObservableListEx
     }
 
     private static IObservable<IChangeSet<T>> Combine<T>(this IObservableList<IObservable<IChangeSet<T>>> sources, CombineOperator type)
+        where T : notnull
     {
         if (sources is null)
         {

--- a/src/DynamicData/List/PageChangeSet.cs
+++ b/src/DynamicData/List/PageChangeSet.cs
@@ -12,6 +12,7 @@ using DynamicData.Operators;
 namespace DynamicData;
 
 internal sealed class PageChangeSet<T> : IPageChangeSet<T>
+    where T : notnull
 {
     private readonly IChangeSet<T> _virtualChangeSet;
 

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -18,6 +18,7 @@ namespace DynamicData;
 /// <typeparam name="T">The type of the object.</typeparam>
 [DebuggerDisplay("SourceList<{typeof(T).Name}> ({Count} Items)")]
 public sealed class SourceList<T> : ISourceList<T>
+    where T : notnull
 {
     private readonly ISubject<IChangeSet<T>> _changes = new Subject<IChangeSet<T>>();
 

--- a/src/DynamicData/List/SourceListEditConvenienceEx.cs
+++ b/src/DynamicData/List/SourceListEditConvenienceEx.cs
@@ -22,6 +22,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="source">The source list.</param>
     /// <param name="item">The item to add.</param>
     public static void Add<T>(this ISourceList<T> source, T item)
+        where T : notnull
     {
         if (source is null)
         {
@@ -38,6 +39,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="source">The source.</param>
     /// <param name="items">The items.</param>
     public static void AddRange<T>(this ISourceList<T> source, IEnumerable<T> items)
+        where T : notnull
     {
         if (source is null)
         {
@@ -53,6 +55,7 @@ public static class SourceListEditConvenienceEx
     /// <typeparam name="T">The item type.</typeparam>
     /// <param name="source">The source to clear.</param>
     public static void Clear<T>(this ISourceList<T> source)
+        where T : notnull
     {
         if (source is null)
         {
@@ -71,6 +74,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="allItems">The items to compare against and performing a delta.</param>
     /// <param name="equalityComparer">The equality comparer used to determine whether an item has changed.</param>
     public static void EditDiff<T>(this ISourceList<T> source, IEnumerable<T> allItems, IEqualityComparer<T>? equalityComparer = null)
+        where T : notnull
     {
         if (source is null)
         {
@@ -94,6 +98,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="index">The index of the item.</param>
     /// <param name="item">The item.</param>
     public static void Insert<T>(this ISourceList<T> source, int index, T item)
+        where T : notnull
     {
         if (source is null)
         {
@@ -111,6 +116,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="items">The items.</param>
     /// <param name="index">The zero-based index at which the new elements should be inserted.</param>
     public static void InsertRange<T>(this ISourceList<T> source, IEnumerable<T> items, int index)
+        where T : notnull
     {
         if (source is null)
         {
@@ -128,6 +134,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="original">The original.</param>
     /// <param name="destination">The destination.</param>
     public static void Move<T>(this ISourceList<T> source, int original, int destination)
+        where T : notnull
     {
         if (source is null)
         {
@@ -145,6 +152,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="item">The item.</param>
     /// <returns>If the item was removed.</returns>
     public static bool Remove<T>(this ISourceList<T> source, T item)
+        where T : notnull
     {
         bool removed = false;
         if (source is null)
@@ -163,6 +171,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="source">The source.</param>
     /// <param name="index">The index.</param>
     public static void RemoveAt<T>(this ISourceList<T> source, int index)
+        where T : notnull
     {
         if (source is null)
         {
@@ -179,6 +188,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="source">The source.</param>
     /// <param name="itemsToRemove">The items to remove.</param>
     public static void RemoveMany<T>(this ISourceList<T> source, IEnumerable<T> itemsToRemove)
+        where T : notnull
     {
         if (source is null)
         {
@@ -198,6 +208,7 @@ public static class SourceListEditConvenienceEx
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="count" /> is less than 0.</exception>
     /// <exception cref="ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range of elements in the <see cref="List{T}" />.</exception>
     public static void RemoveRange<T>(this ISourceList<T> source, int index, int count)
+        where T : notnull
     {
         if (source is null)
         {
@@ -215,6 +226,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="original">The original.</param>
     /// <param name="destination">The destination.</param>
     public static void Replace<T>(this ISourceList<T> source, T original, T destination)
+        where T : notnull
     {
         if (source is null)
         {
@@ -232,6 +244,7 @@ public static class SourceListEditConvenienceEx
     /// <param name="index">The index.</param>
     /// <param name="item">The item.</param>
     public static void ReplaceAt<T>(this ISourceList<T> source, int index, T item)
+        where T : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/List/SourceListEx.cs
+++ b/src/DynamicData/List/SourceListEx.cs
@@ -23,6 +23,8 @@ public static class SourceListEx
     /// <param name="conversionFactory">The conversion factory.</param>
     /// <returns>An observable which emits that change set.</returns>
     public static IObservable<IChangeSet<TDestination>> Cast<TSource, TDestination>(this ISourceList<TSource> source, Func<TSource, TDestination> conversionFactory)
+        where TSource : notnull
+        where TDestination : notnull
     {
         if (source is null)
         {

--- a/src/DynamicData/List/Tests/ChangeSetAggregator.cs
+++ b/src/DynamicData/List/Tests/ChangeSetAggregator.cs
@@ -15,6 +15,7 @@ namespace DynamicData.Tests;
 /// </summary>
 /// <typeparam name="TObject">The type of the object.</typeparam>
 public class ChangeSetAggregator<TObject> : IDisposable
+    where TObject : notnull
 {
     private readonly IDisposable _disposer;
 

--- a/src/DynamicData/List/Tests/ListTextEx.cs
+++ b/src/DynamicData/List/Tests/ListTextEx.cs
@@ -19,6 +19,7 @@ public static class ListTextEx
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <returns>The change set aggregator.</returns>
     public static ChangeSetAggregator<T> AsAggregator<T>(this IObservable<IChangeSet<T>> source)
+        where T : notnull
     {
         return new(source);
     }

--- a/src/DynamicData/List/VirtualChangeSet.cs
+++ b/src/DynamicData/List/VirtualChangeSet.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 namespace DynamicData;
 
 internal class VirtualChangeSet<T> : IVirtualChangeSet<T>
+    where T : notnull
 {
     private readonly IChangeSet<T> _virtualChangeSet;
 

--- a/src/DynamicData/ObservableChangeSet.cs
+++ b/src/DynamicData/ObservableChangeSet.cs
@@ -24,6 +24,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, Action> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -54,6 +55,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, IDisposable> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -94,6 +96,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, Task<IDisposable>> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -118,6 +121,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, CancellationToken, Task<IDisposable>> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -159,6 +163,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, Task<Action>> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -183,6 +188,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, CancellationToken, Task<Action>> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -233,6 +239,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, Task> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -273,6 +280,7 @@ public static class ObservableChangeSet
     /// <param name="keySelector">The key selector.</param>
     /// <returns>The observable cache with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<TObject, TKey>> Create<TObject, TKey>(Func<ISourceCache<TObject, TKey>, CancellationToken, Task> subscribe, Func<TObject, TKey> keySelector)
+        where TObject : notnull
         where TKey : notnull
     {
         if (subscribe is null)
@@ -311,6 +319,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, Action> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -332,6 +341,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, IDisposable> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -372,6 +382,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, Task<IDisposable>> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -388,6 +399,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, CancellationToken, Task<IDisposable>> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -431,6 +443,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, Task<Action>> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -447,6 +460,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, CancellationToken, Task<Action>> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -489,6 +503,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, Task> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {
@@ -521,6 +536,7 @@ public static class ObservableChangeSet
     /// <param name="subscribe">  Implementation of the resulting observable list's Subscribe method. </param>
     /// <returns>The observable list with the specified implementation for the Subscribe method.</returns>
     public static IObservable<IChangeSet<T>> Create<T>(Func<ISourceList<T>, CancellationToken, Task> subscribe)
+        where T : notnull
     {
         if (subscribe is null)
         {

--- a/src/DynamicData/Platforms/net45/PFilter.cs
+++ b/src/DynamicData/Platforms/net45/PFilter.cs
@@ -15,6 +15,7 @@ using DynamicData.Kernel;
 namespace DynamicData.PLinq
 {
     internal class PFilter<TObject, TKey>
+        where TObject : notnull
         where TKey : notnull
     {
         private readonly Func<TObject, bool> _filter;

--- a/src/DynamicData/Platforms/net45/PSubscribeMany.cs
+++ b/src/DynamicData/Platforms/net45/PSubscribeMany.cs
@@ -11,6 +11,7 @@ using System.Reactive.Linq;
 namespace DynamicData.PLinq
 {
     internal class PSubscribeMany<TObject, TKey>
+        where TObject : notnull
         where TKey : notnull
     {
         private readonly ParallelisationOptions _parallelisationOptions;

--- a/src/DynamicData/Platforms/net45/PTransform.cs
+++ b/src/DynamicData/Platforms/net45/PTransform.cs
@@ -14,6 +14,8 @@ using DynamicData.Kernel;
 namespace DynamicData.PLinq
 {
     internal sealed class PTransform<TDestination, TSource, TKey>
+        where TDestination : notnull
+        where TSource : notnull
         where TKey : notnull
     {
         private readonly IObservable<IChangeSet<TSource, TKey>> _source;

--- a/src/DynamicData/Platforms/net45/ParallelEx.cs
+++ b/src/DynamicData/Platforms/net45/ParallelEx.cs
@@ -16,6 +16,7 @@ namespace DynamicData.PLinq
     internal static class ParallelEx
     {
         internal static ParallelQuery<Change<TObject, TKey>> Parallelise<TObject, TKey>(this IChangeSet<TObject, TKey> source, ParallelisationOptions option)
+            where TObject : notnull
             where TKey : notnull
         {
             switch (option.Type)
@@ -79,6 +80,7 @@ namespace DynamicData.PLinq
         }
 
         internal static bool ShouldParallelise<TObject, TKey>(this IChangeSet<TObject, TKey> source, ParallelisationOptions option)
+            where TObject : notnull
             where TKey : notnull
         {
             return (option.Type == ParallelType.Parallelise || option.Type == ParallelType.Ordered) && (option.Threshold >= 0 && source.Count >= option.Threshold);

--- a/src/DynamicData/Platforms/net45/ParallelOperators.cs
+++ b/src/DynamicData/Platforms/net45/ParallelOperators.cs
@@ -26,6 +26,7 @@ namespace DynamicData.PLinq
         /// <returns>An observable which emits a change set.</returns>
         /// <exception cref="System.ArgumentNullException">source.</exception>
         public static IObservable<IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, bool> filter, ParallelisationOptions parallelisationOptions)
+            where TObject : notnull
             where TKey : notnull
         {
             if (source is null)
@@ -52,6 +53,7 @@ namespace DynamicData.PLinq
         /// Subscribes to each item when it is added or updates and unsubscribes when it is removed.
         /// </remarks>
         public static IObservable<IChangeSet<TObject, TKey>> SubscribeMany<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IDisposable> subscriptionFactory, ParallelisationOptions parallelisationOptions)
+            where TObject : notnull
             where TKey : notnull
         {
             if (source is null)
@@ -88,6 +90,7 @@ namespace DynamicData.PLinq
         /// Subscribes to each item when it is added or updates and unsubscribes when it is removed.
         /// </remarks>
         public static IObservable<IChangeSet<TObject, TKey>> SubscribeMany<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IDisposable> subscriptionFactory, ParallelisationOptions parallelisationOptions)
+            where TObject : notnull
             where TKey : notnull
         {
             if (source is null)
@@ -124,6 +127,8 @@ namespace DynamicData.PLinq
         /// or
         /// transformFactory.</exception>
         public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, ParallelisationOptions parallelisationOptions)
+            where TDestination : notnull
+            where TSource : notnull
             where TKey : notnull
         {
             if (source is null)
@@ -160,6 +165,8 @@ namespace DynamicData.PLinq
         /// or
         /// transformFactory.</exception>
         public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, ParallelisationOptions parallelisationOptions)
+            where TDestination : notnull
+            where TSource : notnull
             where TKey : notnull
         {
             return new PTransform<TDestination, TSource, TKey>(source, (t, _, _) => transformFactory(t), parallelisationOptions).Run();
@@ -185,6 +192,8 @@ namespace DynamicData.PLinq
         /// or
         /// transformFactory.</exception>
         public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, ParallelisationOptions parallelisationOptions)
+            where TDestination : notnull
+            where TSource : notnull
             where TKey : notnull
         {
             if (source is null)
@@ -230,6 +239,8 @@ namespace DynamicData.PLinq
         /// or
         /// transformFactory.</exception>
         public static IObservable<IChangeSet<TDestination, TKey>> TransformSafe<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, TDestination> transformFactory, Action<Error<TSource, TKey>> errorHandler, ParallelisationOptions parallelisationOptions)
+            where TDestination : notnull
+            where TSource : notnull
             where TKey : notnull
         {
             return new PTransform<TDestination, TSource, TKey>(source, (t, _, k) => transformFactory(t, k), parallelisationOptions, errorHandler).Run();

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0",
+        "version": "7.0",
         "rollForward": "latestMinor",
         "allowPrerelease": true
     },


### PR DESCRIPTION
In response to #692, this PR adds a `where t : notnull` constraint to `Option<T>`.
That change proliferates out to `IChangeSet` and into a lot of extension methods.

I think this constitutes a breaking change, but code that used nullable types may not have worked correctly anyway.