### PR TITLE
Feature:  MergeManyChangeSets with Parent Item Comparison

### DIFF
--- a/src/DynamicData.Tests/Cache/MergeChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeChangeSetsFixture.cs
@@ -7,15 +7,23 @@ using DynamicData.Tests.Domain;
 using DynamicData.Tests.Utilities;
 using FluentAssertions;
 using Microsoft.Reactive.Testing;
+
 using Xunit;
 
 namespace DynamicData.Tests.Cache;
 
 public sealed partial class MergeChangeSetsFixture : IDisposable
 {
+#if DEBUG
+    const int MarketCount = 5;
+    const int PricesPerMarket = 7;
+    const int RemoveCount = 3;
+#else
     const int MarketCount = 101;
     const int PricesPerMarket = 103;
     const int RemoveCount = 53;
+#endif
+
     const int ItemIdStride = 1000;
     const decimal BasePrice = 10m;
     const decimal PriceOffset = 10m;
@@ -220,8 +228,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var results = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
 
         // when
-        _marketList[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        _marketList[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[0].SetPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[1].SetPrices(0, PricesPerMarket, GetRandomPrice);
 
         // then
         _marketList.Count.Should().Be(2);
@@ -238,8 +246,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         // having
         _marketList.AddRange(Enumerable.Range(0, 2).Select(n => new Market(n)));
         using var results = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
-        _marketList[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        _marketList[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[0].SetPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[1].SetPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
         _marketList[1].RemoveAllPrices();
@@ -259,8 +267,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         // having
         _marketList.AddRange(Enumerable.Range(0, 2).Select(n => new Market(n)));
         using var results = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
-        _marketList[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        _marketList[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[0].SetPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[1].SetPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
         _marketList[0].RemoveAllPrices();
@@ -278,8 +286,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         // having
         _marketList.AddRange(Enumerable.Range(0, 2).Select(n => new Market(n)));
         using var results = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
-        _marketList[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        _marketList[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[0].SetPrices(0, PricesPerMarket, GetRandomPrice);
+        _marketList[1].SetPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
         _marketList[1].RefreshAllPrices(GetRandomPrice);
@@ -321,7 +329,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var others = new[] { marketLow.LatestPrices, marketHigh.LatestPrices };
         using var highPriceResults = marketOriginal.LatestPrices.MergeChangeSets(others, MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = marketOriginal.LatestPrices.MergeChangeSets(others, MarketPrice.LowPriceCompare).AsAggregator();
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
         marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
@@ -347,7 +355,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var marketLow = Add(new Market(1));
         var marketHigh = Add(new Market(2));
         var others = new[] { marketLow.LatestPrices, marketHigh.LatestPrices };
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
         marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
@@ -375,7 +383,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var marketFlipFlop = Add(new Market(1));
         using var highPriceResults = marketOriginal.LatestPrices.MergeChangeSets(marketFlipFlop.LatestPrices, MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = marketOriginal.LatestPrices.MergeChangeSets(marketFlipFlop.LatestPrices, MarketPrice.LowPriceCompare).AsAggregator();
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
         marketFlipFlop.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
@@ -407,7 +415,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var results = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.LowPriceCompare).AsAggregator();
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.HighPriceCompare).AsAggregator();
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
         marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
@@ -440,7 +448,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var marketFlipFlop = Add(new Market(1));
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.LowPriceCompare).AsAggregator();
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
         marketFlipFlop.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
@@ -470,7 +478,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var marketLow = Add(new Market(1));
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.LowPriceCompare).AsAggregator();
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
@@ -500,7 +508,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var marketLow = Add(new Market(1));
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.LowPriceCompare).AsAggregator();
-        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        marketOriginal.SetPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
@@ -600,7 +608,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
 
         var results = market1.LatestPrices.MergeChangeSets(market2.LatestPrices, MarketPrice.EqualityComparer, MarketPrice.LatestPriceCompare).AsAggregator();
         var resultsTimeStamp = market1.LatestPrices.MergeChangeSets(market2.LatestPrices, MarketPrice.EqualityComparerWithTimeStamp, MarketPrice.LatestPriceCompare).AsAggregator();
-        market1.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        market1.SetPrices(0, PricesPerMarket, GetRandomPrice);
         market2.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
@@ -630,7 +638,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
 
         var results1 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.LatestPriceCompare).AsAggregator();
         var results2 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparerWithTimeStamp, MarketPrice.LatestPriceCompare).AsAggregator();
-        market1.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        market1.SetPrices(0, PricesPerMarket, GetRandomPrice);
         market2.SetPrices(0, PricesPerMarket, LowestPrice);
         // Update again, but only the timestamp will change, so results1 will ignore
         market2.SetPrices(0, PricesPerMarket, LowestPrice);
@@ -664,7 +672,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
 
         var results1 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.LatestPriceCompare).AsAggregator();
         var results2 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparerWithTimeStamp, MarketPrice.LatestPriceCompare).AsAggregator();
-        market1.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        market1.SetPrices(0, PricesPerMarket, GetRandomPrice);
         market2.SetPrices(0, PricesPerMarket, LowestPrice - 1);
         // Update again, but only the timestamp will change, so results1 will ignore
         market2.SetPrices(0, PricesPerMarket, LowestPrice - 1);

--- a/src/DynamicData.Tests/Cache/MergeChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeChangeSetsFixture.cs
@@ -324,8 +324,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // then
         _marketList.Count.Should().Be(3);
@@ -348,8 +348,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var marketHigh = Add(new Market(2));
         var others = new[] { marketLow.LatestPrices, marketHigh.LatestPrices };
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
         using var highPriceResults = marketOriginal.LatestPrices.MergeChangeSets(others, MarketPrice.HighPriceCompare).AsAggregator();
@@ -376,7 +376,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var highPriceResults = marketOriginal.LatestPrices.MergeChangeSets(marketFlipFlop.LatestPrices, MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = marketOriginal.LatestPrices.MergeChangeSets(marketFlipFlop.LatestPrices, MarketPrice.LowPriceCompare).AsAggregator();
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketFlipFlop.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketFlipFlop.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
         marketFlipFlop.RefreshAllPrices(LowestPrice);
@@ -408,8 +408,8 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.LowPriceCompare).AsAggregator();
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.HighPriceCompare).AsAggregator();
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
         marketLow.RemoveAllPrices();
@@ -441,7 +441,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.LowPriceCompare).AsAggregator();
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketFlipFlop.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketFlipFlop.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
         marketFlipFlop.UpdateAllPrices(LowestPrice);
@@ -471,7 +471,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.LowPriceCompare).AsAggregator();
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
         marketLow.UpdateAllPrices(LowestPrice - 1);
@@ -501,7 +501,7 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         using var highPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.HighPriceCompare).AsAggregator();
         using var lowPriceResults = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.LowPriceCompare).AsAggregator();
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
         marketLow.RefreshAllPrices(LowestPrice - 1);
@@ -576,10 +576,10 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         // having
         var market = Add(new Market(0));
         using var results = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
-        market.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
-        market.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // then
         _marketList.Count.Should().Be(1);
@@ -601,10 +601,10 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var results = market1.LatestPrices.MergeChangeSets(market2.LatestPrices, MarketPrice.EqualityComparer, MarketPrice.LatestPriceCompare).AsAggregator();
         var resultsTimeStamp = market1.LatestPrices.MergeChangeSets(market2.LatestPrices, MarketPrice.EqualityComparerWithTimeStamp, MarketPrice.LatestPriceCompare).AsAggregator();
         market1.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        market2.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market2.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
-        market2.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market2.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // then
         _marketList.Count.Should().Be(2);
@@ -631,9 +631,9 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var results1 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.LatestPriceCompare).AsAggregator();
         var results2 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparerWithTimeStamp, MarketPrice.LatestPriceCompare).AsAggregator();
         market1.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        market2.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market2.SetPrices(0, PricesPerMarket, LowestPrice);
         // Update again, but only the timestamp will change, so results1 will ignore
-        market2.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market2.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // when
         // results1 won't see the refresh because it ignored the update
@@ -665,9 +665,9 @@ public sealed partial class MergeChangeSetsFixture : IDisposable
         var results1 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparer, MarketPrice.LatestPriceCompare).AsAggregator();
         var results2 = _marketList.Select(m => m.LatestPrices).MergeChangeSets(MarketPrice.EqualityComparerWithTimeStamp, MarketPrice.LatestPriceCompare).AsAggregator();
         market1.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        market2.UpdatePrices(0, PricesPerMarket, LowestPrice - 1);
