### PR TITLE
ToConcreteType Update

### DIFF
--- a/src/DynamicData/Aggregation/AggregateEnumerator.cs
+++ b/src/DynamicData/Aggregation/AggregateEnumerator.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using DynamicData.Cache;
 
 namespace DynamicData.Aggregation;
 
@@ -68,11 +69,11 @@ internal class AggregateEnumerator<TObject, TKey> : IAggregateChangeSet<TObject>
     where TObject : notnull
     where TKey : notnull
 {
-    private readonly IChangeSet<TObject, TKey> _source;
+    private readonly ChangeSet<TObject, TKey> _source;
 
     public AggregateEnumerator(IChangeSet<TObject, TKey> source)
     {
-        _source = source;
+        _source = source.ToConcreteType();
     }
 
     public IEnumerator<AggregateItem<TObject>> GetEnumerator()

--- a/src/DynamicData/Binding/BindingListAdaptor.cs
+++ b/src/DynamicData/Binding/BindingListAdaptor.cs
@@ -5,7 +5,7 @@
 #if SUPPORTS_BINDINGLIST
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-
+using DynamicData.Cache;
 using DynamicData.Cache.Internal;
 
 namespace DynamicData.Binding
@@ -108,7 +108,7 @@ namespace DynamicData.Binding
 
         private static void DoUpdate(IChangeSet<TObject, TKey> changes, BindingList<TObject> list)
         {
-            foreach (var update in changes)
+            foreach (var update in changes.ToConcreteType())
             {
                 switch (update.Reason)
                 {

--- a/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-
+using DynamicData.Cache;
 using DynamicData.Cache.Internal;
 using DynamicData.Kernel;
 
@@ -128,7 +128,7 @@ public class ObservableCollectionAdaptor<TObject, TKey> : IObservableCollectionA
 
     private void DoUpdate(IChangeSet<TObject, TKey> changes, IObservableCollection<TObject> list)
     {
-        void Amend(Change<TObject, TKey> change)
+        foreach (Change<TObject, TKey> change in changes.ToConcreteType())
         {
             switch (change.Reason)
             {
@@ -154,22 +154,6 @@ public class ObservableCollectionAdaptor<TObject, TKey> : IObservableCollectionA
                     }
 
                     break;
-            }
-        }
-
-        if (changes is IList<Change<TObject, TKey>> iList)
-        {
-            // allocation free enumeration
-            foreach (var change in EnumerableIList.Create(iList))
-            {
-                Amend(change);
-            }
-        }
-        else
-        {
-            foreach (var update in changes)
-            {
-                Amend(update);
             }
         }
     }

--- a/src/DynamicData/Cache/CacheChangeSetEx.cs
+++ b/src/DynamicData/Cache/CacheChangeSetEx.cs
@@ -9,14 +9,32 @@ internal static class CacheChangeSetEx
     /// <summary>
     /// IChangeSet is flawed because it automatically means allocations when enumerating.
     /// This extension is a crazy hack to cast to the concrete change set which means we no longer allocate
-    /// as  change set now inherits from List which has allocation free enumerations.
+    /// as change set now inherits from List which has allocation free enumerations.
     ///
-    /// IChangeSet will be removed in V7 and instead Change sets will be used directly
+    /// IChangeSet will be removed in a future version and instead <see cref="ChangeSet{TObject, TKey}"/> will be used directly.
     ///
     /// In the mean time I am banking that no-one has implemented a custom change set - personally I think it is very unlikely.
     /// </summary>
-    /// <param name="changeSet">The source change set.</param>
+    /// <typeparam name="TObject">ChangeSet Object Type.</typeparam>
+    /// <typeparam name="TKey">ChangeSet Key Type.</typeparam>
+    /// <param name="changeSet">ChangeSet to be converted.</param>
+    /// <returns>Concrete Instance of the ChangeSet.</returns>
+    /// <exception cref="NotSupportedException">A custom implementation was found.</exception>
     public static ChangeSet<TObject, TKey> ToConcreteType<TObject, TKey>(this IChangeSet<TObject, TKey> changeSet)
         where TObject : notnull
-        where TKey : notnull => (ChangeSet<TObject, TKey>)changeSet;
+        where TKey : notnull =>
+            changeSet as ChangeSet<TObject, TKey> ?? throw new NotSupportedException("Dynamic Data does not support a custom implementation of IChangeSet");
+
+    /// <summary>
+    /// SortedChangeSet version of <see cref="ToConcreteType{TObject, TKey}(IChangeSet{TObject, TKey})"/>.
+    /// </summary>
+    /// <typeparam name="TObject">ChangeSet Object Type.</typeparam>
+    /// <typeparam name="TKey">ChangeSet Key Type.</typeparam>
+    /// <param name="changeSet">ChangeSet to be converted.</param>
+    /// <returns>Concrete Instance of the ChangeSet.</returns>
+    /// <exception cref="NotSupportedException">A custom implementation was found.</exception>
+    public static SortedChangeSet<TObject, TKey> ToConcreteType<TObject, TKey>(this ISortedChangeSet<TObject, TKey> changeSet)
+        where TObject : notnull
+        where TKey : notnull =>
+            changeSet as SortedChangeSet<TObject, TKey> ?? throw new NotSupportedException("Dynamic Data does not support a custom implementation of IChangeSet");
 }

--- a/src/DynamicData/Cache/CacheChangeSetEx.cs
+++ b/src/DynamicData/Cache/CacheChangeSetEx.cs
@@ -24,17 +24,4 @@ internal static class CacheChangeSetEx
         where TObject : notnull
         where TKey : notnull =>
             changeSet as ChangeSet<TObject, TKey> ?? throw new NotSupportedException("Dynamic Data does not support a custom implementation of IChangeSet");
-
-    /// <summary>
-    /// SortedChangeSet version of <see cref="ToConcreteType{TObject, TKey}(IChangeSet{TObject, TKey})"/>.
-    /// </summary>
-    /// <typeparam name="TObject">ChangeSet Object Type.</typeparam>
-    /// <typeparam name="TKey">ChangeSet Key Type.</typeparam>
-    /// <param name="changeSet">ChangeSet to be converted.</param>
-    /// <returns>Concrete Instance of the ChangeSet.</returns>
-    /// <exception cref="NotSupportedException">A custom implementation was found.</exception>
-    public static SortedChangeSet<TObject, TKey> ToConcreteType<TObject, TKey>(this ISortedChangeSet<TObject, TKey> changeSet)
-        where TObject : notnull
-        where TKey : notnull =>
-            changeSet as SortedChangeSet<TObject, TKey> ?? throw new NotSupportedException("Dynamic Data does not support a custom implementation of IChangeSet");
 }

--- a/src/DynamicData/Cache/Internal/AbstractFilter.cs
+++ b/src/DynamicData/Cache/Internal/AbstractFilter.cs
@@ -59,11 +59,11 @@ internal abstract class AbstractFilter<TObject, TKey> : IFilter<TObject, TKey>
 
     public IChangeSet<TObject, TKey> Update(IChangeSet<TObject, TKey> updates)
     {
-        var withFilter = GetChangesWithFilter(updates);
+        var withFilter = GetChangesWithFilter(updates.ToConcreteType());
         return ProcessResult(withFilter);
     }
 
-    protected abstract IEnumerable<UpdateWithFilter> GetChangesWithFilter(IChangeSet<TObject, TKey> updates);
+    protected abstract IEnumerable<UpdateWithFilter> GetChangesWithFilter(ChangeSet<TObject, TKey> updates);
 
     protected abstract IEnumerable<Change<TObject, TKey>> Refresh(IEnumerable<KeyValuePair<TKey, TObject>> items, Func<KeyValuePair<TKey, TObject>, Optional<Change<TObject, TKey>>> factory);
 

--- a/src/DynamicData/Cache/Internal/Cache.cs
+++ b/src/DynamicData/Cache/Internal/Cache.cs
@@ -47,7 +47,7 @@ internal class Cache<TObject, TKey> : ICache<TObject, TKey>
             throw new ArgumentNullException(nameof(changes));
         }
 
