### PR TITLE
Adds optional useReplaceForUpdates to SortedObservableCollectionAdaptor

### DIFF
--- a/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
@@ -18,14 +18,17 @@ public class SortedObservableCollectionAdaptor<TObject, TKey> : ISortedObservabl
     where TKey : notnull
 {
     private readonly int _refreshThreshold;
+    private readonly bool _useReplaceForUpdates;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SortedObservableCollectionAdaptor{TObject, TKey}"/> class.
     /// </summary>
     /// <param name="refreshThreshold">The number of changes before a Reset event is used.</param>
-    public SortedObservableCollectionAdaptor(int refreshThreshold = 25)
+    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates. </param>
+    public SortedObservableCollectionAdaptor(int refreshThreshold = 25, bool useReplaceForUpdates = true)
     {
         _refreshThreshold = refreshThreshold;
+        _useReplaceForUpdates = useReplaceForUpdates;
     }
 
     /// <summary>
@@ -89,7 +92,7 @@ public class SortedObservableCollectionAdaptor<TObject, TKey> : ISortedObservabl
         }
     }
 
-    private static void DoUpdate(ISortedChangeSet<TObject, TKey> updates, IObservableCollection<TObject> list)
+    private void DoUpdate(ISortedChangeSet<TObject, TKey> updates, IObservableCollection<TObject> list)
     {
         foreach (var update in updates)
         {
@@ -108,7 +111,7 @@ public class SortedObservableCollectionAdaptor<TObject, TKey> : ISortedObservabl
                     break;
 
                 case ChangeReason.Update:
-                    if (update.PreviousIndex != update.CurrentIndex)
+                    if (!_useReplaceForUpdates || update.PreviousIndex != update.CurrentIndex)
                     {
                         list.RemoveAt(update.PreviousIndex);
                         list.Insert(update.CurrentIndex, update.Current);

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -745,10 +745,11 @@ public static class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="resetThreshold">The number of changes before a reset event is called on the observable collection.</param>
+    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates.  NB: Some platforms to not support replace notifications for binding.</param>
     /// <param name="adaptor">Specify an adaptor to change the algorithm to update the target collection.</param>
     /// <returns>An observable which will emit change sets.</returns>
     /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, ISortedObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, bool useReplaceForUpdates = true, ISortedObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
         where TObject : notnull
         where TKey : notnull
     {
@@ -759,7 +760,7 @@ public static class ObservableCacheEx
 
         var target = new ObservableCollectionExtended<TObject>();
         var result = new ReadOnlyObservableCollection<TObject>(target);
-        var updater = adaptor ?? new SortedObservableCollectionAdaptor<TObject, TKey>(resetThreshold);
+        var updater = adaptor ?? new SortedObservableCollectionAdaptor<TObject, TKey>(resetThreshold, useReplaceForUpdates);
         readOnlyObservableCollection = result;
         return source.Bind(target, updater);
     }


### PR DESCRIPTION
In a similar vein to how `useReplaceForUpdates` in `ObservableCollectionAdaptor` toggles between `Replace` and `Remove/Add` update types, this pull request proposes adding the same capability to `SortedObservableCollectionAdaptor`.

Default to `true` for backward compatibility, although if a new major version is in the offing, maybe this could be `false` to match `ObservableCollectionAdaptor`.

The test has been updated to match the equivalent test in `ObservableCollectionBindCacheFixture`.