+        market2.SetPrices(0, PricesPerMarket, LowestPrice - 1);
         // Update again, but only the timestamp will change, so results1 will ignore
-        market2.UpdatePrices(0, PricesPerMarket, LowestPrice - 1);
+        market2.SetPrices(0, PricesPerMarket, LowestPrice - 1);
 
         // when
         // results1 will see this as an update because it ignored the last update

--- a/src/DynamicData.Tests/Cache/MergeManyCacheChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyCacheChangeSetsFixture.cs
@@ -355,8 +355,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         _marketCache.AddOrUpdate(marketHigh);
 
         // when
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // then
         _marketCacheResults.Data.Count.Should().Be(3);
@@ -381,8 +381,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketHigh = new Market(2);
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         _marketCache.AddOrUpdate(marketOriginal);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
         _marketCache.AddOrUpdate(marketLow);
@@ -410,8 +410,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketLow = new Market(1);
         var marketLowLow = new Market(marketLow);
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketLowLow.UpdatePrices(0, PricesPerMarket, LowestPrice - 1);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketLowLow.SetPrices(0, PricesPerMarket, LowestPrice - 1);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
 
@@ -441,7 +441,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketFlipFlop = new Market(1);
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketFlipFlop.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketFlipFlop.SetPrices(0, PricesPerMarket, HighestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketFlipFlop);
 
@@ -478,8 +478,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
         _marketCache.AddOrUpdate(marketHigh);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
-        marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
+        marketHigh.SetPrices(0, PricesPerMarket, HighestPrice);
 
         // when
         _marketCache.Remove(marketLow);
@@ -511,7 +511,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketFlipFlop = new Market(1);
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketFlipFlop.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketFlipFlop.SetPrices(0, PricesPerMarket, HighestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketFlipFlop);
 
@@ -543,7 +543,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
 
@@ -575,7 +575,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        marketLow.SetPrices(0, PricesPerMarket, LowestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
 
@@ -604,11 +604,11 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         // having
         var market = new Market(0);
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
-        market.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market.SetPrices(0, PricesPerMarket, LowestPrice);
         _marketCache.AddOrUpdate(market);
 
         // when
-        market.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // then
         _marketCacheResults.Data.Count.Should().Be(1);

--- a/src/DynamicData.Tests/Cache/MergeManyCacheChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyCacheChangeSetsFixture.cs
@@ -5,6 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Linq;
 using DynamicData.Kernel;
+using DynamicData.Tests.Domain;
+using DynamicData.Tests.Utilities;
 using FluentAssertions;
 
 using Xunit;
@@ -25,6 +27,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
 
     private static readonly Random Random = new Random(0x21123737);
 
+    private static decimal GetRandomPrice() => MarketPrice.RandomPrice(Random, BasePrice, PriceOffset);
+
     private readonly ISourceCache<IMarket, Guid> _marketCache = new SourceCache<IMarket, Guid>(p => p.Id);
 
     private readonly ChangeSetAggregator<IMarket, Guid> _marketCacheResults;
@@ -32,6 +36,75 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
     public MergeManyCacheChangeSetsFixture()
     {
         _marketCacheResults = _marketCache.Connect().AsAggregator();
+    }
+
+    [Fact]
+    public void NullChecks()
+    {
+        // having
+        var emptyChangeSetObs = Observable.Empty<IChangeSet<int, int>>();
+        var nullChangeSetObs = (IObservable<IChangeSet<int, int>>)null!;
+        var emptyChildChangeSetObs = Observable.Empty<IChangeSet<string, string>>();
+        var emptySelector = new Func<int, IObservable<IChangeSet<string, string>>>(i => emptyChildChangeSetObs);
+        var emptyKeySelector = new Func<int, int, IObservable<IChangeSet<string, string>>>((i, key) => emptyChildChangeSetObs);
+        var nullSelector = (Func<int, IObservable<IChangeSet<string, string>>>)null!;
+        var nullKeySelector = (Func<int, int, IObservable<IChangeSet<string, string>>>)null!;
+        var nullParentComparer = (IComparer<int>)null!;
+        var emptyParentComparer = new NoOpComparer<int>() as IComparer<int>;
+        var nullChildComparer = (IComparer<string>)null!;
+        var emptyChildComparer = new NoOpComparer<string>() as IComparer<string>;
+        var nullEqualityComparer = (IEqualityComparer<string>)null!;
+        var emptyEqualityComparer = new NoOpEqualityComparer<string>() as IEqualityComparer<string>;
+
+        // when
+        var actionDefault1 = () => emptyChangeSetObs.MergeManyChangeSets(nullSelector);
+        var actionDefault2a = () => nullChangeSetObs.MergeManyChangeSets(emptyKeySelector);
+        var actionDefault2b = () => emptyChangeSetObs.MergeManyChangeSets(nullKeySelector);
+        var actionChildCompare1 = () => emptyChangeSetObs.MergeManyChangeSets(nullSelector, comparer: emptyChildComparer);
+        var actionChildCompare2a = () => nullChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: emptyChildComparer);
+        var actionChildCompare2b = () => emptyChangeSetObs.MergeManyChangeSets(nullKeySelector, comparer: emptyChildComparer);
+        var actionChildCompare2c = () => emptyChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: nullChildComparer);
+        var actionParentCompare1 = () => emptyChangeSetObs.MergeManyChangeSets(nullSelector, comparer: emptyParentComparer);
+        var actionParentCompareKey1a = () => nullChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: emptyParentComparer);
+        var actionParentCompareKey1b = () => emptyChangeSetObs.MergeManyChangeSets(nullKeySelector, comparer: emptyParentComparer);
+        var actionParentCompareKey1c = () => emptyChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: nullParentComparer);
+        var actionParentCompare2 = () => emptyChangeSetObs.MergeManyChangeSets(nullSelector, comparer: emptyParentComparer, equalityComparer: emptyEqualityComparer);
+        var actionParentCompareKey2a = () => nullChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: emptyParentComparer, equalityComparer: emptyEqualityComparer);
+        var actionParentCompareKey2b = () => emptyChangeSetObs.MergeManyChangeSets(nullKeySelector, comparer: emptyParentComparer, equalityComparer: emptyEqualityComparer);
+        var actionParentCompareKey2c = () => emptyChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: nullParentComparer, equalityComparer: emptyEqualityComparer);
+        var actionParentCompareKey2d = () => emptyChangeSetObs.MergeManyChangeSets(emptyKeySelector, comparer: emptyParentComparer, equalityComparer: nullEqualityComparer);
+
+        // then
+        emptyChangeSetObs.Should().NotBeNull();
+        emptyChildChangeSetObs.Should().NotBeNull();
+        emptyChildComparer.Should().NotBeNull();
+        emptyEqualityComparer.Should().NotBeNull();
+        emptyKeySelector.Should().NotBeNull();
+        emptyParentComparer.Should().NotBeNull();
+        emptySelector.Should().NotBeNull();
+        nullChangeSetObs.Should().BeNull();
+        nullChildComparer.Should().BeNull();
+        nullEqualityComparer.Should().BeNull();
+        nullKeySelector.Should().BeNull();
+        nullParentComparer.Should().BeNull();
+        nullSelector.Should().BeNull();
+
+        actionDefault1.Should().Throw<ArgumentNullException>();
+        actionDefault2a.Should().Throw<ArgumentNullException>();
+        actionDefault2b.Should().Throw<ArgumentNullException>();
+        actionChildCompare1.Should().Throw<ArgumentNullException>();
+        actionChildCompare2a.Should().Throw<ArgumentNullException>();
+        actionChildCompare2b.Should().Throw<ArgumentNullException>();
+        actionChildCompare2c.Should().Throw<ArgumentNullException>();
+        actionParentCompare1.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey1a.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey1b.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey1c.Should().Throw<ArgumentNullException>();
+        actionParentCompare2.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey2a.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey2b.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey2c.Should().Throw<ArgumentNullException>();
+        actionParentCompareKey2d.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
@@ -52,11 +125,6 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         // then
         _marketCacheResults.Data.Count.Should().Be(1);
         invoked.Should().BeTrue();
