### PR TITLE
SourceList Overloads for MergeChangeSets for Cache ChangeSets

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,3 +1,5 @@
-coverage:
+codecov:
+  coverage:
   status:           #Code coverage status will be posted to pull requests based on targets defined below.
     comments: off   #Optional. Details are off by default.
+  flags: []

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet6_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet6_0.verified.txt
@@ -2080,7 +2080,13 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>>> source, System.Collections.Generic.IComparer<TObject> comparer)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<TDestination> MergeMany<T, TDestination>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, System.IObservable<TDestination>> observableSelector)

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet6_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet6_0.verified.txt
@@ -2077,6 +2077,12 @@ namespace DynamicData
             where TGroupKey :  notnull { }
         public static System.IObservable<System.Collections.Generic.IEnumerable<T>> LimitSizeTo<T>(this DynamicData.ISourceList<T> source, int sizeLimit, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where T :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IComparer<TObject> comparer)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<TDestination> MergeMany<T, TDestination>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, System.IObservable<TDestination>> observableSelector)
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TDestination, TDestinationKey>(this System.IObservable<DynamicData.IChangeSet<TObject>> source, System.Func<TObject, System.IObservable<DynamicData.IChangeSet<TDestination, TDestinationKey>>> observableSelector, System.Collections.Generic.IComparer<TDestination> comparer)

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet7_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet7_0.verified.txt
@@ -2080,7 +2080,13 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>>> source, System.Collections.Generic.IComparer<TObject> comparer)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<TDestination> MergeMany<T, TDestination>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, System.IObservable<TDestination>> observableSelector)

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet7_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet7_0.verified.txt
@@ -2077,6 +2077,12 @@ namespace DynamicData
             where TGroupKey :  notnull { }
         public static System.IObservable<System.Collections.Generic.IEnumerable<T>> LimitSizeTo<T>(this DynamicData.ISourceList<T> source, int sizeLimit, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where T :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IComparer<TObject> comparer)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<TDestination> MergeMany<T, TDestination>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, System.IObservable<TDestination>> observableSelector)
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TDestination, TDestinationKey>(this System.IObservable<DynamicData.IChangeSet<TObject>> source, System.Func<TObject, System.IObservable<DynamicData.IChangeSet<TDestination, TDestinationKey>>> observableSelector, System.Collections.Generic.IComparer<TDestination> comparer)

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -2080,7 +2080,13 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>>> source, System.Collections.Generic.IComparer<TObject> comparer)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<TDestination> MergeMany<T, TDestination>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, System.IObservable<TDestination>> observableSelector)

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -2077,6 +2077,12 @@ namespace DynamicData
             where TGroupKey :  notnull { }
         public static System.IObservable<System.Collections.Generic.IEnumerable<T>> LimitSizeTo<T>(this DynamicData.ISourceList<T> source, int sizeLimit, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where T :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IComparer<TObject> comparer)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this DynamicData.IObservableList<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> source, System.Collections.Generic.IEqualityComparer<TObject>? equalityComparer = null, System.Collections.Generic.IComparer<TObject>? comparer = null)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<TDestination> MergeMany<T, TDestination>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, System.IObservable<TDestination>> observableSelector)
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TDestinationKey>> MergeManyChangeSets<TObject, TDestination, TDestinationKey>(this System.IObservable<DynamicData.IChangeSet<TObject>> source, System.Func<TObject, System.IObservable<DynamicData.IChangeSet<TDestination, TDestinationKey>>> observableSelector, System.Collections.Generic.IComparer<TDestination> comparer)

--- a/src/DynamicData.Tests/List/MergeManyCacheChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyCacheChangeSetsFixture.cs
@@ -49,6 +49,8 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var nullChangeSetObs = (IObservable<IChangeSet<int>>)null!;
         var emptySelector = new Func<int, IObservable<IChangeSet<string, string>>>(i => Observable.Empty<IChangeSet<string, string>>());
         var nullSelector = (Func<int, IObservable<IChangeSet<string, string>>>)null!;
