### PR TITLE
Feature:  Operators for IObservable<Optional<T>>

### DIFF
--- a/src/DynamicData.Tests/Kernal/OptionObservableFixture.cs
+++ b/src/DynamicData.Tests/Kernal/OptionObservableFixture.cs
@@ -35,6 +35,7 @@ public class OptionObservableFixture
         var nullConverter = (Func<int, double>)null!;
         var nullOptionalConverter = (Func<int, Optional<double>>)null!;
         var converter = (Func<int, double>)(i => i);
+        var nullFallback = (Func<int>)null!;
         var nullConvertFallback = (Func<double>)null!;
         var nullOptionalFallback = (Func<Optional<int>>)null!;
         var action = (Action)null!;
@@ -56,6 +57,7 @@ public class OptionObservableFixture
         var onHasNoValue = () => nullObservable.OnHasNoValue(action);
         var onHasNoValue2 = () => neverObservable.OnHasNoValue(action);
         var selectValues = () => nullObservable.SelectValues();
+        var valueOr = () => nullObservable.ValueOr(nullFallback);
         var valueOrDefault = () => nullObservable.ValueOrDefault();
         var valueOrThrow1 = () => nullObservable.ValueOrThrow(nullExceptionGenerator);
         var valueOrThrow2 = () => neverObservable.ValueOrThrow(nullExceptionGenerator);
@@ -75,6 +77,7 @@ public class OptionObservableFixture
         onHasNoValue.Should().Throw<ArgumentNullException>();
         onHasNoValue2.Should().Throw<ArgumentNullException>();
         selectValues.Should().Throw<ArgumentNullException>();
+        valueOr.Should().Throw<ArgumentNullException>();
         valueOrDefault.Should().Throw<ArgumentNullException>();
         valueOrThrow1.Should().Throw<ArgumentNullException>();
         valueOrThrow2.Should().Throw<ArgumentNullException>();