-        Assert.Throws<ArgumentNullException>(() => _marketCache.Connect().MergeManyChangeSets((Func<IMarket, IObservable<IChangeSet<MarketPrice, int>>>)null!, comparer: null!));
-        Assert.Throws<ArgumentNullException>(() => _marketCache.Connect().MergeManyChangeSets(_ => Observable.Return(ChangeSet<MarketPrice, int>.Empty), comparer: null!));
-        Assert.Throws<ArgumentNullException>(() => _marketCache.Connect().MergeManyChangeSets((Func<IMarket, IObservable<IChangeSet<MarketPrice, int>>>)null!, null!, null!));
-        Assert.Throws<ArgumentNullException>(() => ObservableCacheEx.MergeManyChangeSets<Market, Guid, MarketPrice, int>(null!, (Func<Market, IObservable<IChangeSet<MarketPrice, int>>>)null!, comparer: null!));
-        Assert.Throws<ArgumentNullException>(() => ObservableCacheEx.MergeManyChangeSets<Market, Guid, MarketPrice, int>(null!, (Func<Market, IObservable<IChangeSet<MarketPrice, int>>>)null!, null!, null!));
     }
 
     [Fact]
@@ -77,11 +145,6 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         // then
         _marketCacheResults.Data.Count.Should().Be(1);
         invoked.Should().BeTrue();
-        Assert.Throws<ArgumentNullException>(() => _marketCache.Connect().MergeManyChangeSets((Func<IMarket, Guid, IObservable<IChangeSet<MarketPrice, int>>>)null!, comparer: null!));
-        Assert.Throws<ArgumentNullException>(() => _marketCache.Connect().MergeManyChangeSets((_, _) => Observable.Return(ChangeSet<MarketPrice, int>.Empty), comparer: null!));
-        Assert.Throws<ArgumentNullException>(() => _marketCache.Connect().MergeManyChangeSets((Func<IMarket, Guid, IObservable<IChangeSet<MarketPrice, int>>>)null!, null!, null!));
-        Assert.Throws<ArgumentNullException>(() => ObservableCacheEx.MergeManyChangeSets(null!, (Func<Market, Guid, IObservable<IChangeSet<MarketPrice, int>>>)null!, comparer: null!));
-        Assert.Throws<ArgumentNullException>(() => ObservableCacheEx.MergeManyChangeSets(null!, (Func<Market, Guid, IObservable<IChangeSet<MarketPrice, int>>>)null!, null!, null!));
     }
 
     [Fact]
@@ -90,7 +153,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         // having
         var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
-        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(Random, m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket));
+        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket, GetRandomPrice));
 
         // when
         _marketCache.AddOrUpdate(markets);
@@ -114,7 +177,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         _marketCache.AddOrUpdate(markets);
 
         // when
-        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(Random, m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket));
+        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket, GetRandomPrice));
 
         // then
         _marketCacheResults.Data.Count.Should().Be(MarketCount);
@@ -133,10 +196,10 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         _marketCache.AddOrUpdate(markets);
-        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(Random, m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket));
+        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket, GetRandomPrice));
 
         // when
-        markets.ForEach(m => m.RefreshAllPrices(Random));
+        markets.ForEach(m => m.RefreshAllPrices(GetRandomPrice));
 
         // then
         _marketCacheResults.Data.Count.Should().Be(MarketCount);
@@ -157,8 +220,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         _marketCache.AddOrUpdate(markets);
 
         // when
-        markets[0].AddRandomPrices(Random, 0, PricesPerMarket);
-        markets[1].AddRandomPrices(Random, 0, PricesPerMarket);
+        markets[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        markets[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
 
         // then
         _marketCacheResults.Data.Count.Should().Be(2);
@@ -176,8 +239,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var markets = Enumerable.Range(0, 2).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         _marketCache.AddOrUpdate(markets);
-        markets[0].AddRandomPrices(Random, 0, PricesPerMarket);
-        markets[1].AddRandomPrices(Random, 0, PricesPerMarket);
+        markets[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        markets[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
         markets[1].RemoveAllPrices();
@@ -198,8 +261,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var markets = Enumerable.Range(0, 2).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         _marketCache.AddOrUpdate(markets);
-        markets[0].AddRandomPrices(Random, 0, PricesPerMarket);
-        markets[1].AddRandomPrices(Random, 0, PricesPerMarket);
+        markets[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        markets[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
         _marketCache.Remove(markets[0]);
@@ -219,11 +282,11 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var markets = Enumerable.Range(0, 2).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         _marketCache.AddOrUpdate(markets);
-        markets[0].AddRandomPrices(Random, 0, PricesPerMarket);
-        markets[1].AddRandomPrices(Random, 0, PricesPerMarket);
+        markets[0].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
+        markets[1].AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
 
         // when
-        markets[1].RefreshAllPrices(Random);
+        markets[1].RefreshAllPrices(GetRandomPrice);
 
         // then
         _marketCacheResults.Data.Count.Should().Be(2);
@@ -239,7 +302,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         _marketCache.AddOrUpdate(markets);
-        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(Random, m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket));
+        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket, GetRandomPrice));
 
         // when
         markets.ForEach(m => m.PricesCache.Edit(updater => updater.RemoveKeys(updater.Keys.Take(RemoveCount))));
@@ -260,7 +323,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         _marketCache.AddOrUpdate(markets);
-        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(Random, m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket));
+        markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.AddRandomPrices(m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket, GetRandomPrice));
 
         // when
         _marketCache.Edit(updater => updater.RemoveKeys(updater.Keys.Take(RemoveCount)));
@@ -278,10 +341,10 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         // having
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
         var market = new Market(0);
-        market.AddRandomPrices(Random, 0, PricesPerMarket * 2);
+        market.AddRandomPrices(0, PricesPerMarket * 2, GetRandomPrice);
         _marketCache.AddOrUpdate(market);
         var updatedMarket = new Market(market);
-        updatedMarket.AddRandomPrices(Random, PricesPerMarket, PricesPerMarket * 3);
+        updatedMarket.AddRandomPrices(PricesPerMarket, PricesPerMarket * 3, GetRandomPrice);
 
         // when
         _marketCache.AddOrUpdate(updatedMarket);
@@ -304,7 +367,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
         var marketHigh = new Market(2);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
         _marketCache.AddOrUpdate(marketHigh);
@@ -334,7 +397,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
         var marketHigh = new Market(2);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
         marketHigh.UpdatePrices(0, PricesPerMarket, HighestPrice);
@@ -364,7 +427,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
         var marketLowLow = new Market(marketLow);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
         marketLowLow.UpdatePrices(0, PricesPerMarket, LowestPrice - 1);
         _marketCache.AddOrUpdate(marketOriginal);
@@ -395,7 +458,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         using var lowPriceResults = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.LowPriceCompare).AsAggregator();
         var marketOriginal = new Market(0);
         var marketFlipFlop = new Market(1);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         marketFlipFlop.UpdatePrices(0, PricesPerMarket, HighestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketFlipFlop);
@@ -429,7 +492,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
         var marketHigh = new Market(2);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
         _marketCache.AddOrUpdate(marketHigh);
@@ -465,7 +528,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         using var lowPriceResults = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.LowPriceCompare).AsAggregator();
         var marketOriginal = new Market(0);
         var marketFlipFlop = new Market(1);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         marketFlipFlop.UpdatePrices(0, PricesPerMarket, HighestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketFlipFlop);
@@ -497,7 +560,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         using var lowPriceResults = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.LowPriceCompare).AsAggregator();
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
@@ -529,7 +592,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         using var lowPriceResults = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer, MarketPrice.LowPriceCompare).AsAggregator();
         var marketOriginal = new Market(0);
         var marketLow = new Market(1);
-        marketOriginal.AddRandomPrices(Random, 0, PricesPerMarket);
+        marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         marketLow.UpdatePrices(0, PricesPerMarket, LowestPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketLow);
@@ -579,7 +642,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
     public void EveryItemVisibleWhenSequenceCompletes()
     {
         // having
-        _marketCache.AddOrUpdate(Enumerable.Range(0, MarketCount).Select(n => new FixedMarket(Random, n * ItemIdStride, (n * ItemIdStride) + PricesPerMarket)));
+        _marketCache.AddOrUpdate(Enumerable.Range(0, MarketCount).Select(n => new FixedMarket(GetRandomPrice, n * ItemIdStride, (n * ItemIdStride) + PricesPerMarket)));
 
         // when
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices).AsAggregator();
@@ -601,7 +664,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
     public void MergedObservableCompletesOnlyWhenSourceAndAllChildrenComplete(bool completeSource, bool completeChildren)
     {
         // having
-        _marketCache.AddOrUpdate(Enumerable.Range(0, MarketCount).Select(n => new FixedMarket(Random, n * ItemIdStride, (n * ItemIdStride) + PricesPerMarket, completable: completeChildren)));
+        _marketCache.AddOrUpdate(Enumerable.Range(0, MarketCount).Select(n => new FixedMarket(GetRandomPrice, n * ItemIdStride, (n * ItemIdStride) + PricesPerMarket, completable: completeChildren)));
         var hasSourceSequenceCompleted = false;
         var hasMergedSequenceCompleted = false;
 
@@ -651,162 +714,4 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         _marketCache.Dispose();
         _marketCache.Clear();
     }