+        var nullListOfCacheChangeSets = (ISourceList<IObservable<IChangeSet<string, string>>>)null!;
+        var emptyListOfCacheChangeSets = new SourceList<IObservable<IChangeSet<string, string>>>();
         var nullChildComparer = (IComparer<string>)null!;
         var emptyChildComparer = new NoOpComparer<string>() as IComparer<string>;
         var emptyEqualityComparer = new NoOpEqualityComparer<string>() as IEqualityComparer<string>;
@@ -59,21 +61,27 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var actionComparer0 = () => nullChangeSetObs.MergeManyChangeSets(emptySelector, comparer: emptyChildComparer);
         var actionComparer1 = () => emptyChangeSetObs.MergeManyChangeSets(nullSelector, comparer: emptyChildComparer);
         var actionComparer2 = () => emptyChangeSetObs.MergeManyChangeSets(emptySelector, comparer: nullChildComparer);
+        var actionMergeChangeSets0 = () => nullListOfCacheChangeSets.MergeChangeSets(comparer: emptyChildComparer);
+        var actionMergeChangeSets1 = () => emptyListOfCacheChangeSets.MergeChangeSets(comparer: nullChildComparer);
 
         // then
         emptyChangeSetObs.Should().NotBeNull();
         emptyChildComparer.Should().NotBeNull();
         emptyEqualityComparer.Should().NotBeNull();
         emptySelector.Should().NotBeNull();
+        emptyListOfCacheChangeSets.Should().NotBeNull();
         nullChangeSetObs.Should().BeNull();
         nullChildComparer.Should().BeNull();
         nullSelector.Should().BeNull();
+        nullListOfCacheChangeSets.Should().BeNull();
 
         actionDefault0.Should().Throw<ArgumentNullException>();
         actionDefault1.Should().Throw<ArgumentNullException>();
         actionComparer0.Should().Throw<ArgumentNullException>();
         actionComparer1.Should().Throw<ArgumentNullException>();
         actionComparer2.Should().Throw<ArgumentNullException>();
+        actionMergeChangeSets0.Should().Throw<ArgumentNullException>();
+        actionMergeChangeSets1.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
@@ -706,6 +714,29 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
 
         // then
         receivedError.Should().Be(expectedError);
+    }
+
+    [Fact]
+    public void SourceListMergeCacheChangeSets()
+    {
+        // having
+        var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
+        using var changeSetList = _marketList.Connect().Transform(m => m.LatestPrices).AsObservableList();
+        using var results = changeSetList.MergeChangeSets(MarketPrice.EqualityComparer).AsAggregator();
+        _marketList.AddRange(markets);
+        markets.ForEach((m, index) => m.AddUniquePrices(index, PricesPerMarket, ItemIdStride, GetRandomPrice));
+
+        // when
+        markets.ForEach(m => _marketList.Remove(m));
+
+        // then
+        _marketListResults.Data.Count.Should().Be(0);
+        markets.Sum(m => m.PricesCache.Count).Should().Be(MarketCount * PricesPerMarket);
+        results.Data.Count.Should().Be(0);
+        results.Messages.Count.Should().Be(MarketCount * 2);
+        results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
+        results.Summary.Overall.Removes.Should().Be(MarketCount * PricesPerMarket);
+        results.Summary.Overall.Updates.Should().Be(0);
     }
 
     public void Dispose()

--- a/src/DynamicData.Tests/List/MergeManyCacheChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyCacheChangeSetsFixture.cs
@@ -62,7 +62,6 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         var actionComparer1 = () => emptyChangeSetObs.MergeManyChangeSets(nullSelector, comparer: emptyChildComparer);
         var actionComparer2 = () => emptyChangeSetObs.MergeManyChangeSets(emptySelector, comparer: nullChildComparer);
         var actionMergeChangeSets0 = () => nullListOfCacheChangeSets.MergeChangeSets(comparer: emptyChildComparer);
-        var actionMergeChangeSets1 = () => emptyListOfCacheChangeSets.MergeChangeSets(comparer: nullChildComparer);
 
         // then
         emptyChangeSetObs.Should().NotBeNull();
