### PR TITLE
Cleanup fix for `.DisposeMany()`

### DIFF
--- a/src/DynamicData.Tests/Cache/DisposeManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/DisposeManyFixture.cs
@@ -153,6 +153,23 @@ public sealed class DisposeManyFixture : IDisposable
         _results.Data.Items.All(item => item.IsDisposed).Should().BeTrue("items remaining in the list should be disposed");
     }
 
+    [Fact]
+    public void RemainingItemsAreDisposedAfterUnsubscription()
+    {
+        var items = new[]
+        {
+            new DisposableObject(1),
+            new DisposableObject(2),
+            new DisposableObject(3)
+        };
+
+        _itemsSource.AddOrUpdate(items);
+
+        _results.Dispose();
+
+        items.All(item => item.IsDisposed).Should().BeTrue("Items remaining in the list should be disposed");
+    }
+
     private class DisposableObject : IDisposable
     {
         public DisposableObject(int id)

--- a/src/DynamicData.Tests/List/DisposeManyFixture.cs
+++ b/src/DynamicData.Tests/List/DisposeManyFixture.cs
@@ -140,6 +140,23 @@ public sealed class DisposeManyFixture : IDisposable
         _results.Data.Items.All(item => item.IsDisposed).Should().BeTrue("Items remaining in the list should be disposed");
     }
 
+    [Fact]
+    public void RemainingItemsAreDisposedAfterUnsubscription()
+    {
+        var items = new[]
+        {
+            new DisposableObject(1),
+            new DisposableObject(2),
+            new DisposableObject(3)
+        };
+
+        _itemsSource.AddRange(items);
+
+        _results.Dispose();
+
+        items.All(item => item.IsDisposed).Should().BeTrue("Items remaining in the list should be disposed");
+    }
+
     private class DisposableObject : IDisposable
     {
         public DisposableObject(int id)

--- a/src/DynamicData/Cache/Internal/DisposeMany.cs
+++ b/src/DynamicData/Cache/Internal/DisposeMany.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace DynamicData.Cache.Internal;
@@ -16,42 +17,53 @@ internal sealed class DisposeMany<TObject, TKey>(IObservable<IChangeSet<TObject,
     public IObservable<IChangeSet<TObject, TKey>> Run()
         => Observable.Create<IChangeSet<TObject, TKey>>(observer =>
         {
+            // Will be locking on cachedItems directly, instead of using an anonymous gate object. This is acceptable, since it's a privately-held object, there's no risk of deadlock from other consumers locking on it.
             var cachedItems = new Dictionary<TKey, TObject>();
 
-            return _source.SubscribeSafe(Observer.Create<IChangeSet<TObject, TKey>>(
-                onNext: changeSet =>
-                {
-                    observer.OnNext(changeSet);
-
-                    foreach (var change in changeSet.ToConcreteType())
+            var sourceSubscription = _source
+                .Synchronize(cachedItems)
+                .SubscribeSafe(Observer.Create<IChangeSet<TObject, TKey>>(
+                    onNext: changeSet =>
                     {
-                        switch (change.Reason)
+                        observer.OnNext(changeSet);
+
+                        foreach (var change in changeSet.ToConcreteType())
                         {
-                            case ChangeReason.Update:
-                                if (change.Previous.HasValue && !EqualityComparer<TObject>.Default.Equals(change.Current, change.Previous.Value))
-                                    (change.Previous.Value as IDisposable)?.Dispose();
-                                break;
+                            switch (change.Reason)
+                            {
+                                case ChangeReason.Update:
+                                    if (change.Previous.HasValue && !EqualityComparer<TObject>.Default.Equals(change.Current, change.Previous.Value))
+                                        (change.Previous.Value as IDisposable)?.Dispose();
+                                    break;
 
-                            case ChangeReason.Remove:
-                                (change.Current as IDisposable)?.Dispose();
-                                break;
+                                case ChangeReason.Remove:
+                                    (change.Current as IDisposable)?.Dispose();
+                                    break;
+                            }
                         }
-                    }
 
-                    cachedItems.Clone(changeSet);
-                },
-                onError: error =>
-                {
-                    observer.OnError(error);
+                        cachedItems.Clone(changeSet);
+                    },
+                    onError: error =>
+                    {
+                        observer.OnError(error);
 
+                        ProcessFinalization(cachedItems);
+                    },
+                    onCompleted: () =>
+                    {
+                        observer.OnCompleted();
+
+                        ProcessFinalization(cachedItems);
+                    }));
+
+            return Disposable.Create(() =>
+            {
+                sourceSubscription.Dispose();
+
+                lock (cachedItems)
                     ProcessFinalization(cachedItems);
-                },
-                onCompleted: () =>
-                {
-                    observer.OnCompleted();
-
-                    ProcessFinalization(cachedItems);
-                }));
+            });
         });
 
     private static void ProcessFinalization(Dictionary<TKey, TObject> cachedItems)


### PR DESCRIPTION
Fixed that `.DisposeMany()` was not disposing items after downstream-teardown of the stream, I.E. unsubscription.

I was mistaken that `onCompleted` propagates to upstream observers. The mechanism for detecting downstream completion is the `IDisposable` that each subscription returns.