-
-    private interface IMarket
-    {
-        public string Name { get; }
-
-        public Guid Id { get; }
-
-        public IObservable<IChangeSet<MarketPrice, int>> LatestPrices { get; }
-    }
-
-    private class Market : IMarket, IDisposable
-    {
-        private readonly ISourceCache<MarketPrice, int> _latestPrices = new SourceCache<MarketPrice, int>(p => p.ItemId);
-
-        private Market(string name, Guid id)
-        {
-            Name = name;
-            Id = id;
-        }
-
-        public Market(Market market) : this(market.Name, market.Id)
-        {
-        }
-
-        public Market(int name) : this($"Market #{name}", Guid.NewGuid())
-        {
-        }
-
-        public string Name { get; }
-
-        public Guid Id { get; }
-
-        public IObservable<IChangeSet<MarketPrice, int>> LatestPrices => _latestPrices.Connect();
-
-        public ISourceCache<MarketPrice, int> PricesCache => _latestPrices;
-
-        public MarketPrice CreatePrice(int itemId, decimal price) => new (itemId, price, Id);
-
-        public void AddRandomIdPrices(Random r, int count, int minId, int maxId) =>
-            _latestPrices.AddOrUpdate(Enumerable.Range(0, int.MaxValue).Select(_ => r.Next(minId, maxId)).Distinct().Take(count).Select(id => CreatePrice(id, RandomPrice(r))));
-
-        public void AddRandomPrices(Random r, int minId, int maxId) =>
-            _latestPrices.AddOrUpdate(Enumerable.Range(minId, (maxId - minId)).Select(id => CreatePrice(id, RandomPrice(r))));
-
-        public void RefreshAllPrices(decimal newPrice) =>
-            _latestPrices.Edit(updater => updater.Items.ForEach(cp =>
-            {
-                cp.Price = newPrice;
-                updater.Refresh(cp);
-            }));
-
-        public void RefreshAllPrices(Random r) => RefreshAllPrices(RandomPrice(r));
-
-        public void RefreshPrice(int id, decimal newPrice) =>
-            _latestPrices.Edit(updater => updater.Lookup(id).IfHasValue(cp =>
-            {
-                cp.Price = newPrice;
-                updater.Refresh(cp);
-            }));
-
-        public void RemoveAllPrices() => _latestPrices.Clear();
-
-        public void RemovePrice(int itemId) => _latestPrices.Remove(itemId);
-
-        public void UpdateAllPrices(decimal newPrice) =>
-            _latestPrices.Edit(updater => updater.AddOrUpdate(updater.Items.Select(cp => CreatePrice(cp.ItemId, newPrice))));
-
-        public void UpdatePrices(int minId, int maxId, decimal newPrice) =>
-            _latestPrices.AddOrUpdate(Enumerable.Range(minId, (maxId - minId)).Select(id => CreatePrice(id, newPrice)));
-
-        public void Dispose() => _latestPrices.Dispose();
-    }
-
-    private static decimal RandomPrice(Random r) => BasePrice + ((decimal)r.NextDouble() * PriceOffset);
-
-    private class MarketPrice
-    {
-        public static IEqualityComparer<MarketPrice> EqualityComparer { get; } = new CurrentPriceEqualityComparer();
-        public static IComparer<MarketPrice> HighPriceCompare { get; } = new HighestPriceComparer();
-        public static IComparer<MarketPrice> LowPriceCompare { get; } = new LowestPriceComparer();
-        public static IComparer<MarketPrice> LatestPriceCompare { get; } = new LatestPriceComparer();
-
-        private decimal _price;
-
-        public MarketPrice(int itemId, decimal price, Guid marketId)
-        {
-            ItemId = itemId;
-            MarketId = marketId;
-            Price = price;
-        }
-
-        public decimal Price
-        {
-            get => _price;
-            set
-            {
-                _price = value;
-                TimeStamp = DateTimeOffset.UtcNow;
-            }
-        }
-
-        public DateTimeOffset TimeStamp { get; private set; }
-
-        public Guid MarketId { get; }
-
-        public int ItemId { get; }
-
-        private class CurrentPriceEqualityComparer : IEqualityComparer<MarketPrice>
-        {
-            public bool Equals([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y) => x.MarketId.Equals(x.MarketId) && (x.ItemId == y.ItemId) && (x.Price == y.Price);
-            public int GetHashCode([DisallowNull] MarketPrice obj) => throw new NotImplementedException();
-        }
-
-        private class LowestPriceComparer : IComparer<MarketPrice>
-        {
-            public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
-            {
-                Debug.Assert(x.ItemId == y.ItemId);
-                return x.Price.CompareTo(y.Price);
-            }
-        }
-
-        private class HighestPriceComparer : IComparer<MarketPrice>
-        {
-            public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
-            {
-                Debug.Assert(x.ItemId == y.ItemId);
-                return y.Price.CompareTo(x.Price);
-            }
-        }
-
-        private class LatestPriceComparer : IComparer<MarketPrice>
-        {
-            public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
-            {
-                Debug.Assert(x.ItemId == y.ItemId);
-                return x.TimeStamp.CompareTo(y.TimeStamp);
-            }
-        }
-    }
-
-    private class FixedMarket : IMarket
-    {
-        public FixedMarket(Random r, int minId, int maxId, bool completable = true)
-        {
-            Id = Guid.NewGuid();
-            LatestPrices = Enumerable.Range(minId, maxId - minId)
-                                    .Select(id => new MarketPrice(id, RandomPrice(r), Id))
-                                    .AsObservableChangeSet(cp => cp.ItemId, completable: completable);
-        }
-
-        public IObservable<IChangeSet<MarketPrice, int>> LatestPrices { get; }
-
-        public string Name => Id.ToString("B");
-
-        public Guid Id { get; }
-    }
-
 }

--- a/src/DynamicData.Tests/Cache/MergeManyCacheChangeSetsSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyCacheChangeSetsSourceCompareFixture.cs
@@ -513,7 +513,7 @@ public sealed class MergeManyCacheChangeSetsSourceCompareFixture : IDisposable
         _marketCacheResults.Data.Count.Should().Be(2);
         results.Data.Count.Should().Be(PricesPerMarket);
         results.Summary.Overall.Adds.Should().Be(PricesPerMarket);
-        results.Summary.Overall.Updates.Should().Be(0);
+        results.Summary.Overall.Updates.Should().Be(PricesPerMarket);
         results.Data.Items.Select(cp => cp.MarketId).ForEach(guid => guid.Should().Be(marketBetter.Id));
         resultsLow.Data.Count.Should().Be(PricesPerMarket);
         resultsLow.Summary.Overall.Adds.Should().Be(PricesPerMarket);
@@ -589,7 +589,7 @@ public sealed class MergeManyCacheChangeSetsSourceCompareFixture : IDisposable
         var marketLowest = new Market(2);
         marketLowest.Rating = marketHighest.Rating = 1.0;
         marketOriginal.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
-        marketHighest.UpdatePrices(0, PricesPerMarket, HighestPrice);
+        marketHighest.SetPrices(0, PricesPerMarket, HighestPrice);
         marketLowest.AddRandomPrices(0, PricesPerMarket, GetRandomPrice);
         _marketCache.AddOrUpdate(marketOriginal);
         _marketCache.AddOrUpdate(marketHighest);
@@ -688,11 +688,11 @@ public sealed class MergeManyCacheChangeSetsSourceCompareFixture : IDisposable
         // having
         var market = new Market(0);
         using var results = CreateChangeSet("Equality Compare", Market.RatingCompare, equalityComparer: MarketPrice.EqualityComparer, resortOnRefresh: true).AsAggregator();
-        market.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market.SetPrices(0, PricesPerMarket, LowestPrice);
         _marketCache.AddOrUpdate(market);
 
         // when