@@ -80,8 +79,6 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         actionComparer0.Should().Throw<ArgumentNullException>();
         actionComparer1.Should().Throw<ArgumentNullException>();
         actionComparer2.Should().Throw<ArgumentNullException>();
-        actionMergeChangeSets0.Should().Throw<ArgumentNullException>();
-        actionMergeChangeSets1.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1069,6 +1069,43 @@ public static class ObservableListEx
     }
 
     /// <summary>
+    /// Merges each Observable ChangeSet in the ObservableList into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the object key.</typeparam>
+    /// <param name="source">The SourceList of Observable Cache ChangeSets.</param>
+    /// <param name="comparer"><see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> source, IComparer<TObject> comparer)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+        return source.MergeChangeSets(comparer: comparer);
+    }
+
+    /// <summary>
+    /// Merges each Observable ChangeSet in the ObservableList into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the object key.</typeparam>
+    /// <param name="source">The SourceList of Observable Cache ChangeSets.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> source, IEqualityComparer<TObject>? equalityComparer = null, IComparer<TObject>? comparer = null)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+
+        return source.Connect().MergeManyChangeSets(static src => src, equalityComparer, comparer);
+    }
+
+    /// <summary>
     /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TDestination, TDestinationKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1081,13 +1081,11 @@ public static class ObservableListEx
         where TObject : notnull
         where TKey : notnull
     {
-        if (comparer == null) throw new ArgumentNullException(nameof(comparer));
-
-        return source.MergeChangeSets(comparer: comparer);
+        return source.Connect().MergeChangeSets(comparer: comparer);
     }
 
     /// <summary>
-    /// Merges each Observable ChangeSet in the ObservableList into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Merges all of the Cache Observable ChangeSets into a single ChangeSets while correctly handling multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the object key.</typeparam>
@@ -1100,9 +1098,44 @@ public static class ObservableListEx
         where TObject : notnull
         where TKey : notnull
     {
+        return source.Connect().MergeChangeSets(equalityComparer, comparer);
+    }
+
+    /// <summary>
+    /// Merges all of the Cache Observable ChangeSets into a single ChangeSets while correctly handling multiple Keys and removal of the parent items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the object key.</typeparam>
+    /// <param name="source">The List Observable ChangeSet of Cache Observable ChangeSets.</param>
+    /// <param name="comparer"><see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this IObservable<IChangeSet<IObservable<IChangeSet<TObject, TKey>>>> source, IComparer<TObject> comparer)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+        return source.MergeChangeSets(comparer: comparer);
+    }
+
+    /// <summary>
+    /// Merges each Observable ChangeSet in the ObservableList into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the object key.</typeparam>
+    /// <param name="source">The List Observable ChangeSet of Cache Observable ChangeSets.</param>
+    /// <param name="equalityComparer">Optional <see cref="IEqualityComparer{T}"/> instance to determine if two elements are the same.</param>
+    /// <param name="comparer">Optional <see cref="IComparer{T}"/> instance to determine which element to emit if the same key is emitted from multiple child changesets.</param>
+    /// <returns>The result from merging the child changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this IObservable<IChangeSet<IObservable<IChangeSet<TObject, TKey>>>> source, IEqualityComparer<TObject>? equalityComparer = null, IComparer<TObject>? comparer = null)
+        where TObject : notnull
+        where TKey : notnull
+    {
         if (source == null) throw new ArgumentNullException(nameof(source));
 
-        return source.Connect().MergeManyChangeSets(static src => src, equalityComparer, comparer);
+        return source.MergeManyChangeSets(static src => src, equalityComparer, comparer);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Adds overloads for `ISourceList` to enable using `MergeChangeSets` for Cache Observable ChangeSets just like one can invoke similar to IEnumerable<IObservable<IChangeSet<TObject, TKey>>>`.

Just some syntactic sugar that I think would be helpful for some users to find the functionality.

It also supports `IObservable<IChangeSet<IObservable<IChangeSet<TObject, TKey>>>>` for list changesets of cache changesets.