--- a/src/DynamicData.Tests/Kernal/OptionObservableFixture.cs
+++ b/src/DynamicData.Tests/Kernal/OptionObservableFixture.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Globalization;
+using DynamicData.Kernel;
+using DynamicData.Tests.Domain;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace DynamicData.Tests.Kernal;
+
+public class OptionObservableFixture
+{
+    [Fact]
+    public void ImplictCastHasValue()
+    {
+        var person = new Person("Name", 20);
+        Optional<Person> option = person;
+
+        option.HasValue.Should().BeTrue();
+        ReferenceEquals(person, option.Value).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionElseInvokedIfOptionHasNoValue()
+    {
+        Optional<Person>? source = null;
+
+        var ifactioninvoked = false;
+        var elseactioninvoked = false;
+
+        source.IfHasValue(p => ifactioninvoked = true).Else(() => elseactioninvoked = true);
+
+        ifactioninvoked.Should().BeFalse();
+        elseactioninvoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionIfHasValueInvokedIfOptionHasValue()
+    {
+        Optional<Person> source = new Person("A", 1);
+
+        var ifactioninvoked = false;
+        var elseactioninvoked = false;
+
+        source.IfHasValue(p => ifactioninvoked = true).Else(() => elseactioninvoked = true);
+
+        ifactioninvoked.Should().BeTrue();
+        elseactioninvoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionNoneHasNoValue()
+    {
+        var option = Optional.None<IChangeSet<Person, string>>();
+        option.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionSetToNullHasNoValue1()
+    {
+        Person? person = null;
+        var option = Optional.Some(person);
+        option.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionSetToNullHasNoValue2()
+    {
+        Person? person = null;
+        Optional<Person> option = person;
+        option.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionSomeHasValue()
+    {
+        var person = new Person("Name", 20);
+        var option = Optional.Some(person);
+        option.HasValue.Should().BeTrue();
+        ReferenceEquals(person, option.Value).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionConvertThrowsIfConverterIsNull()
+    {
+        var caught = false;
+
+        Func<string, string>? converter = null;
+
+        try
+        {
+            Optional.None<string>().Convert(converter!);
+        }
+        catch (ArgumentNullException)
+        {
+            caught = true;
+        }
+
+        caught.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionConvertToOptionalInvokesConverterWithValue()
+    {
+        var option = Optional.Some(string.Empty);
+        var invoked = false;
+
+        Optional<string> Converter(string input)
+        {
+            invoked = true;
+            return Optional.Some(input);
+        }
+
+        var result = option.Convert(Converter);
+
+        invoked.Should().BeTrue();
+        result.HasValue.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionConvertToOptionalInvokesConverterOnlyWithValue()
+    {
+        var option = Optional.None<string>();
+        var invoked = false;
+
+        Optional<string> Converter(string input)
+        {
+            invoked = true;
+            return Optional.Some(input);
+        }
+
+        var result = option.Convert(Converter);
+
+        invoked.Should().BeFalse();
+        result.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionConvertToOptionalCanReturnValue()
+    {
+        const int TestData = 37;
+
+        var option = Optional.Some(TestData.ToString());
+
+        var result = option.Convert(ParseInt);
+
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().Be(TestData);
+    }
+
+    [Fact]
+    public void OptionConvertToOptionalCanReturnNone()
+    {
+        var option = Optional.Some("Not An Int");
+
+        var result = option.Convert(ParseInt);
+
+        result.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionConvertToOptionalThrowsIfConverterIsNull()
+    {
+        var caught = false;
+
+        Func<string, Optional<string>>? converter = null;
+
+        try
+        {
+            Optional.None<string>().Convert(converter!);
+        }
+        catch (ArgumentNullException)
+        {
+            caught = true;
+        }
+
+        caught.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionOrElseInvokesWithoutValue()
+    {
+        var option = Optional.None<string>();
+        var invoked = false;
+
+        Optional<string> Fallback()
+        {
+            invoked = true;
+            return Optional.None<string>();
+        }
+
+        var result = option.OrElse(Fallback);
+
+        invoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OptionOrElseInvokesOnlyWithoutValue()
+    {
+        var option = Optional.Some(string.Empty);
+        var invoked = false;
+
+        Optional<string> Fallback()
+        {
+            invoked = true;
+            return Optional.None<string>();
+        }
+
+        var result = option.OrElse(Fallback);
+
+        invoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionOrElseCanReturnValue()
+    {
+        const string TestString = nameof(TestString);
+
+        var option = Optional.None<string>();
+        var result = option.OrElse(() => TestString);
+
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().Be(TestString);
+    }
+
+    [Fact]
+    public void OptionOrElseCanReturnNone()
+    {
+        var option = Optional.None<string>();
+        var result = option.OrElse(Optional.None<string>);
+
+        result.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OptionOrElseCanBeChained()
+    {
+        const int Expected = unchecked((int)0xc001d00d);
+
+        var option = Optional.None<string>();
+        var result = option.OrElse(Optional.None<string>)
+                                      .OrElse(() => Optional.Some(Expected.ToString("x")))
+                                      .Convert(s => ParseInt(s).OrElse(() => ParseHex(s)));
+
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().Be(Expected);
+    }
+
+    [Fact]
+    public void OptionOrElseThrowsIfFallbackIsNull()
+    {
+        var caught = false;
+
+        try
+        {
+            Optional.None<string>().OrElse(null!);
+        }
+        catch(ArgumentNullException)
+        {
+            caught = true;
+        }
+
+        caught.Should().BeTrue();
+    }
+
+    private static Optional<int> ParseInt(string input) =>
+        int.TryParse(input, out var result) ? Optional.Some(result) : Optional.None<int>();
+
+    private static Optional<int> ParseHex(string input) =>
+        int.TryParse(input, NumberStyles.HexNumber, null, out var result) ? Optional.Some(result) : Optional.None<int>();
+}

--- a/src/DynamicData/Kernel/OptionObservableExtensions.cs
+++ b/src/DynamicData/Kernel/OptionObservableExtensions.cs
@@ -1,0 +1,301 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace DynamicData.Kernel;
+
+/// <summary>
+/// Extensions for optional.
+/// </summary>
+public static class OptionObservableExtensions
+{
+    /// <summary>
+    /// Converts an Observable Optional of <typeparamref name="TSource"/> into an Observable Optional of <typeparamref name="TDestination"/> by applying
+    /// the conversion function to those Optionals that have a value.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="converter">The converter.</param>
+    /// <returns>Observable Optional of <typeparamref name="TDestination"/>.</returns>
+    /// <exception cref="System.ArgumentNullException">Source or Converter was null.</exception>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.Convert{TSource, TDestination}(Optional{TSource}, Func{TSource, TDestination})"/>.</remarks>
+    public static IObservable<Optional<TDestination>> Convert<TSource, TDestination>(this IObservable<Optional<TSource>> source, Func<TSource, TDestination> converter)
+        where TSource : notnull
+        where TDestination : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
+        return source.Select(optional => optional.HasValue ? converter(optional.Value) : Optional.None<TDestination>());
+    }
+
+    /// <summary>
+    /// Overload of <see cref="Convert{TSource, TDestination}(IObservable{Optional{TSource}}, Func{TSource, TDestination})"/> that allows the conversion
+    /// operation to also return an Optional.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="converter">The converter that returns an optional value.</param>
+    /// <returns>Observable Optional of <typeparamref name="TDestination"/>.</returns>
+    /// <exception cref="System.ArgumentNullException">Source or Converter was null.</exception>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.Convert{TSource, TDestination}(Optional{TSource}, Func{TSource, Optional{TDestination}})"/>.</remarks>
+    public static IObservable<Optional<TDestination>> Convert<TSource, TDestination>(this IObservable<Optional<TSource>> source, Func<TSource, Optional<TDestination>> converter)
+        where TSource : notnull
+        where TDestination : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
+        return source.Select(optional => optional.HasValue ? converter(optional.Value) : Optional.None<TDestination>());
+    }
+
+    /// <summary>
+    /// Converts an observable of optional into an observable of <typeparamref name="TDestination"/> by applying <paramref name="converter"/> to convert Optionals with a value
+    /// and using <paramref name="fallbackConverter"/> to generate a value for those that don't have a value.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="converter">The converter.</param>
+    /// <param name="fallbackConverter">The fallback converter.</param>
+    /// <returns>Observable of <typeparamref name="TDestination"/>.</returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// source
+    /// or
+    /// converter
+    /// or
+    /// fallbackConverter.
+    /// </exception>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.ConvertOr{TSource, TDestination}(Optional{TSource}, Func{TSource?, TDestination?}, Func{TDestination?})"/>.</remarks>
+    public static IObservable<TDestination?> ConvertOr<TSource, TDestination>(this IObservable<Optional<TSource>> source, Func<TSource, TDestination?> converter, Func<TDestination?> fallbackConverter)
+        where TSource : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
+        if (fallbackConverter is null)
+        {
+            throw new ArgumentNullException(nameof(fallbackConverter));
+        }
+
+        return source.Select(optional => optional.HasValue ? converter(optional.Value) : fallbackConverter());
+    }
+
+    /// <summary>
+    /// Observable Optional operator that provides a way to (possibly) create a value for those Optionals that don't already have one.
+    /// </summary>
+    /// <typeparam name="T">The type of the source.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="fallbackOperation">The fallback operation.</param>
+    /// <returns>An Observable Optional that contains the Optionals with Values or the results of the fallback operation.</returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// source
+    /// or
+    /// fallbackOperation.
+    /// </exception>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.OrElse{T}(Optional{T}, Func{Optional{T}})"/>.</remarks>
+    public static IObservable<Optional<T>> OrElse<T>(this IObservable<Optional<T>> source, Func<Optional<T>> fallbackOperation)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (fallbackOperation is null)
+        {
+            throw new ArgumentNullException(nameof(fallbackOperation));
+        }
+
+        return source.Select(optional => optional.HasValue ? optional : fallbackOperation());
+    }
+
+    /// <summary>
+    /// Pass-Thru operator that invokes the specified action for Optionals with a value (or, if provided, the else Action for those without a value).
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="action">The action.</param>
+    /// <param name="elseAction">Optional alternative action for the Else case.</param>
+    /// <returns>The same Observable Optional.</returns>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.IfHasValue{T}(Optional{T}, Action{T})"/>.</remarks>
+    public static IObservable<Optional<T>> OnHasValue<T>(this IObservable<Optional<T>> source, Action<T> action, Action? elseAction = null)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return source.Do(optional =>
+        {
+            if (optional.HasValue)
+            {
+                action(optional.Value);
+            }
+            else
+            {
+                elseAction?.Invoke();
+            }
+        });
+    }
+
+    /// <summary>
+    /// Pass-Thru operator that invokes the specified action for Optionals without a value (or, if provided, the else Action for those with a value).
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="action">The action.</param>
+    /// <param name="elseAction">Optional alternative action for the Else case.</param>
+    /// <returns>The same Observable Optional.</returns>
+    public static IObservable<Optional<T>> OnHasNoValue<T>(this IObservable<Optional<T>> source, Action action, Action<T>? elseAction = null)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return source.Do(optional =>
+        {
+            if (!optional.HasValue)
+            {
+                action();
+            }
+            else
+            {
+                elseAction?.Invoke(optional.Value);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Converts an Observable of <see cref="Optional{T}"/> into an IObservable of <typeparamref name="T"/> by extracting
+    /// the values from Optionals that have one.
+    /// </summary>
+    /// <typeparam name="T">The type of item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <returns>An Observable with the Values.</returns>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.SelectValues{T}(IEnumerable{Optional{T}})"/>.</remarks>
+    public static IObservable<T> SelectValues<T>(this IObservable<Optional<T>> source)
+        where T : notnull
+    {
+        return source.Where(t => t.HasValue && t.Value is not null).Select(t => t.Value!);
+    }
+
+    /// <summary>
+    /// Converts an Observable of <see cref="Optional{T}"/> into an IObservable of <typeparamref name="T"/> by extracting the
+    /// values from the ones that contain a value and then using <paramref name="valueSelector"/> to generate a value for the others.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>If the value or a provided default.</returns>
+    /// <exception cref="System.ArgumentNullException">valueSelector.</exception>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.ValueOr{T}(Optional{T}, Func{T})"/>.</remarks>
+    public static IObservable<T> ValueOr<T>(this IObservable<Optional<T>> source, Func<T> valueSelector)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return source.Select(optional => optional.HasValue ? optional.Value : valueSelector());
+    }
+
+    /// <summary>
+    /// Returns the value if the optional has a value, otherwise returns the default value of T.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <returns>The value or default.</returns>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.ValueOrDefault{T}(Optional{T})"/>.</remarks>
+    public static IObservable<T?> ValueOrDefault<T>(this IObservable<Optional<T>> source)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return source.Select(optional => optional.ValueOrDefault());
+    }
+
+    /// <summary>
+    /// Converts an Observable of <see cref="Optional{T}"/> into an IObservable of <typeparamref name="T"/> by extracting the values.
+    /// If it has no value, <paramref name="exceptionGenerator"/> is used to generate an exception that is injected into the stream as error.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="exceptionGenerator">The exception generator.</param>
+    /// <returns>The value.</returns>
+    /// <exception cref="System.ArgumentNullException">exceptionGenerator.</exception>
+    /// <remarks>Observable version of <seealso cref="OptionExtensions.ValueOrThrow{T}(Optional{T}, Func{Exception})"/>.</remarks>
+    public static IObservable<T> ValueOrThrow<T>(this IObservable<Optional<T>> source, Func<Exception> exceptionGenerator)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (exceptionGenerator is null)
+        {
+            throw new ArgumentNullException(nameof(exceptionGenerator));
+        }
+
+        return Observable.Create<T>(observer =>
+        {
+            return source.Subscribe(optional =>
+            {
+                if (optional.HasValue && optional.Value is not null)
+                {
+                    observer.OnNext(optional.Value);
+                }
+                else
+                {
+                    observer.OnError(exceptionGenerator());
+                }
+            }, observer.OnError, observer.OnCompleted);
+        });
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.0",
+    "version": "8.1",
     "publicReleaseRefSpec": [
         "^refs/heads/main$", // we release out of master
         "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
## Description

This PR adds some extension methods to `IObservable<Optional<T>>` to enable the same fluent syntax for `IObservable<Optional<T>>` that exists for `Optional<T>`.  The operations are the identical to the single `Optional` versions except they apply to every value that comes through the observable event stream.

## Examples Usage

Some basic usage shown below:

```csharp
// Assume These
IObservable<Optional<string>> GetOptionalStringObservable();
Optional<int> ParseInt(string input) =>
    int.TryParse(input, out var result) ? Optional.Some(result) : Optional.None<int>();
Optional<int> GetFallbackValue();

IObservable<int> intObservable = GetOptionalStringObservable()
                                       .Convert(ParseInt)
                                       .OnHasValue(i => Console.WriteLine("Parsed: " + i.ToString()))
                                       .OrElse(GetFallbackValue);
```

Combine them with other Observable Optional functionality, such as that from #740.

```csharp
const int MagicId = 37;
var sourceCache = new SourceCache<Person, int>(p => p.Id);

using var cleanup1 = sourceCache.ToOptionalObservable(MagicId , initialOptionalWhenMissing: true)
                        .OnHasNoValue(() => Console.WriteLine("Person is not present"))
                        .Convert(p => p.FullName)
                        .SelectValues()
                        .Subscribe(name => Console.WriteLine("Person's Full Name: " + name));

using var cleanup2 = sourceCache.ToOptionalObservable(MagicId , initialOptionalWhenMissing: false)
                        .OnHasValue(p => Console.WriteLine("Person Added: " + p.FullName))
                        .ValueOrThrow(() => new Exception("Person was removed!"))
                        .Subscribe();
```

It can also be used with the extension methods added in #739 to create this advanced helper functions that syncs a value between an observable cache and a source cache:

(There are better ways to implement such a thing, this is just an example.)

```csharp
IDisposable SyncValue<TSource, TKey, TDest, TDestKey>(IObservableCache<TSource, TKey> source, ISourceCache<TDest, TDestKey> destination, TKey syncValueKey, Func<TSource, TDest> converter) =>
    source.Connect()
        .ToOptionalObservable(syncValueKey)  // Create Observable Optional
        .Convert(converter)                  // Convert to Destination Type
        .EditDiff(destination.KeySelector)   // Convert to Change Set
        .PopulateInto(destination);          // Merge into Destination
```