### PR TITLE
Additional Extension Methods for Optional

### DIFF
--- a/src/DynamicData.Tests/Kernal/OptionFixture.cs
+++ b/src/DynamicData.Tests/Kernal/OptionFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using DynamicData.Kernel;
 using DynamicData.Tests.Domain;
 
@@ -81,6 +82,25 @@ public class OptionFixture
     }
 
     [Fact]
+    public void OptionConvertThrowsIfConverterIsNull()
+    {
+        var caught = false;
+
+        Func<string, string>? converter = null;
+
+        try
+        {
+            Optional.None<string>().Convert(converter!);
+        }
+        catch (ArgumentNullException)
+        {
+            caught = true;
+        }
+
+        caught.Should().BeTrue();
+    }
+
+    [Fact]
     public void OptionConvertToOptionalInvokesConverterWithValue()
     {
         var option = Optional.Some(string.Empty);
@@ -137,6 +157,25 @@ public class OptionFixture
         var result = option.Convert(ParseInt);
 
         result.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionConvertToOptionalThrowsIfConverterIsNull()
+    {
+        var caught = false;
+
+        Func<string, Optional<string>>? converter = null;
+
+        try
+        {
+            Optional.None<string>().Convert(converter!);
+        }
+        catch (ArgumentNullException)
+        {
+            caught = true;
+        }
+
+        caught.Should().BeTrue();
     }
 
     [Fact]
@@ -206,6 +245,23 @@ public class OptionFixture
 
         result.HasValue.Should().BeTrue();
         result.Value.Should().Be(Expected);
+    }
+
+    [Fact]
+    public void OptionOrElseThrowsIfFallbackIsNull()
+    {
+        var caught = false;
+
+        try
+        {
+            Optional.None<string>().OrElse(null!);
+        }
+        catch(ArgumentNullException)
+        {
+            caught = true;
+        }
+
+        caught.Should().BeTrue();
     }
 
     private static Optional<int> ParseInt(string input) =>

--- a/src/DynamicData/Kernel/OptionExtensions.cs
+++ b/src/DynamicData/Kernel/OptionExtensions.cs
@@ -86,26 +86,26 @@ public static class OptionExtensions
     }
 
     /// <summary>
-    /// Returns the original optional if it has a value, otherwise returns the result of the fallback selector.
+    /// Returns the original optional if it has a value, otherwise returns the result of the fallback operation.
     /// </summary>
     /// <typeparam name="T">The type of the source.</typeparam>
     /// <param name="source">The source.</param>
-    /// <param name="fallbackSelector">The fallback converter.</param>
-    /// <returns>The destination optional value.</returns>
+    /// <param name="fallbackOperation">The fallback operation.</param>
+    /// <returns>The original value or the result of the fallback operation.</returns>
     /// <exception cref="System.ArgumentNullException">
     /// converter
     /// or
-    /// fallbackConverter.
+    /// fallbackOperation.
     /// </exception>
-    public static Optional<T> OrElse<T>(this Optional<T> source, Func<Optional<T>> fallbackSelector)
+    public static Optional<T> OrElse<T>(this Optional<T> source, Func<Optional<T>> fallbackOperation)
         where T : notnull
     {
-        if (fallbackSelector is null)
+        if (fallbackOperation is null)
         {
-            throw new ArgumentNullException(nameof(fallbackSelector));
+            throw new ArgumentNullException(nameof(fallbackOperation));
         }
 
-        return source.HasValue ? source : fallbackSelector();
+        return source.HasValue ? source : fallbackOperation();
     }
 
     /// <summary>

--- a/src/DynamicData/Kernel/OptionExtensions.cs
+++ b/src/DynamicData/Kernel/OptionExtensions.cs
@@ -35,6 +35,27 @@ public static class OptionExtensions
     }
 
     /// <summary>
+    /// Attempts to converts the specified source, but the conversion might result in a None value.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="converter">The converter that returns an optional value.</param>
+    /// <returns>The converted value.</returns>
+    /// <exception cref="System.ArgumentNullException">converter.</exception>
+    public static Optional<TDestination> Convert<TSource, TDestination>(this Optional<TSource> source, Func<TSource, Optional<TDestination>> converter)
+        where TSource : notnull
+        where TDestination : notnull
+    {
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
+        return source.HasValue ? converter(source.Value) : Optional.None<TDestination>();
+    }
+
+    /// <summary>
     /// Converts the option value if it has a value, otherwise returns the result of the fallback converter.
     /// </summary>
     /// <typeparam name="TSource">The type of the source.</typeparam>
@@ -62,6 +83,29 @@ public static class OptionExtensions
         }
 
         return source.HasValue ? converter(source.Value) : fallbackConverter();
+    }
+
+    /// <summary>
+    /// Returns the original optional if it has a value, otherwise returns the result of the fallback selector.
+    /// </summary>
+    /// <typeparam name="T">The type of the source.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="fallbackSelector">The fallback converter.</param>
+    /// <returns>The destination optional value.</returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// converter
+    /// or
+    /// fallbackConverter.
+    /// </exception>
+    public static Optional<T> OrElse<T>(this Optional<T> source, Func<Optional<T>> fallbackSelector)
+        where T : notnull
+    {
+        if (fallbackSelector is null)
+        {
+            throw new ArgumentNullException(nameof(fallbackSelector));
+        }
+
+        return source.HasValue ? source : fallbackSelector();
     }
 
     /// <summary>


### PR DESCRIPTION
I'd like to contribute a couple of extension methods that I have found to be very useful.

1) An overload for `Convert` that takes a `Func<TSource, Optional<TDestination>>` instead of a `Func<TSource, TDestination>` so that the conversion operation can fail without ending up with an `Optional<Optional<T>>`.

1) `OrElse`, which is similar in that it takes a function that returns an `Optional<T>`, except it only is invoked if the source Optional doesn't have a value.

### Examples

The `Convert` overload can be used to chain operations together when any of the operations could fail:

```C#
private static Optional<string> GetPathFromUser();
private static Optional<FileInfo> FindFile(string path);
private static Optional<Image> LoadImage(FileInfo fileInfo);

public static Optional<Image> LoadImageFromUser() =>
    GetPathFromUser().Convert(FindFile).Convert(LoadImage);
```

`OrElse` allows alternative ways of obtaining a value to be tried until one is successful.  It works nicely with `Convert`.

```C#
private static Optional<int> ParseDecimal(string input);
private static Optional<int> ParseHex(string input);

public static Optional<int> ParseInt(Optional<string> input) =>
    input.Convert(s => ParseDecimal(s).OrElse(() => ParseHex(s)));
```

I've included a bunch of unit tests, but if there's anything else you'd like me to do, please let me know.  I have several other contributions to make, but I thought it made sense to start with an easy one.