-        market.UpdatePrices(0, PricesPerMarket, LowestPrice);
+        market.SetPrices(0, PricesPerMarket, LowestPrice);
 
         // then
         _marketCacheResults.Data.Count.Should().Be(1);

--- a/src/DynamicData.Tests/Domain/Market.cs
+++ b/src/DynamicData.Tests/Domain/Market.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using DynamicData.Kernel;
+using DynamicData.Tests.Utilities;
+
+namespace DynamicData.Tests.Domain;
+
+internal interface IMarket
+{
+    public string Name { get; }
+
+    public Guid Id { get; }
+
+    public IObservable<IChangeSet<MarketPrice, int>> LatestPrices { get; }
+}
+
+internal class Market : IMarket, IDisposable
+{
+    private readonly ISourceCache<MarketPrice, int> _latestPrices = new SourceCache<MarketPrice, int>(p => p.ItemId);
+
+    private Market(string name, Guid id)
+    {
+        Name = name;
+        Id = id;
+    }
+
+    public Market(Market market) : this(market.Name, market.Id)
+    {
+    }
+
+    public Market(int name) : this($"Market #{name}", Guid.NewGuid())
+    {
+    }
+
+    public string Name { get; }
+
+    public Guid Id { get; }
+
+    public IObservable<IChangeSet<MarketPrice, int>> LatestPrices => _latestPrices.Connect();
+
+    public ISourceCache<MarketPrice, int> PricesCache => _latestPrices;
+
+    public MarketPrice CreatePrice(int itemId, decimal price) => new(itemId, price, Id);
+
+    public Market AddRandomIdPrices(Random r, int count, int minId, int maxId, Func<decimal> randPrices)
+    {
+        _latestPrices.AddOrUpdate(Enumerable.Range(0, int.MaxValue).Select(_ => r.Next(minId, maxId)).Distinct().Take(count).Select(id => CreatePrice(id, randPrices())));
+        return this;
+    }
+
+    public Market AddRandomPrices(int minId, int maxId, Func<decimal> randPrices)
+    {
+        _latestPrices.AddOrUpdate(Enumerable.Range(minId, maxId - minId).Select(id => CreatePrice(id, randPrices())));
+        return this;
+    }
+
+    public Market AddUniquePrices(int section, int count, int stride, Func<decimal> randPrices) => AddRandomPrices(section * stride, section * stride + count, randPrices);
+
+    public Market RefreshAllPrices(decimal newPrice)
+    {
+        _latestPrices.Edit(updater => updater.Items.ForEach(cp =>
+        {
+            cp.Price = newPrice;
+            updater.Refresh(cp);
+        }));
+
+        return this;
+    }
+
+    public Market RefreshAllPrices(Func<decimal> randPrices) => RefreshAllPrices(randPrices());
+
+    public Market RefreshPrice(int id, decimal newPrice)
+    {
+        _latestPrices.Edit(updater => updater.Lookup(id).IfHasValue(cp =>
+        {
+            cp.Price = newPrice;
+            updater.Refresh(cp);
+        }));
+        return this;
+    }
+
+    public void RemoveAllPrices() => this.With(_ => _latestPrices.Clear());
+
+    public void RemovePrice(int itemId) => this.With(_ => _latestPrices.Remove(itemId));
+
+    public Market UpdateAllPrices(decimal newPrice) => this.With(_ => _latestPrices.Edit(updater => updater.AddOrUpdate(updater.Items.Select(cp => CreatePrice(cp.ItemId, newPrice)))));
+
+    public Market UpdatePrices(int minId, int maxId, decimal newPrice) => this.With(_ => _latestPrices.AddOrUpdate(Enumerable.Range(minId, maxId - minId).Select(id => CreatePrice(id, newPrice))));
+
+    public void Dispose() => _latestPrices.Dispose();
+}
+
+
+internal class FixedMarket : IMarket
+{
+    public FixedMarket(Func<decimal> getPrice, int minId, int maxId, bool completable = true)
+    {
+        Id = Guid.NewGuid();
+        LatestPrices = Enumerable.Range(minId, maxId - minId)
+                                .Select(id => new MarketPrice(id, getPrice(), Id))
+                                .AsObservableChangeSet(cp => cp.ItemId, completable: completable);
+    }
+
+    public IObservable<IChangeSet<MarketPrice, int>> LatestPrices { get; }
+
+    public string Name => Id.ToString("B");
+
+    public Guid Id { get; }
+}

--- a/src/DynamicData.Tests/Domain/Market.cs
+++ b/src/DynamicData.Tests/Domain/Market.cs
@@ -95,9 +95,11 @@ internal class Market : IMarket, IDisposable
 
     public Market UpdateAllPrices(decimal newPrice) => this.With(_ => _latestPrices.Edit(updater => updater.AddOrUpdate(updater.Items.Select(cp => CreatePrice(cp.ItemId, newPrice)))));
 
-    public Market UpdatePrices(int minId, int maxId, decimal newPrice) => this.With(_ => _latestPrices.AddOrUpdate(Enumerable.Range(minId, maxId - minId).Select(id => CreatePrice(id, newPrice))));
+    public Market SetPrices(int minId, int maxId, decimal newPrice) => this.With(_ => _latestPrices.AddOrUpdate(Enumerable.Range(minId, maxId - minId).Select(id => CreatePrice(id, newPrice))));
 
     public void Dispose() => _latestPrices.Dispose();
+
+    public override string ToString() => $"Market '{Name}' [{Id}] (Rating: {Rating})";
 
     private class RatingComparer : IComparer<IMarket>
     {
@@ -127,4 +129,6 @@ internal class FixedMarket : IMarket
     public double Rating { get; set; }
 
     public Guid Id { get; }
+
+    public override string ToString() => $"Fixed Market '{Name}' (Rating: {Rating})";
 }

