### PR TITLE
Feature:  EditDiff extension method for IObservable<Optional<T>>

### DIFF
--- a/src/DynamicData.Tests/Cache/EditDiffChangeSetOptionalFixture.cs
+++ b/src/DynamicData.Tests/Cache/EditDiffChangeSetOptionalFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Linq;
@@ -18,10 +19,14 @@ public class EditDiffChangeSetOptionalFixture
     private const int MaxItems = 1097;
 
     [Fact]
+    [Description("Required to maintain test coverage percentage")]
     public void NullChecksArePerformed()
     {
-        Assert.Throws<ArgumentNullException>(() => Observable.Empty<Optional<Person>>().EditDiff<Person, int>(null!));
-        Assert.Throws<ArgumentNullException>(() => default(IObservable<Optional<Person>>)!.EditDiff<Person, int>(null!));
+        Action actionNullKeySelector = () => Observable.Empty<Optional<Person>>().EditDiff<Person, int>(null!);
+        Action actionNullObservable = () => default(IObservable<Optional<Person>>)!.EditDiff<Person, int>(null!);
+
+        actionNullKeySelector.Should().Throw<ArgumentNullException>().WithParameterName("keySelector");
+        actionNullObservable.Should().Throw<ArgumentNullException>().WithParameterName("source");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/EditDiffChangeSetOptionalFixture.cs
+++ b/src/DynamicData.Tests/Cache/EditDiffChangeSetOptionalFixture.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reactive.Linq;
+using FluentAssertions;
+
+using Xunit;
+
+namespace DynamicData.Tests.Cache;
+
+public class EditDiffChangeSetOptionalFixture
+{
+    private const int MaxItems = 1097;
+
+    [Fact]
+    public void NullChecksArePerformed()
+    {
+        Assert.Throws<ArgumentNullException>(() => Observable.Empty<IEnumerable<Person>>().EditDiff<Person, int>(null!));
+        Assert.Throws<ArgumentNullException>(() => default(IObservable<IEnumerable<Person>>)!.EditDiff<Person, int>(null!));
+    }
+
+    [Fact]
+    public void ItemsFromEnumerableAreAddedToChangeSet()
+    {
+        // having
+        var enumerable = CreatePeople(0, MaxItems, "Name");
+        var enumObservable = Observable.Return(enumerable);
+
+        // when
+        var observableChangeSet = enumObservable.EditDiff(p => p.Id);
+        using var results = observableChangeSet.AsAggregator();
+
+        // then
+        results.Data.Count.Should().Be(MaxItems);
+        results.Messages.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void ItemsRemovedFromEnumerableAreRemovedFromChangeSet()
+    {
+        // having
+        var enumerable = CreatePeople(0, MaxItems, "Name");
+        var enumObservable = new[] {enumerable, Enumerable.Empty<Person>()}.ToObservable();
+
+        // when
+        var observableChangeSet = enumObservable.EditDiff(p => p.Id);
+        using var results = observableChangeSet.AsAggregator();
+
+        // then
+        results.Data.Count.Should().Be(0);
+        results.Messages.Count.Should().Be(2);
+        results.Messages[0].Adds.Should().Be(MaxItems);
+        results.Messages[1].Removes.Should().Be(MaxItems);
+        results.Messages[1].Updates.Should().Be(0);
+    }
+
+    [Fact]
+    public void ItemsUpdatedAreUpdatedInChangeSet()
+    {
+        // having
+        var enumerable1 = CreatePeople(0, MaxItems * 2, "Name");
+        var enumerable2 = CreatePeople(MaxItems, MaxItems, "Update");
+        var enumObservable = new[] { enumerable1, enumerable2 }.ToObservable();
+
+        // when
+        var observableChangeSet = enumObservable.EditDiff(p => p.Id);
+        using var results = observableChangeSet.AsAggregator();
+
+        // then
+        results.Data.Count.Should().Be(MaxItems);
+        results.Messages.Count.Should().Be(2);
+        results.Messages[0].Adds.Should().Be(MaxItems * 2);
+        results.Messages[1].Updates.Should().Be(MaxItems);
+        results.Messages[1].Removes.Should().Be(MaxItems);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ResultCompletesIfAndOnlyIfSourceCompletes(bool completeSource)
+    {
+        // having
+        var enumerable = CreatePeople(0, MaxItems, "Name");
+        var enumObservable = Observable.Return(enumerable);
+        if (!completeSource)
+        {
+            enumObservable = enumObservable.Concat(Observable.Never<IEnumerable<Person>>());
+        }
+        bool completed = false;
+
+        // when
+        using var results = enumObservable.Subscribe(_ => { }, () => completed = true);
+
+        // then
+        completed.Should().Be(completeSource);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ResultFailsIfAndOnlyIfSourceFails (bool failSource)
+    {
+        // having
+        var enumerable = CreatePeople(0, MaxItems, "Name");
+        var enumObservable = Observable.Return(enumerable);
+        var testException = new Exception("Test");
+        if (failSource)
+        {
+            enumObservable = enumObservable.Concat(Observable.Throw<IEnumerable<Person>>(testException));
+        }
+        var receivedError = default(Exception);
+
+        // when
+        using var results = enumObservable.Subscribe(_ => { }, err => receivedError = err);
+
+        // then
+        receivedError.Should().Be(failSource ? testException : default);
+    }
+
+    [Trait("Performance", "Manual run only")]
+    [Theory]
+    [InlineData(7, 3, 5)]
+    [InlineData(233, 113, MaxItems)]
+    [InlineData(233, 0, MaxItems)]
+    [InlineData(233, 233, MaxItems)]
+    [InlineData(2521, 1187, MaxItems)]
+    [InlineData(2521, 0, MaxItems)]
+    [InlineData(2521, 2521, MaxItems)]
+    [InlineData(5081, 2683, MaxItems)]
+    [InlineData(5081, 0, MaxItems)]
+    [InlineData(5081, 5081, MaxItems)]
+    public void Perf(int collectionSize, int updateSize, int maxItems)
+    {
+        Debug.Assert(updateSize <= collectionSize);
+
+        // having
+        var enumerables = Enumerable.Range(1, maxItems - 1)
+            .Select(n => n * (collectionSize - updateSize))
+            .Select(index => CreatePeople(index, updateSize, "Overlap")
+                                                            .Concat(CreatePeople(index + updateSize, collectionSize - updateSize, "Name")))
+            .Prepend(CreatePeople(0, collectionSize, "Name"));
+        var enumObservable = enumerables.ToObservable();
+
+        // when
+        var observableChangeSet = enumObservable.EditDiff(p => p.Id);
+        using var results = observableChangeSet.AsAggregator();
+
+        // then
+        results.Data.Count.Should().Be(collectionSize);
+        results.Messages.Count.Should().Be(maxItems);
+        results.Summary.Overall.Adds.Should().Be((collectionSize * maxItems) - (updateSize * (maxItems - 1)));
+        results.Summary.Overall.Removes.Should().Be((collectionSize - updateSize) * (maxItems - 1));
+        results.Summary.Overall.Updates.Should().Be(updateSize * (maxItems - 1));
+    }
+
+    private static Person CreatePerson(int id, string name) => new(id, name);
+
+    private static IEnumerable<Person> CreatePeople(int baseId, int count, string baseName) =>
+        Enumerable.Range(baseId, count).Select(i => CreatePerson(i, baseName + i));
+
+    private class Person
+    {
+        public Person(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+    }
+}

--- a/src/DynamicData/Cache/Internal/EditDiffChangeSetOptional.cs
+++ b/src/DynamicData/Cache/Internal/EditDiffChangeSetOptional.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using DynamicData.Kernel;
+
+namespace DynamicData.Cache.Internal;
+
+internal sealed class EditDiffChangeSetOptional<TObject, TKey>
+    where TObject : notnull
+    where TKey : notnull
+{
+    private static readonly IEqualityComparer<TKey> KeyComparer = EqualityComparer<TKey>.Default;
+
+    private readonly IObservable<Optional<TObject>> _source;
+
+    private readonly IEqualityComparer<TObject> _equalityComparer;
+
+    private readonly Func<TObject, TKey> _keySelector;
+
+    public EditDiffChangeSetOptional(IObservable<Optional<TObject>> source, Func<TObject, TKey> keySelector, IEqualityComparer<TObject>? equalityComparer)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _keySelector = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
+        _equalityComparer = equalityComparer ?? EqualityComparer<TObject>.Default;
+    }
+
+    public IObservable<IChangeSet<TObject, TKey>> Run()
+    {
+        return Observable.Create<IChangeSet<TObject, TKey>>(observer =>
+        {
+            var shared = _source.StartWith(Optional.None<TObject>()).Synchronize().Publish();
+
+            var cleanup = shared.Zip(shared.Skip(1)).Select(
+                tuple =>
+                {
+                    var previous = tuple.First;
+                    var current = tuple.Second;
+
+                    if (previous.HasValue && current.HasValue)
+                    {
+                        var previousKey = _keySelector(previous.Value);
+                        var currentKey = _keySelector(current.Value);
+
+                        if (KeyComparer.Equals(previousKey, currentKey))
+                        {
+                            if (!_equalityComparer.Equals(previous.Value, current.Value))
+                            {
+                                return new[] { new Change<TObject, TKey>(ChangeReason.Update, currentKey, current.Value, previous.Value) };
+                            }
+                        }
+                        else
+                        {
+                            return new[] { new Change<TObject, TKey>(ChangeReason.Remove, previousKey, previous.Value), new Change<TObject, TKey>(ChangeReason.Add, currentKey, current.Value) };
+                        }
+                    }
+                    else if (previous.HasValue)
+                    {
+                        var previousKey = _keySelector(previous.Value);
+                        return new[] { new Change<TObject, TKey>(ChangeReason.Remove, previousKey, previous.Value) };
+                    }
+                    else if (current.HasValue)
+                    {
+                        var currentKey = _keySelector(current.Value);
+                        return new[] { new Change<TObject, TKey>(ChangeReason.Add, currentKey, current.Value) };
+                    }
+
+                    return Array.Empty<Change<TObject, TKey>>();
+                })
+                .Where(changes => changes.Length > 0)
+                .Select(changes => new ChangeSet<TObject, TKey>(changes))
+                .SubscribeSafe(observer);
+
+            return new CompositeDisposable(cleanup, shared.Connect());
+        });
+    }
+}

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -1280,6 +1280,33 @@ public static class ObservableCacheEx
     }
 
     /// <summary>
+    /// Converts an Observable Optional to an Observable ChangeSet that adds/removes/updates as the optional changes.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="keySelector">Key Selection Function for the ChangeSet.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to use for comparing values.</param>
+    /// <returns>An observable changeset.</returns>
+    /// <exception cref="System.ArgumentNullException">source.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> EditDiff<TObject, TKey>(this IObservable<Optional<TObject>> source, Func<TObject, TKey> keySelector, IEqualityComparer<TObject>? equalityComparer = null)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (keySelector is null)
+        {
+            throw new ArgumentNullException(nameof(keySelector));
+        }
+
+        return new EditDiffChangeSetOptional<TObject, TKey>(source, keySelector, equalityComparer).Run();
+    }
+
+    /// <summary>
     /// Signal observers to re-evaluate the specified item.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -1298,6 +1298,7 @@ public static class ObservableCacheEx
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
+        }
 
         if (keySelector is null)
         {


### PR DESCRIPTION
### Description
Similar to #738, this is an overload that operates on `IObservable<Optional<T>>` instead of `IObeservable<IEnumerable<T>>`.  It is useful because it provides yet another way to have child-change sets (and also works nicely with `MergeManyChangeSets` as seen below).

When the first Optional with a value is observed, an Add change is emitted.  When an empty Optional is observed, a Remove change is emitted for the previously Added value.  If a non-empty Optional is observed, the Keys are computed and compared to determine if either a single Update (keys are the same) or a Remove/Add pair of Updates (keys are different) should be emitted.

### Rationale
Since `Optional` is essentially a container with at most one value, the same behavior could be easily done with #738 and a helper function such as:

```C#
public static IEnumerable<T> AsEnumerable(this Optional<T> optional)
{
    if (optional.HasValue) yield return optional.Value;
}

public static IObservable<IChangeSet<TObject, TKey>> EditDiff<TObject, TKey>(this IObservable<Optional<TObject>> source, Func<TObject, TKey> keySelector, IEqualityComparer<TObject>? equalityComparer = null)
        where TObject : notnull
        where TKey : notnull =>
    source.Select(opt => opt.AsEnumerable()).EditDiff(keySelector, equalityComparer);
```

However, using such an approach will result in using an entire SourceCache that is essentially empty.  This specialized version is optimized around only having to deal with a single value at a time and is extremely light weight.

### Example
```C#
interface IPerson : INotifyPropertyChange
{
  int Id { get; }
  string Name { get; }
  Optional<IPerson> Spouse { get; }
  IReadOnlyList<IPerson> Children { get; }
}

IObservableCache<IPerson, int> peopleCache = GetPeopleCache();

// Treat all changes to all spouse properties as one observable changeset
// Creates "Add" events when a Spouse property is set with a value
// Creates "Remove" events when it is set without a value
IObservable<IChangeSet<IPerson, int>> spouseChangeSet = 
    peopleCache.Connect()
               .MergeManyChangeSets(person => person.WhenAnyValue(p => p.Spouse).EditDiff(p => p.Id));
```