-        foreach (var item in changes)
+        foreach (var item in changes.ToConcreteType())
         {
             switch (item.Reason)
             {

--- a/src/DynamicData/Cache/Internal/Cast.cs
+++ b/src/DynamicData/Cache/Internal/Cast.cs
@@ -30,7 +30,7 @@ internal class Cast<TSource, TKey, TDestination>
         return _source.Select(
             changes =>
             {
-                var transformed = changes.Select(change => new Change<TDestination, TKey>(change.Reason, change.Key, _converter(change.Current), change.Previous.Convert(_converter), change.CurrentIndex, change.PreviousIndex));
+                var transformed = changes.ToConcreteType().Select(change => new Change<TDestination, TKey>(change.Reason, change.Key, _converter(change.Current), change.Previous.Convert(_converter), change.CurrentIndex, change.PreviousIndex));
                 return new ChangeSet<TDestination, TKey>(transformed);
             });
     }

--- a/src/DynamicData/Cache/Internal/Combiner.cs
+++ b/src/DynamicData/Cache/Internal/Combiner.cs
@@ -106,7 +106,7 @@ internal sealed class Combiner<TObject, TKey>
     private IChangeSet<TObject, TKey> UpdateCombined(IChangeSet<TObject, TKey> updates)
     {
         // child caches have been updated before we reached this point.
-        foreach (var update in updates)
+        foreach (var update in updates.ToConcreteType())
         {
             TKey key = update.Key;
             switch (update.Reason)

--- a/src/DynamicData/Cache/Internal/DisposeMany.cs
+++ b/src/DynamicData/Cache/Internal/DisposeMany.cs
@@ -49,7 +49,7 @@ internal sealed class DisposeMany<TObject, TKey>
 
     private void RegisterForRemoval(IChangeSet<TObject, TKey> changes, Cache<TObject, TKey> cache)
     {
-        changes.ForEach(
+        changes.ToConcreteType().ForEach(
             change =>
             {
                 switch (change.Reason)

--- a/src/DynamicData/Cache/Internal/IndexCalculator.cs
+++ b/src/DynamicData/Cache/Internal/IndexCalculator.cs
@@ -47,7 +47,7 @@ internal sealed class IndexCalculator<TObject, TKey>
         var result = new List<Change<TObject, TKey>>(changes.Count);
         var refreshes = new List<Change<TObject, TKey>>(changes.Refreshes);
 
-        foreach (var u in changes)
+        foreach (var u in changes.ToConcreteType())
         {
             var current = new KeyValuePair<TKey, TObject>(u.Key, u.Current);
 

--- a/src/DynamicData/Cache/Internal/RemoveKeyEnumerator.cs
+++ b/src/DynamicData/Cache/Internal/RemoveKeyEnumerator.cs
@@ -36,7 +36,7 @@ internal class RemoveKeyEnumerator<TObject, TKey> : IEnumerable<Change<TObject>>
     /// </returns>
     public IEnumerator<Change<TObject>> GetEnumerator()
     {
-        foreach (var change in _source)
+        foreach (var change in _source.ToConcreteType())
         {
             switch (change.Reason)
             {

--- a/src/DynamicData/Cache/Internal/TransformMany.cs
+++ b/src/DynamicData/Cache/Internal/TransformMany.cs
@@ -207,7 +207,7 @@ internal class TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>
 
         public IEnumerator<Change<TDestination, TDestinationKey>> GetEnumerator()
         {
-            foreach (var change in _changes)
+            foreach (var change in _changes.ToConcreteType())
             {
                 switch (change.Reason)
                 {

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -6201,7 +6201,7 @@ public static class ObservableCacheEx
 
         IEnumerable<Change<TObject, TKey>> ReplaceMoves(IChangeSet<TObject, TKey> items)
         {
-            foreach (var change in items.ToConcreteType()))
+            foreach (var change in items.ToConcreteType())
             {
                 if (change.Reason == ChangeReason.Moved)
                 {

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -14,6 +14,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 using DynamicData.Binding;
+using DynamicData.Cache;
 using DynamicData.Cache.Internal;
 using DynamicData.Kernel;
 
@@ -1057,7 +1058,7 @@ public static class ObservableCacheEx
         return source.Do(
             changes =>
             {
-                foreach (var item in changes)
+                foreach (var item in changes.ToConcreteType())
                 {
                     switch (item.Reason)
                     {
@@ -5996,7 +5997,7 @@ public static class ObservableCacheEx
 
         IEnumerable<Change<TObject, TKey>> ReplaceMoves(IChangeSet<TObject, TKey> items)
         {
-            foreach (var change in items)
+            foreach (var change in items.ToConcreteType()))
             {
                 if (change.Reason == ChangeReason.Moved)
                 {

--- a/src/DynamicData/List/Linq/AddKeyEnumerator.cs
+++ b/src/DynamicData/List/Linq/AddKeyEnumerator.cs
@@ -30,7 +30,7 @@ internal class AddKeyEnumerator<TObject, TKey> : IEnumerable<Change<TObject, TKe
     /// </returns>
     public IEnumerator<Change<TObject, TKey>> GetEnumerator()
     {
-        foreach (var change in _source)
+        foreach (var change in _source.ToConcreteType())
         {
             switch (change.Reason)
             {

--- a/src/DynamicData/List/Linq/AddKeyEnumerator.cs
+++ b/src/DynamicData/List/Linq/AddKeyEnumerator.cs
@@ -30,7 +30,7 @@ internal class AddKeyEnumerator<TObject, TKey> : IEnumerable<Change<TObject, TKe
     /// </returns>
     public IEnumerator<Change<TObject, TKey>> GetEnumerator()
     {
-        foreach (var change in _source.ToConcreteType())
+        foreach (var change in _source)
         {
             switch (change.Reason)
             {

--- a/src/DynamicData/Platforms/net45/PFilter.cs
+++ b/src/DynamicData/Platforms/net45/PFilter.cs
@@ -51,7 +51,7 @@ namespace DynamicData.PLinq
                 _parallelisationOptions = parallelisationOptions;
             }
 
-            protected override IEnumerable<UpdateWithFilter> GetChangesWithFilter(IChangeSet<TObject, TKey> updates)
+            protected override IEnumerable<UpdateWithFilter> GetChangesWithFilter(ChangeSet<TObject, TKey> updates)
             {
                 if (updates.ShouldParallelise(_parallelisationOptions))
                 {


### PR DESCRIPTION
## Description

This PR continues to effort to replace `IChangeSet<TObject, TKey>` with `ChangeSet<TObject, TKey>` in order to avoid allocations that can take place when enumerating with the former instead of the latter.

- Updates `ToConcreteType` to throw an exception if a non-ChangeSet implementation of IChangeSet is encountered
- Changes anywhere enumeration would happen using IChangeSet to invoke `ToConcreteType` so that it is done with `ChangeSet` instead.
- When possible, `IChangeSet` was completely replaced with `ChangeSet` in order to ensure more consistent use and reduce the number of places that `ToConcreteType` needs to be invoked explicitly