--- a/src/DynamicData.Tests/Domain/MarketPrice.cs
+++ b/src/DynamicData.Tests/Domain/MarketPrice.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DynamicData.Tests.Domain;
+
+internal class MarketPrice
+{
+    public static IEqualityComparer<MarketPrice> EqualityComparer { get; } = new CurrentPriceEqualityComparer();
+    public static IEqualityComparer<MarketPrice> EqualityComparerWithTimeStamp { get; } = new TimeStampPriceEqualityComparer();
+    public static IComparer<MarketPrice> HighPriceCompare { get; } = new HighestPriceComparer();
+    public static IComparer<MarketPrice> LowPriceCompare { get; } = new LowestPriceComparer();
+    public static IComparer<MarketPrice> LatestPriceCompare { get; } = new LatestPriceComparer();
+
+    private decimal _price;
+
+    public MarketPrice(int itemId, decimal price, Guid marketId)
+    {
+        ItemId = itemId;
+        MarketId = marketId;
+        Price = price;
+    }
+
+    public decimal Price
+    {
+        get => _price;
+        set
+        {
+            _price = value;
+            TimeStamp = DateTimeOffset.UtcNow;
+        }
+    }
+
+    public DateTimeOffset TimeStamp { get; private set; }
+
+    public Guid MarketId { get; }
+
+    public int ItemId { get; }
+
+    public override string ToString() => $"{ItemId:D5} - {Price:c} ({MarketId}) [{TimeStamp:HH:mm:ss.fffffff}]";
+
+    public static decimal RandomPrice(Random r, decimal basePrice, decimal offset) => basePrice + (decimal)r.NextDouble() * offset;
+
+    private class CurrentPriceEqualityComparer : IEqualityComparer<MarketPrice>
+    {
+        public virtual bool Equals([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y) => x.MarketId.Equals(x.MarketId) && x.ItemId == y.ItemId && x.Price == y.Price;
+        public int GetHashCode([DisallowNull] MarketPrice obj) => throw new NotImplementedException();
+    }
+
+    private class TimeStampPriceEqualityComparer : CurrentPriceEqualityComparer, IEqualityComparer<MarketPrice>
+    {
+        public override bool Equals([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y) => base.Equals(x, y) && x.TimeStamp == y.TimeStamp;
+    }
+
+    private class LowestPriceComparer : IComparer<MarketPrice>
+    {
+        public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
+        {
+            Debug.Assert(x.ItemId == y.ItemId);
+            return x.Price.CompareTo(y.Price);
+        }
+    }
+
+    private class HighestPriceComparer : IComparer<MarketPrice>
+    {
+        public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
+        {
+            Debug.Assert(x.ItemId == y.ItemId);
+            return y.Price.CompareTo(x.Price);
+        }
+    }
+
+    private class LatestPriceComparer : IComparer<MarketPrice>
+    {
+        public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
+        {
+            Debug.Assert(x.ItemId == y.ItemId);
+            return y.TimeStamp.CompareTo(x.TimeStamp);
+        }
+    }
+}

--- a/src/DynamicData.Tests/Utilities/ComparerExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/ComparerExtensions.cs
@@ -14,3 +14,19 @@ internal class NoOpEqualityComparer<T> : IEqualityComparer<T>
     public bool Equals(T x, T y) => throw new NotImplementedException();
     public int GetHashCode([DisallowNull] T obj) => throw new NotImplementedException();
 }
+
+
+internal class InvertedComparer<T> : IComparer<T>
+{
+    private readonly IComparer<T> _original;
+
+    public InvertedComparer(IComparer<T> original) => _original = original;
+
+    public int Compare(T x, T y) => _original.Compare(x, y) * -1;
+}
+
+
+internal static class ComparerExtensions
+{
+    public static IComparer<T> Invert<T>(this IComparer<T> comparer) => new InvertedComparer<T>(comparer);
+}

--- a/src/DynamicData.Tests/Utilities/FunctionalExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/FunctionalExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DynamicData.Tests.Utilities;
+
+internal static class FunctionalExtensions
+{
+    public static T With<T>(this T item, Action<T> action)
+    {
+        action(item);
+        return item;
+    }
+}

--- a/src/DynamicData.Tests/Utilities/NoOps.cs
+++ b/src/DynamicData.Tests/Utilities/NoOps.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DynamicData.Tests.Utilities;
+
+internal class NoOpComparer<T> : IComparer<T>
+{
+    public int Compare(T x, T y) => throw new NotImplementedException();
+}
+
+internal class NoOpEqualityComparer<T> : IEqualityComparer<T>
+{
+    public bool Equals(T x, T y) => throw new NotImplementedException();
+    public int GetHashCode([DisallowNull] T obj) => throw new NotImplementedException();
+}

--- a/src/DynamicData.Tests/Utilities/ObservableExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/ObservableExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace DynamicData.Tests.Utilities;
+
+internal static class ObservableExtensions
+{
+    /// <summary>
+    /// Forces the given observable to fail after the specified number events if an exception is provided.
+    /// </summary>
+    /// <typeparam name="T">Observable type.</typeparam>
+    /// <param name="source">Source Observable.</param>
+    /// <param name="count">Number of events before failing.</param>
+    /// <param name="e">Exception to fail with.</param>
+    /// <returns>The new Observable.</returns>
+    public static IObservable<T> ForceFail<T>(this IObservable<T> source, int count, Exception? e) =>
+        e is not null
+            ? source.Take(count).Concat(Observable.Throw<T>(e))
+            : source;
+}

--- a/src/DynamicData/Cache/Internal/ChangeSetMergeTracker.cs
+++ b/src/DynamicData/Cache/Internal/ChangeSetMergeTracker.cs
@@ -262,7 +262,7 @@ internal class ChangeSetMergeTracker<TObject, TKey>
     }
 
     private bool CheckEquality(TObject left, TObject right) =>
-        ReferenceEquals(left, right) || (_equalityComparer?.Equals(left, right) ?? (_comparer?.Compare(left, right) == 0));
+        ReferenceEquals(left, right) || (_equalityComparer?.Equals(left, right) ?? false);
 
     // Return true if candidate should replace current as the observed downstream value
     private bool ShouldReplace(TObject candidate, TObject current) =>

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
@@ -79,7 +79,7 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
             }).Transform(entry => entry.Child);
     }
 
-    private class ParentChildEntry
+    private sealed class ParentChildEntry
     {
         public ParentChildEntry(TObject parent, TDestination child)
         {
@@ -92,7 +92,7 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
         public TDestination Child { get; }
     }
 
-    private class ParentChildCompare : IComparer<ParentChildEntry>
+    private sealed class ParentChildCompare : Comparer<ParentChildEntry>
     {
         private readonly IComparer<TObject> _comparerParent;
         private readonly IComparer<TDestination> _comparerChild;
@@ -103,41 +103,47 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
             _comparerChild = comparerChild;
         }
 
-        public int Compare(ParentChildEntry? x, ParentChildEntry? y) =>
-            (x is null && y is null) ? 0
-                : (x is null) ? 1
-                : (y is null) ? -1
-                : _comparerParent.Compare(x.Parent, y.Parent) switch
-                    {
-                        0 => _comparerChild.Compare(x.Child, x.Child),
-                        int i => i,
-                    };
+        public override int Compare(ParentChildEntry? x, ParentChildEntry? y) => (x, y) switch
+        {
+            (not null, not null) => _comparerParent.Compare(x.Parent, y.Parent) switch
+                                    {
+                                        0 => _comparerChild.Compare(x.Child, x.Child),
+                                        int i => i,
+                                    },
+            (null, null) => 0,
+            (null, not null) => 1,
+            (not null, null) => -1,
+        };
     }
 
-    private class ParentOnlyCompare : IComparer<ParentChildEntry>
+    private sealed class ParentOnlyCompare : Comparer<ParentChildEntry>
     {
         private readonly IComparer<TObject> _comparerParent;
 
         public ParentOnlyCompare(IComparer<TObject> comparer) => _comparerParent = comparer;
 
-        public int Compare(ParentChildEntry? x, ParentChildEntry? y) =>
-            (x is null && y is null) ? 0
-                : (x is null) ? 1
-                : (y is null) ? -1
-                : _comparerParent.Compare(x.Parent, y.Parent);
+        public override int Compare(ParentChildEntry? x, ParentChildEntry? y) => (x, y) switch
+        {
+            (not null, not null) => _comparerParent.Compare(x.Parent, x.Parent),
+            (null, null) => 0,
+            (null, not null) => 1,
+            (not null, null) => -1,
+        };
     }
 
