### PR TITLE
Feature:  MergeMany Support for OnComplete (List Version)

### DIFF
--- a/src/DynamicData.Tests/List/MergeManyFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
 using FluentAssertions;
@@ -72,6 +73,93 @@ public class MergeManyFixture : IDisposable
         stream.Dispose();
     }
 
+    /// <summary>
+    /// Merged stream does not complete if a child stream is still active.
+    /// </summary>
+    [Fact]
+    public void MergedStreamDoesNotCompleteWhileItemStreamActive()
+    {
+        var streamCompleted = false;
+        var sourceCompleted = false;
+
+        var item = new ObjectWithObservable(1);
+        _source.Add(item);
+
+        using var stream = _source.Connect().Do(_ => { }, () => sourceCompleted = true)
+                .MergeMany(o => o.Observable).Subscribe(_ => { }, () => streamCompleted = true);
+
+        _source.Dispose();
+
+        sourceCompleted.Should().BeTrue();
+        streamCompleted.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Stream completes only when source and all child are complete.
+    /// </summary>
+    [Fact]
+    public void MergedStreamCompletesWhenSourceAndItemsComplete()
+    {
+        var streamCompleted = false;
+        var sourceCompleted = false;
+
+        var item = new ObjectWithObservable(1);
+        _source.Add(item);
+
+        using var stream = _source.Connect().Do(_ => { }, () => sourceCompleted = true)
+                .MergeMany(o => o.Observable).Subscribe(_ => { }, () => streamCompleted = true);
+
+        _source.Dispose();
+        item.CompleteObservable();
+
+        sourceCompleted.Should().BeTrue();
+        streamCompleted.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Stream completes even if one of the children fails.
+    /// </summary>
+    [Fact]
+    public void MergedStreamCompletesIfLastItemFails()
+    {
+        var receivedError = default(Exception);
+        var streamCompleted = false;
+        var sourceCompleted = false;
+
+        var item = new ObjectWithObservable(1);
+        _source.Add(item);
+
+        using var stream = _source.Connect().Do(_ => { }, () => sourceCompleted = true)
+                .MergeMany(o => o.Observable).Subscribe(_ => { }, err => receivedError = err, () => streamCompleted = true);
+
+        _source.Dispose();
+        item.FailObservable(new Exception("Test exception"));
+
+        receivedError.Should().Be(default);
+        sourceCompleted.Should().BeTrue();
+        streamCompleted.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// If the source stream has an error, the merged steam should also.
+    /// </summary>
+    [Fact]
+    public void MergedStreamFailsWhenSourceFails()
+    {
+        var receivedError = default(Exception);
+        var expectedError = new Exception("Test exception");
+        var throwObservable = Observable.Throw<IChangeSet<ObjectWithObservable>>(expectedError);
+        var stream = _source.Connect().Concat(throwObservable)
+                .MergeMany(o => o.Observable).Subscribe(_ => { }, err => receivedError = err);
+
+        var item = new ObjectWithObservable(1);
+        _source.Add(item);
+
+        _source.Dispose();
+
+        receivedError.Should().Be(expectedError);
+    }
+
     private class ObjectWithObservable
     {
         private readonly ISubject<bool> _changed = new Subject<bool>();
@@ -86,6 +174,16 @@ public class MergeManyFixture : IDisposable
         public int Id { get; }
 
         public IObservable<bool> Observable => _changed;
+
+        public void CompleteObservable()
+        {
+            _changed.OnCompleted();
+        }
+
+        public void FailObservable(Exception ex)
+        {
+            _changed.OnError(ex);
+        }
 
         public void InvokeObservable(bool value)
         {


### PR DESCRIPTION
## Description

Updates the List version of `MergeMany` to have the same behavior added to the cache version (#736):  The [resulting sequence will fire `OnComplete`](https://github.com/reactivemarbles/DynamicData/pull/736#issuecomment-1760561143) when the source sequence and all child sequences complete.  It is the same behavior as `Observable.SelectMany`.

All of the changes are identical to the changes made to the cache version.  The `SubscriptionCounter` class could be abstracted out and shared between them, but that doesn't seem to be consistent with how things work in this repo, so I didn't do it that way.

This change is needed for the upcoming List version of `MergeManyChangeSets` (still in progress) but this part is done, with unit tests, and it makes sense to have it as a separate PR.