-    private class ParentChildEqualityCompare : IEqualityComparer<ParentChildEntry>
+    private sealed class ParentChildEqualityCompare : EqualityComparer<ParentChildEntry>
     {
         private readonly IEqualityComparer<TDestination> _comparer;
 
         public ParentChildEqualityCompare(IEqualityComparer<TDestination> comparer) => _comparer = comparer;
 
-        public bool Equals(ParentChildEntry? x, ParentChildEntry? y) =>
-            (x is null && y is null) ? true
-                : (x is null || y is null) ? false
-                : _comparer.Equals(x.Child, y.Child);
+        public override bool Equals(ParentChildEntry? x, ParentChildEntry? y) => (x, y) switch
+        {
+            (not null, not null) => _comparer.Equals(x.Child, y.Child),
+            (null, null) => true,
+            _ => false,
+        };
 
-        public int GetHashCode(ParentChildEntry obj) => _comparer.GetHashCode(obj.Child);
+        public override int GetHashCode(ParentChildEntry obj) => _comparer.GetHashCode(obj.Child);
     }
 }

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
@@ -107,7 +107,7 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
         {
             (not null, not null) => _comparerParent.Compare(x.Parent, y.Parent) switch
                                     {
-                                        0 => _comparerChild.Compare(x.Child, x.Child),
+                                        0 => _comparerChild.Compare(x.Child, y.Child),
                                         int i => i,
                                     },
             (null, null) => 0,
@@ -124,7 +124,7 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
 
         public override int Compare(ParentChildEntry? x, ParentChildEntry? y) => (x, y) switch
         {
-            (not null, not null) => _comparerParent.Compare(x.Parent, x.Parent),
+            (not null, not null) => _comparerParent.Compare(x.Parent, y.Parent),
             (null, null) => 0,
             (null, not null) => 1,
             (not null, null) => -1,

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace DynamicData.Cache.Internal;
+
+/// <summary>
+/// Alternate version of MergeManyCacheChangeSets that uses a Comparer of the source, not the destination type
+/// So that items from the most important source go into the resulting changeset.
+/// </summary>
+internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDestination, TDestinationKey>
+    where TObject : notnull
+    where TKey : notnull
+    where TDestination : notnull
+    where TDestinationKey : notnull
+{
+    private readonly IObservable<IChangeSet<TObject, TKey>> _source;
+
+    private readonly Func<TObject, TKey, IObservable<IChangeSet<ParentChildEntry, TDestinationKey>>> _changeSetSelector;
+
+    private readonly IComparer<ParentChildEntry>? _comparer;
+
+    private readonly IEqualityComparer<ParentChildEntry>? _equalityComparer;
+
+    private readonly bool _reevalOnRefresh;
+
+    public MergeManyCacheChangeSetsSourceCompare(IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> selector, IComparer<TObject> comparer, IEqualityComparer<TDestination>? equalityComparer, bool reevalOnRefresh = false)
+    {
+        _source = source;
+        _changeSetSelector = (obj, key) => selector(obj, key).Transform(dest => new ParentChildEntry(obj, dest));
+        _comparer = new ParentChildCompare(comparer);
+        _equalityComparer = (equalityComparer != null) ? new ParentChildEqualityCompare(equalityComparer) : null;
+        _reevalOnRefresh = reevalOnRefresh;
+    }
+
+    public IObservable<IChangeSet<TDestination, TDestinationKey>> Run()
+    {
+        return Observable.Create<IChangeSet<ParentChildEntry, TDestinationKey>>(
+            observer =>
+            {
+                var locker = new object();
+
+                // Transform to an observable cache of merge containers.
+                var sourceCacheOfCaches = _source
+                                            .Transform((obj, key) => new ChangeSetCache<ParentChildEntry, TDestinationKey>(_changeSetSelector(obj, key)))
+                                            .Synchronize(locker)
+                                            .AsObservableCache();
+
+                var shared = sourceCacheOfCaches.Connect().Publish();
+
+                // this is manages all of the changes
+                var changeTracker = new ChangeSetMergeTracker<ParentChildEntry, TDestinationKey>(() => sourceCacheOfCaches.Items, _comparer, _equalityComparer);
+
+                // merge the items back together
+                var allChanges = shared.MergeMany(mc => mc.Source)
+                                                 .Synchronize(locker)
+                                                 .Subscribe(
+                                                        changes => changeTracker.ProcessChangeSet(changes, observer),
+                                                        observer.OnError,
+                                                        observer.OnCompleted);
+
+                // when a source item is removed, all of its sub-items need to be removed
+                var removedItems = shared
+                    .OnItemRemoved(mc => changeTracker.RemoveItems(mc.Cache.KeyValues, observer))
+                    .OnItemUpdated((_, prev) => changeTracker.RemoveItems(prev.Cache.KeyValues, observer))
+                    .Subscribe();
+
+                // If requested, when the source sees a refresh event, re-evaluate all the keys associated with that source because the priority may have changed
+                // Because the comparison is based on the parent, which has just been refreshed.
+                var refreshItems = _reevalOnRefresh
+                    ? shared.OnItemRefreshed(mc => changeTracker.RefreshItems(mc.Cache.Keys, observer)).Subscribe()
+                    : Disposable.Empty;
+
+                return new CompositeDisposable(sourceCacheOfCaches, allChanges, removedItems, refreshItems, shared.Connect());
+            }).Transform(entry => entry.Child);
+    }
+
+    private readonly struct ParentChildEntry
+    {
+        public ParentChildEntry(TObject parent, TDestination child)
+        {
+            Parent = parent;
+            Child = child;
+        }
+
+        public TObject Parent { get; }
+
+        public TDestination Child { get; }
+    }
+
+    private class ParentChildCompare : IComparer<ParentChildEntry>
+    {
+        private readonly IComparer<TObject> _comparer;
+
+        public ParentChildCompare(IComparer<TObject> comparer) => _comparer = comparer;
+
+        public int Compare(ParentChildEntry x, ParentChildEntry y) => _comparer.Compare(x.Parent, y.Parent);
+    }
+
+    private class ParentChildEqualityCompare : IEqualityComparer<ParentChildEntry>
+    {
+        private readonly IEqualityComparer<TDestination> _comparer;
+
+        public ParentChildEqualityCompare(IEqualityComparer<TDestination> comparer) => _comparer = comparer;
+
+        public bool Equals(ParentChildEntry x, ParentChildEntry y) => _comparer.Equals(x.Child, y.Child);
+
+        public int GetHashCode(ParentChildEntry obj) => _comparer.GetHashCode(obj.Child);
+    }
+}

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -3291,6 +3291,56 @@ public static class ObservableCacheEx
     /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
     /// <param name="source">The Source Observable ChangeSet.</param>
     /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> comparer, IEqualityComparer<TDestination>? equalityComparer = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
+
+        return source.MergeManyChangeSets((t, _) => observableSelector(t), comparer, equalityComparer);
+    }
+
+    /// <summary>
+    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> comparer, IEqualityComparer<TDestination>? equalityComparer = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
+        if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+        return new MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDestination, TDestinationKey>(source, observableSelector, comparer, equalityComparer).Run();
+    }
+
+    /// <summary>
+    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
     /// <param name="comparer"><see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
     /// <returns>The result from merging the child changesets together.</returns>
     /// <exception cref="ArgumentNullException">Parameter was null.</exception>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -27,6 +27,7 @@ namespace DynamicData;
 public static class ObservableCacheEx
 {
     private const int DefaultSortResetThreshold = 100;
+    private const bool DefaultResortOnSourceRefresh = false;
 
     /// <summary>
     /// Inject side effects into the stream using the specified adaptor.
@@ -3380,58 +3381,6 @@ public static class ObservableCacheEx
     }
 
     /// <summary>
-    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IComparer{TDestination})"/> that
-    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <typeparam name="TDestination">The type of the destination.</typeparam>
-    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
-    /// <param name="source">The Source Observable ChangeSet.</param>
-    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
-    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which parents items should be emitted when the same key is used by multiple child changesets.</param>
-    /// <param name="resortOnParentRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
-    /// <returns>The result from merging the child changesets together.</returns>
-    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
-    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> comparer, bool resortOnParentRefresh = false)
-        where TObject : notnull
-        where TKey : notnull
-        where TDestination : notnull
-        where TDestinationKey : notnull
-    {
-        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
-
-        return source.MergeManyChangeSets((t, _) => observableSelector(t), comparer, resortOnParentRefresh);
-    }
-
-    /// <summary>
-    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, TKey, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IComparer{TDestination})"/> that
-    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <typeparam name="TDestination">The type of the destination.</typeparam>
-    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
-    /// <param name="source">The Source Observable ChangeSet.</param>
-    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
-    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
-    /// <param name="resortOnParentRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
-    /// <returns>The result from merging the child changesets together.</returns>
-    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
-    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> comparer, bool resortOnParentRefresh = false)
-        where TObject : notnull
-        where TKey : notnull
-        where TDestination : notnull
-        where TDestinationKey : notnull
-    {
-        if (source == null) throw new ArgumentNullException(nameof(source));
-        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
-        if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-
-        return new MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDestination, TDestinationKey>(source, observableSelector, comparer, equalityComparer: null, resortOnParentRefresh).Run();
-    }
-
-    /// <summary>
     /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
     /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
     /// </summary>
@@ -3441,12 +3390,11 @@ public static class ObservableCacheEx
     /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
     /// <param name="source">The Source Observable ChangeSet.</param>
     /// <param name="observableSelector">Factory Function used to create child changesets.</param>
-    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
-    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
-    /// <param name="resortOnParentRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
     /// <returns>The result from merging the child changesets together.</returns>
     /// <exception cref="ArgumentNullException">Parameter was null.</exception>
-    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> comparer, IEqualityComparer<TDestination> equalityComparer, bool resortOnParentRefresh = false)
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, IComparer<TDestination> childComparer)
         where TObject : notnull
         where TKey : notnull
         where TDestination : notnull
@@ -3454,7 +3402,7 @@ public static class ObservableCacheEx
     {
         if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
 
-        return source.MergeManyChangeSets((t, _) => observableSelector(t), comparer, equalityComparer, resortOnParentRefresh);
+        return source.MergeManyChangeSets((t, _) => observableSelector(t), sourceComparer, DefaultResortOnSourceRefresh, equalityComparer: null, childComparer);
     }
 
     /// <summary>
@@ -3467,12 +3415,163 @@ public static class ObservableCacheEx
     /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
     /// <param name="source">The Source Observable ChangeSet.</param>
     /// <param name="observableSelector">Factory Function used to create child changesets.</param>
-    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
-    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
-    /// <param name="resortOnParentRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
     /// <returns>The result from merging the child changesets together.</returns>
     /// <exception cref="ArgumentNullException">Parameter was null.</exception>
-    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> comparer, IEqualityComparer<TDestination> equalityComparer, bool resortOnParentRefresh = false)
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, IComparer<TDestination> childComparer)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        return source.MergeManyChangeSets(observableSelector, sourceComparer, DefaultResortOnSourceRefresh, equalityComparer: null, childComparer);
+    }
+
+    /// <summary>
+    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
+    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="resortOnSourceRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, bool resortOnSourceRefresh, IComparer<TDestination> childComparer)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
+
+        return source.MergeManyChangeSets((t, _) => observableSelector(t), sourceComparer, resortOnSourceRefresh, equalityComparer: null, childComparer);
+    }
+
+    /// <summary>
+    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, TKey, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
+    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="resortOnSourceRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, bool resortOnSourceRefresh, IComparer<TDestination> childComparer)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        return source.MergeManyChangeSets(observableSelector, sourceComparer, resortOnSourceRefresh, equalityComparer: null, childComparer);
+    }
+
+    /// <summary>
+    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
+    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, IEqualityComparer<TDestination>? equalityComparer = null, IComparer<TDestination>? childComparer = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
+
+        return source.MergeManyChangeSets((t, _) => observableSelector(t), sourceComparer, DefaultResortOnSourceRefresh, equalityComparer, childComparer);
+    }
+
+    /// <summary>
+    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, TKey, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
+    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, IEqualityComparer<TDestination>? equalityComparer = null, IComparer<TDestination>? childComparer = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        return source.MergeManyChangeSets(observableSelector, sourceComparer, DefaultResortOnSourceRefresh, equalityComparer, childComparer);
+    }
+
+    /// <summary>
+    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
+    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="resortOnSourceRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, bool resortOnSourceRefresh, IEqualityComparer<TDestination>? equalityComparer = null, IComparer<TDestination>? childComparer = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TDestination : notnull
+        where TDestinationKey : notnull
+    {
+        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
+
+        return source.MergeManyChangeSets((t, _) => observableSelector(t), sourceComparer, resortOnSourceRefresh, equalityComparer, childComparer);
+    }
+
+    /// <summary>
+    /// Overload of <see cref="MergeManyChangeSets{TObject, TKey, TDestination, TDestinationKey}(IObservable{IChangeSet{TObject, TKey}}, Func{TObject, TKey, IObservable{IChangeSet{TDestination, TDestinationKey}}}, IEqualityComparer{TDestination}?, IComparer{TDestination}?)"/> that
+    /// will handle key collisions by using an <see cref="IComparer{T}"/> instance that operates on the sources, so that the values from the preferred source take precedent over other values with the same.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TDestinationKey">The type of the destination key.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <param name="sourceComparer"><see cref="IComparer{T}"/> instance to determine which source elements child to use when two sources provide a child element with the same key.</param>
+    /// <param name="resortOnSourceRefresh">Optional boolean to indicate whether or not a refresh event in the parent stream should re-evaluate item priorities.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <param name="childComparer">Optional fallback <see cref="IComparer{T}"/> instance to determine which child element to emit if the sources compare to be the same.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TKey, TDestination, TDestinationKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> observableSelector, IComparer<TObject> sourceComparer, bool resortOnSourceRefresh, IEqualityComparer<TDestination>? equalityComparer = null, IComparer<TDestination>? childComparer = null)
         where TObject : notnull
         where TKey : notnull
         where TDestination : notnull
@@ -3480,10 +3579,9 @@ public static class ObservableCacheEx
     {
         if (source == null) throw new ArgumentNullException(nameof(source));
         if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
-        if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-        if (equalityComparer == null) throw new ArgumentNullException(nameof(equalityComparer));
+        if (sourceComparer == null) throw new ArgumentNullException(nameof(sourceComparer));
 
-        return new MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDestination, TDestinationKey>(source, observableSelector, comparer, equalityComparer, resortOnParentRefresh).Run();
+        return new MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDestination, TDestinationKey>(source, observableSelector, sourceComparer, equalityComparer, childComparer, resortOnSourceRefresh).Run();
     }
 
     /// <summary>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -27,7 +27,7 @@ namespace DynamicData;
 public static class ObservableCacheEx
 {
     private const int DefaultSortResetThreshold = 100;
-    private const bool DefaultResortOnSourceRefresh = false;
+    private const bool DefaultResortOnSourceRefresh = true;
 
     /// <summary>
     /// Inject side effects into the stream using the specified adaptor.


### PR DESCRIPTION
## Description

This PR adds overloads to the Cache verion of `MergeManyChangeSets` that allow an additional `IComparer` parameter that operates on the **source** type so that priority of the resulting changeset can be based on factors in the source item, and not just child items.

Two `IComparer` instance can be provided so that child-based comparisons can be done as a fallback when the source comparison evaluates as the same.

## Examples

Say there's a mobile app that aggregates movie review web sites and has these basic interfaces:
```cs
interface IMovieReview
{
    Guid MovieId { get; }
    Guid CriticId { get; }
    double Rating { get; }
    DateTimeOffset DatePublished { get; }
    string Title { get; }
    Uri Link { get; }
}

interface IMovieCritic : INotifyPropertyChanged
{
    Guid Id { get; }
    string Name { get; }
    double Popularity { get; }
    IObservableCache<IMovieReview, Guid> Reviews { get; }
}

interface IMovieWebService
{
    IObservableCache<IMovieCritic, Guid> AllCritics { get; }
}

public static class MovieWebApi
{
    public IMovieWebService Service => GetTheWebServiceSomehow();
}

```

And the goal is to create an observable changeset that has a review for each movie, but when the movie has been reviewed by multiple critics, it should emit the review from the most popular critic.  This is problematic because the Internet is fickle and popularity can change.  How can you do such a thing?  DynamicData and Rx will come to the rescue.

With this PR, all such a changeset can be created with just a few lines of code:

```cs

// Need a comparer for Critics
class CriticComparer : IComparer<IMovieCritic>
{
    // Not a production-quality implementation, but you get the idea
    public int Compare(IMovieCritic x, IMovieCritic y) => y.Popularity.CompareTo(x.Popularity);
}

// Create the observable cache of movie reviews for every movie using the review for the most popular critic to have rated that movie
using var movieReviewCache = MovieWebApi.Service.AllCritics.Connect()
                                .AutoRefresh(critic => critic.Popularity)
                                .MergeManyChangeSets((critic, id) => critic.Reviews.Connect(), new CriticComparer())
                                .AsObservableCache();

```

That's all there is to it!  And now `movieReviewCache` will always contain the review of each movie from the most popular critic to have reviewed that movie.  For example, it will exhibit some of the following behaviors:
1) If a new critic is added, any movies they've reviewed will be added (unless they've already been reviewed by a more popular reviewer)
2) If a critic is removed, any movies only reviewed by them will be removed.  Other movies will be `Updated` to the review from next most-popular reviewer.
3) If any critic is the first to review a movie, it will be added.  When another critic reviews the same movie, their review may or may not replace the first one, depending on which reviewer is the most popular.
4) If the most popular critic to review a given movie removes their review, it will be updated to the next most popular critic to have reviewed that movie.  If no one else has a review for that movie, it will be removed from the cache instead.
5) If the Popularity of the Reviewer changes, reviews will be added/updated depending on how many more popular reviewers have reviewed the same movies such that the result cache always contains the review from the most popular reviewer.

### Another Example

At this point, you might be wondering "What if two Critics have the same popularity and rate the same movie?  I need it to always include the Best/First/Most Recent/etc review in those cases."

Well, there's an overload for that as well.  You just need a comparer for the child objects that will be used as a fallback when two parents compare to be the same.

```cs

// Need a comparer for Reviews (sorts earliest publishing dates first)
class FirstPublishedReviewComparer : IComparer<IMovieReview>
{
    // Not a production-quality implementation, but you get the idea
    public int Compare(IMovieReview x, IMovieReview y) => x.DatePublished.CompareTo(y.DatePublished);
}

// Create the observable cache of movie reviews for every movie using the review for the most popular critic to have rated that movie (going by publish date when multiple reviewers are tied)
using var movieReviewCache = MovieWebApi.Service.AllCritics.Connect()
                                .AutoRefresh(critic => critic.Popularity)
                                .MergeManyChangeSets((critic, id) => critic.Reviews.Connect(), new CriticComparer(), new FirstPublishedReviewComparer())
                                .AsObservableCache();

```

## Testing Improvements

- Moves the data classes `Market` and `MarketPrice` to be part of `Domain` namespace promote re-use
- Adds extension methods for creating tests
