### PR TITLE
Re-design for `ToObservableChangeSet()`

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet6_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet6_0.verified.txt
@@ -614,6 +614,7 @@ namespace DynamicData
         public static readonly DynamicData.IChangeSet<T> Empty;
         public ChangeSet() { }
         public ChangeSet(System.Collections.Generic.IEnumerable<DynamicData.Change<T>> items) { }
+        public ChangeSet(int capacity) { }
         public int Adds { get; }
         public int Moves { get; }
         public int Refreshes { get; }

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet7_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet7_0.verified.txt
@@ -614,6 +614,7 @@ namespace DynamicData
         public static readonly DynamicData.IChangeSet<T> Empty;
         public ChangeSet() { }
         public ChangeSet(System.Collections.Generic.IEnumerable<DynamicData.Change<T>> items) { }
+        public ChangeSet(int capacity) { }
         public int Adds { get; }
         public int Moves { get; }
         public int Refreshes { get; }

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -614,6 +614,7 @@ namespace DynamicData
         public static readonly DynamicData.IChangeSet<T> Empty;
         public ChangeSet() { }
         public ChangeSet(System.Collections.Generic.IEnumerable<DynamicData.Change<T>> items) { }
+        public ChangeSet(int capacity) { }
         public int Adds { get; }
         public int Moves { get; }
         public int Refreshes { get; }

--- a/src/DynamicData.Tests/Cache/ToObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Cache/ToObservableChangeSetFixture.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -15,6 +17,63 @@ namespace DynamicData.Tests.Cache;
 public class ToObservableChangeSetFixture
     : ReactiveTest
 {
+    [Fact]
+    public void NextItemToExpireIsReplaced_ExpirationIsRescheduledIfNeeded()
+    {
+        using var source = new Subject<Item>();
+
+        var scheduler = new TestScheduler();
+
+        using var results = new ChangeSetAggregator<Item, int>(source
+            .ToObservableChangeSet(
+                keySelector: static item => item.Id,
+                expireAfter: static item => item.Lifetime,
+                scheduler: scheduler));
+
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        source.OnNext(item1);
+        scheduler.AdvanceBy(1);
+
+        // Extend the expiration to a later time
+        var item2 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(20) };
+        source.OnNext(item2);
+        scheduler.AdvanceBy(1);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(2, "2 items were emitted");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2 }, "2 items were emitted, 1 of which was a replacement");
+
+        scheduler.AdvanceTo(TimeSpan.FromMilliseconds(10).Ticks);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(2, "no changes should have occurred, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2 }, "no changes should have occurred, since the last check");
+
+        // Shorten the expiration to an earlier time (5ms from now is 15m total)
+        var item3 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(5) };
+        source.OnNext(item3);
+        scheduler.AdvanceBy(1);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "1 item was emitted, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item3 }, "1 item was replaced, since the last check");
+
+        // One more update with no changes to the expiration
+        var item4 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(5) };
+        source.OnNext(item4);
+        scheduler.AdvanceBy(1);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(4, "1 item was emitted, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item4 }, "1 item was replaced, since the last check");
+
+        scheduler.AdvanceTo(TimeSpan.FromMilliseconds(15).Ticks);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(5, "1 expiration should have occurred, since the last check");
+        results.Data.Items.Should().BeEmpty("the last item should have expired, since the last check");
+    }
+
     [Fact]
     public void ExpirationIsGiven_RemovalIsScheduled()
     {
@@ -113,14 +172,87 @@ public class ToObservableChangeSetFixture
     }
 
     [Fact]
+    public void ItemIsEvictedBeforeExpiration_ExpirationIsCancelled()
+    {
+        using var source = new Subject<IEnumerable<Item>>();
+
+        var scheduler = new TestScheduler();
+
+        using var results = new ChangeSetAggregator<Item, int>(source
+            .ToObservableChangeSet(
+                keySelector: static item => item.Id,
+                expireAfter: static item => item.Lifetime,
+                limitSizeTo: 3,
+                scheduler: scheduler));
+
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item2 = new Item() { Id = 2, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item3 = new Item() { Id = 3, Lifetime = TimeSpan.FromMilliseconds(10) };
+        source.OnNext(new[] { item1, item2, item3 });
+        scheduler.AdvanceBy(1);
+
+        var item4 = new Item() { Id = 4 };
+        source.OnNext(new[] { item4 });
+        scheduler.AdvanceBy(1);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(2, "2 item sets were emitted");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2, item3, item4 }, "the size limit of the collection was 3");
+
+        scheduler.AdvanceTo(TimeSpan.FromMilliseconds(10).Ticks);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "2 items should have expired, at the same time, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item4 }, "2 items should have expired, since the last check");
+    }
+
+    [Fact]
+    public void ItemExpiresBeforeEviction_EvictionIsSkipped()
+    {
+        using var source = new Subject<IEnumerable<Item>>();
+
+        var scheduler = new TestScheduler();
+
+        using var results = new ChangeSetAggregator<Item, int>(source
+            .ToObservableChangeSet(
+                keySelector: static item => item.Id,
+                expireAfter: static item => item.Lifetime,
+                limitSizeTo: 3,
+                scheduler: scheduler));
+
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item2 = new Item() { Id = 2 };
+        var item3 = new Item() { Id = 3 };
+        source.OnNext(new[] { item1, item2, item3 });
+        scheduler.AdvanceBy(1);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(1, "1 item set was emitted");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item1, item2, item3 }, "the size limit of the collection was 3");
+
+        scheduler.AdvanceTo(TimeSpan.FromMilliseconds(10).Ticks);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(2, "1 expiration should have occurred, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2, item3 }, "item #1 should have expired");
+
+        var item4 = new Item() { Id = 4 };
+        source.OnNext(new[] { item4 });
+        scheduler.AdvanceBy(1);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "1 item set was emitted, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2, item3, item4 }, "no eviction should have occurred");
+    }
+
+    [Fact]
     public void KeySelectorIsNull_ThrowsException()
         => FluentActions.Invoking(() => ObservableCacheEx.ToObservableChangeSet<object, object>(
                 source: new Subject<object>(),
                 keySelector: null!))
             .Should().Throw<ArgumentNullException>();
 
-    [Fact(Skip = "Outstanding bug, error re-throws, instead of emitting on the stream")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Bug to be fixed")]
+    [Fact]
     public void KeySelectorThrows_SubscriptionReceivesError()
     {
         using var source = new Subject<Item>();
@@ -142,8 +274,31 @@ public class ToObservableChangeSetFixture
         results.Data.Items.Should().BeEquivalentTo(new[] { item1 }, "1 item was emitted before an error occurred");
     }
 
-    [Fact(Skip = "Outstanding bug, completion is not forwarded")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Bug to be fixed")]
+    [Fact]
+    public void LimitToSizeIs0_ChangeSetsAreEmpty()
+    {
+        using var source = new Subject<Item>();
+
+        using var results = new ChangeSetAggregator<Item, int>(source
+            .ToObservableChangeSet(
+                keySelector: static item => item.Id,
+                limitSizeTo: 0));
+
+        var item1 = new Item() { Id = 1 };
+        source.OnNext(item1);
+
+        var item2 = new Item() { Id = 2 };
+        source.OnNext(item2);
+
+        var item3 = new Item() { Id = 3 };
+        source.OnNext(item3);
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "3 items were emitted");
+        results.Data.Items.Should().BeEmpty("the size limit of the collection was 0");
+    }
+
+    [Fact]
     public void RemovalsArePending_CompletionWaitsForRemovals()
     {
         using var source = new Subject<IEnumerable<Item>>();
@@ -164,19 +319,20 @@ public class ToObservableChangeSetFixture
 
         source.OnCompleted();
 
+        results.Error.Should().BeNull();
         results.Completed.Should().BeFalse("item removals have been scheduled, and not completed");
         results.Messages.Count.Should().Be(1, "1 item set was emitted");
         results.Data.Items.Should().BeEquivalentTo(new[] { item1, item2, item3 }, "3 items were emitted");
 
         scheduler.AdvanceTo(TimeSpan.FromMilliseconds(30).Ticks);
 
+        results.Error.Should().BeNull();
         results.Completed.Should().BeTrue("the source has completed, and no outstanding expirations remain");
         results.Messages.Count.Should().Be(3, "2 expirations should have occurred, since the last check");
         results.Data.Items.Should().BeEquivalentTo(new[] { item2 }, "3 items were emitted, and 2 should have expired");
     }
 
-    [Fact(Skip = "Outstanding bug, https://github.com/reactivemarbles/DynamicData/issues/635")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Bug to be fixed")]
+    [Fact]
     public void SourceCompletesImmediately_SubscriptionCompletes()
     {
         var item = new Item() { Id = 1 };
@@ -191,6 +347,7 @@ public class ToObservableChangeSetFixture
         using var results = new ChangeSetAggregator<Item, int>(source
             .ToObservableChangeSet(static item => item.Id));
 
+        results.Error.Should().BeNull();
         results.Completed.Should().BeTrue("the source has completed, and no outstanding expirations remain");
         results.Messages.Count.Should().Be(1, "1 item was emitted");
         results.Data.Items.Should().BeEquivalentTo(new[] { item }, "1 item was emitted");
@@ -246,12 +403,11 @@ public class ToObservableChangeSetFixture
         scheduler.AdvanceBy(1);
 
         results.Error.Should().BeNull();
-        results.Messages.Count.Should().Be(9, "6 item sets were emitted by the source, 3 of which triggered followup evictions");
+        results.Messages.Count.Should().Be(6, "6 item sets were emitted by the source");
         results.Data.Items.Should().BeEquivalentTo(new[] { item5, item6, item9, item10, item11 }, "the size limit of the collection was 5");
     }
 
-    [Fact(Skip = "Outstanding bug, notifications are not synchronized, initial item emits after error")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Bug to be fixed")]
+    [Fact]
     public void SourceErrorsImmediately_SubscriptionReceivesError()
     {
         var item = new Item() { Id = 1 };
@@ -321,6 +477,38 @@ public class ToObservableChangeSetFixture
                 source: null!,
                 keySelector: static item => item))
             .Should().Throw<ArgumentNullException>();
+
+    [Fact]
+    public void ThreadPoolSchedulerIsUsed_ExpirationIsThreadSafe()
+    {
+        var testDuration = TimeSpan.FromSeconds(1);
+        var maxItemLifetime = TimeSpan.FromMilliseconds(50);
+
+        using var source = new Subject<Item>();
+
+        using var results = new ChangeSetAggregator<Item, int>(source
+            .ToObservableChangeSet(
+                keySelector: static item => item.Id,
+                expireAfter: static item => item.Lifetime,
+                limitSizeTo: 1000,
+                scheduler: ThreadPoolScheduler.Instance));
+
+        var nextItemId = 1;
+        var rng = new Random(Seed: 1234567);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        while (stopwatch.Elapsed < testDuration)
+        {
+            source.OnNext(new()
+            {
+                Id = nextItemId++,
+                Lifetime = TimeSpan.FromMilliseconds(rng.Next(maxItemLifetime.Milliseconds + 1))
+            });
+        }
+
+        results.Error.Should().BeNull();
+    }
 
     public class Item
     {

--- a/src/DynamicData.Tests/List/ToObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/List/ToObservableChangeSetFixture.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-
-using DynamicData.Tests.Domain;
 
 using FluentAssertions;
 
@@ -29,27 +29,27 @@ public class ToObservableChangeSetFixture
                 expireAfter: static item => item.Lifetime,
                 scheduler: scheduler));
 
-        var item1 = new Item() { Lifetime = TimeSpan.FromMilliseconds(10) };
-        var item2 = new Item() { Lifetime = TimeSpan.FromMilliseconds(20) };
-        var item3 = new Item() { Lifetime = TimeSpan.FromMilliseconds(30) };
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item2 = new Item() { Id = 2, Lifetime = TimeSpan.FromMilliseconds(20) };
+        var item3 = new Item() { Id = 3, Lifetime = TimeSpan.FromMilliseconds(30) };
         source.OnNext(new[] { item1, item2, item3 });
         scheduler.AdvanceBy(1);
 
         // Item removals should batch to the closest prior millisecond.
         // This actually seems wrong to me, that for items to be removed earlier than asked for.
         // Should this maybe batch to the closest future millisecond, or just round to the nearest?
-        var item4 = new Item() { Lifetime = TimeSpan.FromMilliseconds(20.1) };
-        var item5 = new Item() { Lifetime = TimeSpan.FromMilliseconds(20.9) };
+        var item4 = new Item() { Id = 4, Lifetime = TimeSpan.FromMilliseconds(20.1) };
+        var item5 = new Item() { Id = 5, Lifetime = TimeSpan.FromMilliseconds(20.9) };
         source.OnNext(new[] { item4, item5 });
         scheduler.AdvanceBy(1);
 
         // Out-of-order removal
-        var item6 = new Item() { Lifetime = TimeSpan.FromMilliseconds(15) };
+        var item6 = new Item() { Id = 6, Lifetime = TimeSpan.FromMilliseconds(15) };
         source.OnNext(new[] { item6 });
         scheduler.AdvanceBy(1);
 
         // Non-expiring item
-        var item7 = new Item();
+        var item7 = new Item() { Id = 7 };
         source.OnNext(new[] { item7 });
         scheduler.AdvanceBy(1);
 
@@ -84,6 +84,101 @@ public class ToObservableChangeSetFixture
     }
 
     [Fact]
+    public void ItemIsEvictedBeforeExpiration_ExpirationIsCancelled()
+    {
+        using var source = new Subject<IEnumerable<Item>>();
+
+        var scheduler = new TestScheduler();
+
+        using var results = new ChangeSetAggregator<Item>(source
+            .ToObservableChangeSet(
+                expireAfter: static item => item.Lifetime,
+                limitSizeTo: 3,
+                scheduler: scheduler));
+
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item2 = new Item() { Id = 2, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item3 = new Item() { Id = 3, Lifetime = TimeSpan.FromMilliseconds(10) };
+        source.OnNext(new[] { item1, item2, item3 });
+        scheduler.AdvanceBy(1);
+
+        var item4 = new Item() {Id = 4 };
+        source.OnNext(new[] { item4 });
+        scheduler.AdvanceBy(1);
+
+        results.Exception.Should().BeNull();
+        results.Messages.Count.Should().Be(2, "2 item sets were emitted");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2, item3, item4 }, "the size limit of the collection was 3");
+
+        scheduler.AdvanceTo(TimeSpan.FromMilliseconds(10).Ticks);
+
+        results.Exception.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "2 items should have expired, at the same time, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item4 }, "2 items should have expired, since the last check");
+    }
+
+    [Fact]
+    public void ItemExpiresBeforeEviction_EvictionIsSkipped()
+    {
+        using var source = new Subject<IEnumerable<Item>>();
+
+        var scheduler = new TestScheduler();
+
+        using var results = new ChangeSetAggregator<Item>(source
+            .ToObservableChangeSet(
+                expireAfter: static item => item.Lifetime,
+                limitSizeTo: 3,
+                scheduler: scheduler));
+
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item2 = new Item() { Id = 2 };
+        var item3 = new Item() { Id = 3 };
+        source.OnNext(new[] { item1, item2, item3 });
+        scheduler.AdvanceBy(1);
+
+        results.Exception.Should().BeNull();
+        results.Messages.Count.Should().Be(1, "1 item set was emitted");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item1, item2, item3 }, "the size limit of the collection was 3");
+
+        scheduler.AdvanceTo(TimeSpan.FromMilliseconds(10).Ticks);
+
+        results.Exception.Should().BeNull();
+        results.Messages.Count.Should().Be(2, "1 expiration should have occurred, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2, item3 }, "item #1 should have expired");
+
+        var item4 = new Item() { Id = 4 };
+        source.OnNext(new[] { item4 });
+        scheduler.AdvanceBy(1);
+
+        results.Exception.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "1 item set was emitted, since the last check");
+        results.Data.Items.Should().BeEquivalentTo(new[] { item2, item3, item4 }, "no eviction should have occurred");
+    }
+
+    [Fact]
+    public void LimitToSizeIs0_ChangeSetsAreEmpty()
+    {
+        using var source = new Subject<Item>();
+
+        using var results = new ChangeSetAggregator<Item>(source
+            .ToObservableChangeSet(
+                limitSizeTo: 0));
+
+        var item1 = new Item() { Id = 1 };
+        source.OnNext(item1);
+
+        var item2 = new Item() { Id = 2 };
+        source.OnNext(item2);
+
+        var item3 = new Item() { Id = 3 };
+        source.OnNext(item3);
+
+        results.Exception.Should().BeNull();
+        results.Messages.Count.Should().Be(3, "3 items were emitted");
+        results.Data.Items.Should().BeEmpty("the size limit of the collection was 0");
+    }
+
+    [Fact]
     public void RemovalsArePending_CompletionWaitsForRemovals()
     {
         using var source = new Subject<IEnumerable<Item>>();
@@ -95,27 +190,28 @@ public class ToObservableChangeSetFixture
                 expireAfter: static item => item.Lifetime,
                 scheduler: scheduler));
 
-        var item1 = new Item() { Lifetime = TimeSpan.FromMilliseconds(10) };
-        var item2 = new Item();
-        var item3 = new Item() { Lifetime = TimeSpan.FromMilliseconds(30) };
+        var item1 = new Item() { Id = 1, Lifetime = TimeSpan.FromMilliseconds(10) };
+        var item2 = new Item() { Id = 2 };
+        var item3 = new Item() { Id = 3, Lifetime = TimeSpan.FromMilliseconds(30) };
         source.OnNext(new[] { item1, item2, item3 });
         scheduler.AdvanceBy(1);
 
         source.OnCompleted();
 
+        results.Exception.Should().BeNull();
         results.IsCompleted.Should().BeFalse("item removals have been scheduled, and not completed");
         results.Messages.Count.Should().Be(1, "1 item set was emitted");
         results.Data.Items.Should().BeEquivalentTo(new[] { item1, item2, item3 }, "3 items were emitted");
 
         scheduler.AdvanceTo(TimeSpan.FromMilliseconds(30).Ticks);
 
-        results.IsCompleted.Should().BeFalse("the source has completed, and no outstanding expirations remain");
+        results.Exception.Should().BeNull();
+        results.IsCompleted.Should().BeTrue("the source has completed, and no outstanding expirations remain");
         results.Messages.Count.Should().Be(3, "2 expirations should have occurred, since the last check");
         results.Data.Items.Should().BeEquivalentTo(new[] { item2 }, "3 items were emitted, and 2 should have expired");
     }
 
-    [Fact(Skip = "Outstanding bug, completions are not forwarded")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Bug to be fixed")]
+    [Fact]
     public void SourceCompletesImmediately_SubscriptionCompletes()
     {
         var item = new Item();
@@ -130,6 +226,7 @@ public class ToObservableChangeSetFixture
         using var results = new ChangeSetAggregator<Item>(source
             .ToObservableChangeSet());
 
+        results.Exception.Should().BeNull();
         results.IsCompleted.Should().BeTrue("the source has completed, and no outstanding expirations remain");
         results.Messages.Count.Should().Be(1, "1 item was emitted");
         results.Data.Items.Should().BeEquivalentTo(new[] { item }, "1 item was emitted");
@@ -144,22 +241,22 @@ public class ToObservableChangeSetFixture
             .ToObservableChangeSet(limitSizeTo: 4));
 
         // Populate enough initial items so that at least one item at the end never gets evicted
-        var item1 = new Item();
-        var item2 = new Item();
-        var item3 = new Item();
+        var item1 = new Item() { Id = 1 };
+        var item2 = new Item() { Id = 2 };
+        var item3 = new Item() { Id = 3 };
         source.OnNext(new[] { item1, item2, item3 });
 
         // Limit is reached
-        var item4 = new Item();
+        var item4 = new Item() { Id = 4 };
         source.OnNext(new[] { item4 });
 
         // New item exceeds the limit
-        var item5 = new Item();
+        var item5 = new Item() { Id = 5 };
         source.OnNext(new[] { item5 });
 
         // Multiple items exceed the limit
-        var item6 = new Item();
-        var item7 = new Item();
+        var item6 = new Item() { Id = 6 };
+        var item7 = new Item() { Id = 7 };
         source.OnNext(new[] { item6, item7 });
 
         results.Exception.Should().BeNull();
@@ -167,8 +264,7 @@ public class ToObservableChangeSetFixture
         results.Data.Items.Should().BeEquivalentTo(new[] { item4, item5, item6, item7 }, "the size limit of the collection was 4");
     }
 
-    [Fact(Skip = "Outstanding bug, notifications are not synchronized, initial item emits after error")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Bug to be fixed")]
+    [Fact]
     public void SourceErrorsImmediately_SubscriptionReceivesError()
     {
         var item = new Item();
@@ -197,13 +293,13 @@ public class ToObservableChangeSetFixture
         using var results = new ChangeSetAggregator<Item>(source
             .ToObservableChangeSet());
 
-        var item1 = new Item();
+        var item1 = new Item() { Id = 1 };
         source.OnNext(item1);
 
-        var item2 = new Item();
+        var item2 = new Item() { Id = 2 };
         source.OnNext(item2);
 
-        var item3 = new Item();
+        var item3 = new Item() { Id = 3 };
         source.OnNext(item3);
 
         results.Exception.Should().BeNull();
@@ -221,12 +317,12 @@ public class ToObservableChangeSetFixture
         using var results = new ChangeSetAggregator<Item>(source
             .ToObservableChangeSet());
 
-        var item1 = new Item();
-        var item2 = new Item();
+        var item1 = new Item() { Id = 1 };
+        var item2 = new Item() { Id = 2 };
         source.OnNext(new[] { item1, item2 });
 
-        var item3 = new Item();
-        var item4 = new Item();
+        var item3 = new Item() { Id = 3 };
+        var item4 = new Item() { Id = 4 };
         source.OnNext(new[] { item3, item4 });
 
         results.Exception.Should().BeNull();
@@ -239,10 +335,41 @@ public class ToObservableChangeSetFixture
         => FluentActions.Invoking(() => ObservableListEx.ToObservableChangeSet<object>(source: null!))
             .Should().Throw<ArgumentNullException>();
 
+    [Fact]
+    public void ThreadPoolSchedulerIsUsed_ExpirationIsThreadSafe()
+    {
+        var testDuration = TimeSpan.FromSeconds(1);
+        var maxItemLifetime = TimeSpan.FromMilliseconds(500);
+
+        using var source = new Subject<Item>();
+
+        using var results = new ChangeSetAggregator<Item>(source
+            .ToObservableChangeSet(
+                expireAfter: static item => item.Lifetime,
+                limitSizeTo: 1000,
+                scheduler: ThreadPoolScheduler.Instance));
+
+        var nextItemId = 1;
+        var rng = new Random(Seed: 1234567);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        while (stopwatch.Elapsed < testDuration)
+        {
+            source.OnNext(new()
+            {
+                Id = nextItemId++,
+                Lifetime = TimeSpan.FromMilliseconds(rng.Next(maxItemLifetime.Milliseconds + 1))
+            });
+        }
+
+        results.Exception.Should().BeNull();
+    }
+
     public class Item
     {
-        public Exception? Error { get; init; }
+        public int Id { get; set; }
 
-        public TimeSpan? Lifetime { get; init; }
+        public TimeSpan? Lifetime { get; set; }
     }
 }

--- a/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
@@ -400,42 +400,42 @@ internal class ToObservableChangeSet<TObject, TKey>
             _expirationState?.Queue.Clear();
         }
 
-        private struct ItemState
+        private readonly struct ItemState
         {
-            public DateTimeOffset? ExpireAt { get; set; }
+            public required DateTimeOffset? ExpireAt { get; init; }
 
-            public TObject Item { get; set; }
+            public required TObject Item { get; init; }
         }
 
-        private struct EvictionState
+        private readonly struct EvictionState
         {
-            public int LimitSizeTo { get; set; }
+            public required int LimitSizeTo { get; init; }
 
-            public Queue<TKey> Queue { get; set; }
+            public required Queue<TKey> Queue { get; init; }
         }
 
-        private struct Expiration
+        private readonly struct Expiration
         {
-            public DateTimeOffset ExpireAt { get; set; }
+            public required DateTimeOffset ExpireAt { get; init; }
 
-            public TKey Key { get; set; }
+            public required TKey Key { get; init; }
         }
 
-        private struct ExpirationState
+        private readonly struct ExpirationState
         {
-            public List<Change<TObject, TKey>> ChangesBuffer;
+            public required List<Change<TObject, TKey>> ChangesBuffer { get; init; }
 
-            public Func<TObject, TimeSpan?> ExpireAfter { get; set; }
+            public required Func<TObject, TimeSpan?> ExpireAfter { get; init; }
 
             // Potential performance improvement: Instead of List<T>, use PriorityQueue<T> available in .NET 6+, or an equivalent.
-            public List<Expiration> Queue { get; set; }
+            public required List<Expiration> Queue { get; init; }
         }
 
-        private struct ScheduledExpiration
+        private readonly struct ScheduledExpiration
         {
-            public IDisposable Cancellation { get; set; }
+            public required IDisposable Cancellation { get; init; }
 
-            public DateTimeOffset DueTime { get; set; }
+            public required DateTimeOffset DueTime { get; init; }
         }
     }
 }

--- a/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
@@ -115,7 +115,7 @@ internal class ToObservableChangeSet<TObject, TKey>
                         Queue = new()
                     };
 
-                _itemStatesByKey = new();
+                _itemStatesByKey = [];
             }
 
             _sourceSubscription = source
@@ -174,7 +174,7 @@ internal class ToObservableChangeSet<TObject, TKey>
                         _hasSourceCompleted = true;
 
                         // If there are pending expirations scheduled, wait to complete the stream until they're done
-                        if (_expirationState is null or { Queue: { Count: 0 } })
+                        if (_expirationState is null or { Queue.Count: 0 })
                             observer.OnCompleted();
                     }));
         }

--- a/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
@@ -2,107 +2,440 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace DynamicData.Cache.Internal;
 
-internal class ToObservableChangeSet<TObject, TKey>(IObservable<IEnumerable<TObject>> source,
-    Func<TObject, TKey> keySelector,
-    Func<TObject, TimeSpan?>? expireAfter,
-    int limitSizeTo,
-    IScheduler? scheduler = null)
+internal class ToObservableChangeSet<TObject, TKey>
     where TObject : notnull
     where TKey : notnull
 {
-    private readonly IObservable<IEnumerable<TObject>> _source = source ?? throw new ArgumentNullException(nameof(source));
-    private readonly Func<TObject, TKey> _keySelector = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
-    private readonly IScheduler _scheduler = scheduler ?? Scheduler.Default;
-
-    public ToObservableChangeSet(IObservable<TObject> source,
+    public ToObservableChangeSet(
+        IObservable<TObject> source,
         Func<TObject, TKey> keySelector,
         Func<TObject, TimeSpan?>? expireAfter,
         int limitSizeTo,
-        IScheduler? scheduler = null)
-        : this(source.Select(t => new[] { t }), keySelector, expireAfter, limitSizeTo, scheduler)
+        IScheduler? scheduler)
     {
+        _expireAfter = expireAfter;
+        _keySelector = keySelector;
+        _limitSizeTo = limitSizeTo;
+        _scheduler = scheduler ?? Scheduler.Default;
+
+        _source = Observable.Create<IEnumerable<TObject>>(observer =>
+        {
+            // Reusable buffer, to avoid allocating per-item
+            var buffer = new TObject[1];
+
+            return source.SubscribeSafe(Observer.Create<TObject>(
+                onNext: item =>
+                {
+                    buffer[0] = item;
+                    observer.OnNext(buffer);
+                },
+                onError: observer.OnError,
+                onCompleted: observer.OnCompleted));
+        });
     }
 
-    public IObservable<IChangeSet<TObject, TKey>> Run() => Observable.Create<IChangeSet<TObject, TKey>>(observer =>
-                                                                {
-                                                                    var locker = new object();
+    public ToObservableChangeSet(
+        IObservable<IEnumerable<TObject>> source,
+        Func<TObject, TKey> keySelector,
+        Func<TObject, TimeSpan?>? expireAfter,
+        int limitSizeTo,
+        IScheduler? scheduler)
+    {
+        _expireAfter = expireAfter;
+        _keySelector = keySelector;
+        _limitSizeTo = limitSizeTo;
+        _scheduler = scheduler ?? Scheduler.Default;
+        _source = source;
+    }
 
-                                                                    var dataSource = new SourceCache<TObject, TKey>(_keySelector);
+    public IObservable<IChangeSet<TObject, TKey>> Run()
+        => Observable.Create<IChangeSet<TObject, TKey>>(observer => new Subscription(
+            source: _source,
+            expireAfter: _expireAfter,
+            keySelector: _keySelector,
+            limitSizeTo: _limitSizeTo,
+            observer: observer,
+            scheduler: _scheduler));
 
-                                                                    // load local data source with current items
-                                                                    var populator = _source.Synchronize(locker)
-                                                                        .Subscribe(items => dataSource.AddOrUpdate(items), observer.OnError);
+    private readonly Func<TObject, TimeSpan?>? _expireAfter;
+    private readonly Func<TObject, TKey> _keySelector;
+    private readonly int _limitSizeTo;
+    private readonly IScheduler _scheduler;
+    private readonly IObservable<IEnumerable<TObject>> _source;
 
-                                                                    // handle size expiration
-                                                                    var sizeExpiryDisposer = new CompositeDisposable();
+    private sealed class Subscription
+        : IDisposable
+    {
+        public Subscription(
+            IObservable<IEnumerable<TObject>> source,
+            Func<TObject, TimeSpan?>? expireAfter,
+            Func<TObject, TKey> keySelector,
+            int limitSizeTo,
+            IObserver<IChangeSet<TObject, TKey>> observer,
+            IScheduler scheduler)
+        {
+            _keySelector = keySelector;
+            _observer = observer;
+            _scheduler = scheduler;
 
-                                                                    if (limitSizeTo > 0)
-                                                                    {
-                                                                        long orderItemWasAdded = -1;
+            if (limitSizeTo >= 0)
+            {
+                _evictionState = new()
+                {
+                    LimitSizeTo = limitSizeTo,
+                    Queue = new(capacity: limitSizeTo)
+                };
 
-                                                                        var transformed = dataSource.Connect()
-                                                                            .Transform(t => (Item: t, Order: Interlocked.Increment(ref orderItemWasAdded)))
-                                                                            .AsObservableCache();
+                _expirationState = (expireAfter is null)
+                    ? null
+                    : new()
+                    {
+                        ChangesBuffer = new(),
+                        ExpireAfter = expireAfter,
+                        Queue = new(capacity: limitSizeTo)
+                    };
 
-                                                                        var transformedRemoved = transformed.Connect()
-                                                                            .Subscribe(_ =>
-                                                                            {
-                                                                                if (transformed.Count <= limitSizeTo) return;
+                _itemStatesByKey = new(capacity: limitSizeTo);
+            }
+            else
+            {
+                _expirationState = (expireAfter is null)
+                    ? null
+                    : new()
+                    {
+                        ChangesBuffer = new(),
+                        ExpireAfter = expireAfter,
+                        Queue = new()
+                    };
 
-                                                                                // remove oldest items
-                                                                                var itemsToRemove = transformed.KeyValues
-                                                                                    .OrderBy(exp => exp.Value.Order)
-                                                                                    .Take(transformed.Count - limitSizeTo)
-                                                                                    .Select(x => x.Key)
-                                                                                    .ToArray();
+                _itemStatesByKey = new();
+            }
 
-                                                                                // schedule, otherwise we can get a deadlock when removing due to re-entrancey
-                                                                                _scheduler.Schedule(() => dataSource.Remove(itemsToRemove));
-                                                                            });
-                                                                        sizeExpiryDisposer.Add(transformed);
-                                                                        sizeExpiryDisposer.Add(transformedRemoved);
-                                                                    }
+            _sourceSubscription = source
+                .Synchronize(SynchronizationGate)
+                .SubscribeSafe(Observer.Create<IEnumerable<TObject>>(
+                    onNext: items =>
+                    {
+                        try
+                        {
+                            var now = _scheduler.Now;
 
-                                                                    // handle time expiration
-                                                                    var timeExpiryDisposer = new CompositeDisposable();
+                            var hasExpirationQueueChanged = false;
 
-                                                                    DateTime Trim(DateTime date, long ticks) => new(date.Ticks - (date.Ticks % ticks), date.Kind);
+                            var itemCount = items switch
+                            {
+                                ICollection<TObject> itemsCollection => itemsCollection.Count,
+                                IReadOnlyCollection<TObject> itemsCollection => itemsCollection.Count,
+                                _ => 0
+                            };
 
-                                                                    if (expireAfter is not null)
-                                                                    {
-                                                                        var expiry = dataSource.Connect()
-                                                                            .Transform(t =>
-                                                                            {
-                                                                                var removeAt = expireAfter?.Invoke(t);
+                            var changeSet = new ChangeSet<TObject, TKey>(capacity: (_evictionState is EvictionState evictionState)
+                                ? Math.Max(itemCount + evictionState.Queue.Count - evictionState.LimitSizeTo, 0)
+                                : itemCount);
 
-                                                                                if (removeAt is null)
-                                                                                    return (Item: t, ExpireAt: DateTime.MaxValue);
+                            if (items is IReadOnlyList<TObject> itemsList)
+                            {
+                                for (var i = 0; i < itemsList.Count; ++i)
+                                    HandleIncomingItem(itemsList[i], now, changeSet, ref hasExpirationQueueChanged);
+                            }
+                            else
+                            {
+                                foreach (var item in items)
+                                    HandleIncomingItem(item, now, changeSet, ref hasExpirationQueueChanged);
+                            }
 
-                                                                                // get absolute expiry, and round by milliseconds to we can attempt to batch as many items into a single group
-                                                                                var expireTime = Trim(_scheduler.Now.UtcDateTime.Add(removeAt.Value), TimeSpan.TicksPerMillisecond);
+                            if (hasExpirationQueueChanged)
+                                OnExpirationQueueChanged();
 
-                                                                                return (Item: t, ExpireAt: expireTime);
-                                                                            })
-                                                                            .Filter(ei => ei.ExpireAt != DateTime.MaxValue)
-                                                                            .GroupWithImmutableState(ei => ei.ExpireAt)
-                                                                            .MergeMany(grouping => Observable.Timer(grouping.Key, _scheduler).Select(_ => grouping))
-                                                                            .Synchronize(locker)
-                                                                            .Subscribe(grouping => dataSource.Remove(grouping.Keys));
+                            observer.OnNext(changeSet);
+                        }
+                        catch (Exception error)
+                        {
+                            TearDownStates();
 
-                                                                        timeExpiryDisposer.Add(expiry);
-                                                                    }
+                            observer.OnError(error);
+                        }
+                    },
+                    onError: error =>
+                    {
+                        TearDownStates();
 
-                                                                    return new CompositeDisposable(
-                                                                        dataSource,
-                                                                        populator,
-                                                                        sizeExpiryDisposer,
-                                                                        timeExpiryDisposer,
-                                                                        dataSource.Connect().SubscribeSafe(observer));
-                                                                });
+                        observer.OnError(error);
+                    },
+                    onCompleted: () =>
+                    {
+                        _hasSourceCompleted = true;
+
+                        // If there are pending expirations scheduled, wait to complete the stream until they're done
+                        if (_expirationState is null or { Queue: { Count: 0 } })
+                            observer.OnCompleted();
+                    }));
+        }
+
+        public void Dispose()
+        {
+            lock (SynchronizationGate)
+            {
+                _sourceSubscription.Dispose();
+
+                TearDownStates();
+            }
+        }
+
+        private static int CompareExpireAtToExpiration(DateTimeOffset expireAt, Expiration expiration)
+            => expireAt.CompareTo(expiration.ExpireAt);
+
+        // Instead of using a dedicated _synchronizationGate object, we can save an allocation by using any object that is never exposed to consumers.
+        private object SynchronizationGate
+            => _itemStatesByKey;
+
+        private void HandleIncomingItem(
+            TObject item,
+            DateTimeOffset now,
+            ChangeSet<TObject, TKey> changeSet,
+            ref bool hasExpirationQueueChanged)
+        {
+            var key = _keySelector.Invoke(item);
+            var previousItemState = _itemStatesByKey.TryGetValue(key, out var existingItemState)
+                ? existingItemState
+                : null as ItemState?;
+
+            // Perform processing for eviction behavior, if applicable
+            if (_evictionState is EvictionState evictionState)
+            {
+                // Backwards compatibility
+                if (evictionState.LimitSizeTo is 0)
+                    return;
+
+                // Eviction is only applicable to adds, not replacements
+                if (previousItemState is null)
+                {
+                    // If our size limit has been reached, evict the oldest item before adding a new one.
+                    // Repeat removals until we drop below the limit, since items in the queue might have already expired.
+                    while (_itemStatesByKey.Count >= evictionState.LimitSizeTo)
+                    {
+                        var keyToEvict = evictionState.Queue.Dequeue();
+
+                        if (_itemStatesByKey.TryGetValue(keyToEvict, out var itemStateToEvict))
+                        {
+                            _itemStatesByKey.Remove(keyToEvict);
+                            changeSet.Add(new(
+                                reason: ChangeReason.Remove,
+                                key: keyToEvict,
+                                current: itemStateToEvict.Item));
+                        }
+                    }
+
+                    evictionState.Queue.Enqueue(key);
+                }
+            }
+
+            // Perform processing for expiration behavior, if applicable
+            var expireAt = null as DateTimeOffset?;
+            if (_expirationState is ExpirationState expirationState)
+            {
+                var previousExpireAt = previousItemState?.ExpireAt;
+                var expireAfter = expirationState.ExpireAfter.Invoke(item);
+                if (expireAfter is TimeSpan resolvedExpireAfter)
+                {
+                    // Truncate to milliseconds to promote batching expirations together.
+                    var expireAtTicks = now.UtcTicks + resolvedExpireAfter.Ticks;
+                    expireAt = new DateTimeOffset(ticks: expireAtTicks - (expireAtTicks % TimeSpan.TicksPerMillisecond), offset: TimeSpan.Zero);
+                }
+
+                // Queue the item for expiration if it's new and needs to expire, or if it's a replacement with a different expiration time.
+                if ((expireAt is not null) && (expireAt != previousExpireAt))
+                {
+                    var insertionIndex = expirationState.Queue.BinarySearch(expireAt.Value, CompareExpireAtToExpiration);
+                    if (insertionIndex < 0)
+                        insertionIndex = ~insertionIndex;
+
+                    expirationState.Queue.Insert(
+                        index: insertionIndex,
+                        item: new()
+                        {
+                            ExpireAt = expireAt.Value,
+                            Key = key
+                        });
+
+                    hasExpirationQueueChanged = true;
+                }
+            }
+
+            // Track the item's state, to be able to detect replacements later, and issue either an add or replace change for it.
+            _itemStatesByKey[key] = new()
+            {
+                ExpireAt = expireAt,
+                Item = item
+            };
+            changeSet.Add((previousItemState is null)
+                ? new(
+                    reason: ChangeReason.Add,
+                    key: key,
+                    current: item)
+                : new(
+                    reason: ChangeReason.Update,
+                    key: key,
+                    current: item,
+                    previous: previousItemState.Value.Item));
+        }
+
+        private void HandleScheduledExpiration()
+        {
+            var expirationState = _expirationState!.Value;
+
+            var now = _scheduler.Now;
+
+            // Buffer removals, so we can optimize the allocation for the final changeset, or skip it entirely.
+            // Also, so we can optimize removal from the queue as a range removal.
+            var processedExpirationCount = 0;
+            foreach (var expiration in expirationState.Queue)
+            {
+                if (expiration.ExpireAt > now)
+                    break;
+
+                ++processedExpirationCount;
+
+                // If the item hasn't already been evicted, or had its expiration time change, formally remove it
+                if (_itemStatesByKey.TryGetValue(expiration.Key, out var itemState) && (itemState.ExpireAt <= now))
+                {
+                    _itemStatesByKey.Remove(expiration.Key);
+                    expirationState.ChangesBuffer.Add(new(
+                        reason: ChangeReason.Remove,
+                        key: expiration.Key,
+                        current: itemState.Item));
+                }
+            }
+
+            expirationState.Queue.RemoveRange(0, processedExpirationCount);
+
+            // We can end up with no changes here for a couple of reasons:
+            // * An item's expiration time can change
+            // * When items are evicted due to the size limit, it still remains in the expiration queue.
+            // * The scheduler only promises "best effort" to cancel scheduled operations.
+            if (expirationState.ChangesBuffer.Count is not 0)
+            {
+                _observer.OnNext(new ChangeSet<TObject, TKey>(expirationState.ChangesBuffer));
+
+                expirationState.ChangesBuffer.Clear();
+            }
+
+            OnExpirationQueueChanged();
+        }
+
+        private void OnExpirationQueueChanged()
+        {
+            var expirationState = _expirationState!.Value;
+
+            // If there aren't any items queued to expire, check to see if the stream should be terminated (I.E. we just expired the last item).
+            // Otherwise, make sure we have an operation scheduled to handle the next expiration.
+            if (expirationState.Queue.Count is 0)
+            {
+                if (_hasSourceCompleted)
+                    _observer.OnCompleted();
+            }
+            else
+            {
+                // If there's already a scheduled operation, and it doesn't match the current next-item-to-expire time, wipe it out and re-schedule it.
+                var nextExpireAt = expirationState.Queue[0].ExpireAt;
+                if (_scheduledExpiration is ScheduledExpiration scheduledExpiration)
+                {
+                    if (scheduledExpiration.DueTime != nextExpireAt)
+                    {
+                        scheduledExpiration.Cancellation.Dispose();
+                        _scheduledExpiration = null;
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+
+                _scheduledExpiration = new()
+                {
+                    Cancellation = _scheduler.Schedule(
+                        state: this,
+                        dueTime: nextExpireAt,
+                        action: static (_, @this) =>
+                        {
+                            lock (@this.SynchronizationGate)
+                            {
+                                @this._scheduledExpiration = null;
+
+                                @this.HandleScheduledExpiration();
+                            }
+
+                            return Disposable.Empty;
+                        }),
+                    DueTime = nextExpireAt
+                };
+            }
+        }
+
+        private void TearDownStates()
+        {
+            _scheduledExpiration?.Cancellation.Dispose();
+            _scheduledExpiration = null;
+
+            _evictionState?.Queue.Clear();
+
+            _expirationState?.Queue.Clear();
+        }
+
+        private readonly EvictionState? _evictionState;
+        private readonly ExpirationState? _expirationState;
+        private readonly Dictionary<TKey, ItemState> _itemStatesByKey;
+        private readonly Func<TObject, TKey> _keySelector;
+        private readonly IObserver<IChangeSet<TObject, TKey>> _observer;
+        private readonly IScheduler _scheduler;
+        private readonly IDisposable _sourceSubscription;
+
+        private bool _hasSourceCompleted;
+        private ScheduledExpiration? _scheduledExpiration;
+
+        private struct ItemState
+        {
+            public DateTimeOffset? ExpireAt { get; set; }
+
+            public TObject Item { get; set; }
+        }
+
+        private struct EvictionState
+        {
+            public int LimitSizeTo { get; set; }
+
+            public Queue<TKey> Queue { get; set; }
+        }
+
+        private struct Expiration
+        {
+            public DateTimeOffset ExpireAt { get; set; }
+
+            public TKey Key { get; set; }
+        }
+
+        private struct ExpirationState
+        {
+            public List<Change<TObject, TKey>> ChangesBuffer;
+
+            public Func<TObject, TimeSpan?> ExpireAfter { get; set; }
+
+            // Potential performance improvement: Instead of List<T>, use PriorityQueue<T> available in .NET 6+, or an equivalent.
+            public List<Expiration> Queue { get; set; }
+        }
+
+        private struct ScheduledExpiration
+        {
+            public IDisposable Cancellation { get; set; }
+
+            public DateTimeOffset DueTime { get; set; }
+        }
+    }
 }

--- a/src/DynamicData/List/ChangeSet.cs
+++ b/src/DynamicData/List/ChangeSet.cs
@@ -35,6 +35,15 @@ public class ChangeSet<T> : List<Change<T>>, IChangeSet<T>
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ChangeSet{T}"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial capacity of the change set.</param>
+    public ChangeSet(int capacity)
+        : base(capacity)
+    {
+    }
+
+    /// <summary>
     ///     Gets the number of additions.
     /// </summary>
     public int Adds

--- a/src/DynamicData/List/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/List/Internal/ToObservableChangeSet.cs
@@ -132,16 +132,22 @@ internal class ToObservableChangeSet<TObject>
                             if (items is IReadOnlyList<TObject> itemsList)
                             {
                                 for (var i = 0; i < itemsList.Count; ++i)
+                                {
                                     HandleIncomingItem(itemsList[i], now, changeSet, ref hasExpirationQueueChanged);
+                                }
                             }
                             else
                             {
                                 foreach (var item in items)
+                                {
                                     HandleIncomingItem(item, now, changeSet, ref hasExpirationQueueChanged);
+                                }
                             }
 
                             if (hasExpirationQueueChanged)
+                            {
                                 OnExpirationQueueChanged();
+                            }
 
                             observer.OnNext(changeSet);
                         }
@@ -163,8 +169,10 @@ internal class ToObservableChangeSet<TObject>
                         _hasSourceCompleted = true;
 
                         // If there are pending expirations scheduled, wait to complete the stream until they're done
-                        if (_expirationState is null or { Queue: { Count: 0 } })
+                        if (_expirationState is null or { Queue.Count: 0 })
+                        {
                             observer.OnCompleted();
+                        }
                     }));
         }
 
@@ -192,7 +200,9 @@ internal class ToObservableChangeSet<TObject>
             {
                 // Backwards compatibility
                 if (evictionState.LimitSizeTo is 0)
+                {
                     return;
+                }
 
                 // If our size limit has been reached, evict the oldest item before adding a new one.
                 // Repeat removals until we drop below the limit, since items in the queue might have already expired.
@@ -242,7 +252,9 @@ internal class ToObservableChangeSet<TObject>
 
                     var insertionIndex = expirationState.Queue.BinarySearch(expireAt, CompareExpireAtToExpiration);
                     if (insertionIndex < 0)
+                    {
                         insertionIndex = ~insertionIndex;
+                    }
 
                     expirationState.Queue.Insert(
                         index: insertionIndex,
@@ -276,7 +288,9 @@ internal class ToObservableChangeSet<TObject>
             foreach (var expiration in expirationState.Queue)
             {
                 if (expiration.ExpireAt > now)
+                {
                     break;
+                }
 
                 expirationState.RemovalsBuffer.Add(new(
                     key: expiration.Index,
@@ -310,7 +324,10 @@ internal class ToObservableChangeSet<TObject>
                     {
                         var expiration = expirationState.Queue[j];
                         if (expiration.Index > indexToRemove)
+                        {
                             --expiration.Index;
+                        }
+
                         expirationState.Queue[j] = expiration;
                     }
 
@@ -335,7 +352,9 @@ internal class ToObservableChangeSet<TObject>
             if (expirationState.Queue.Count is 0)
             {
                 if (_hasSourceCompleted)
+                {
                     _observer.OnCompleted();
+                }
             }
             else
             {

--- a/src/DynamicData/List/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/List/Internal/ToObservableChangeSet.cs
@@ -415,36 +415,36 @@ internal class ToObservableChangeSet<TObject>
             _expirationState?.Queue.Clear();
         }
 
-        private struct EvictionState
+        private readonly struct EvictionState
         {
-            public int LimitSizeTo { get; set; }
+            public required int LimitSizeTo { get; init; }
 
-            public List<TObject> Queue { get; set; }
+            public required List<TObject> Queue { get; init; }
         }
 
         private struct Expiration
         {
-            public DateTimeOffset ExpireAt { get; set; }
+            public required DateTimeOffset ExpireAt { get; init; }
 
-            public int Index { get; set; }
+            public required int Index { get; set; }
 
-            public TObject Item { get; set; }
+            public required TObject Item { get; init; }
         }
 
-        private struct ExpirationState
+        private readonly struct ExpirationState
         {
-            public List<KeyValuePair<int, TObject>> RemovalsBuffer { get; set; }
+            public required List<KeyValuePair<int, TObject>> RemovalsBuffer { get; init; }
 
-            public Func<TObject, TimeSpan?> ExpireAfter { get; set; }
+            public required Func<TObject, TimeSpan?> ExpireAfter { get; init; }
 
-            public List<Expiration> Queue { get; set; }
+            public required List<Expiration> Queue { get; init; }
         }
 
-        private struct ScheduledExpiration
+        private readonly struct ScheduledExpiration
         {
-            public IDisposable Cancellation { get; set; }
+            public required IDisposable Cancellation { get; init; }
 
-            public DateTimeOffset DueTime { get; set; }
+            public required DateTimeOffset DueTime { get; init; }
         }
     }
 }

--- a/src/DynamicData/List/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/List/Internal/ToObservableChangeSet.cs
@@ -2,83 +2,430 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace DynamicData.List.Internal;
 
-internal class ToObservableChangeSet<T>(IObservable<IEnumerable<T>> source, Func<T, TimeSpan?>? expireAfter, int limitSizeTo, IScheduler? scheduler = null)
-    where T : notnull
+internal class ToObservableChangeSet<TObject>
+    where TObject : notnull
 {
-    private readonly IScheduler _scheduler = scheduler ?? Scheduler.Default;
-
-    public ToObservableChangeSet(IObservable<T> source, Func<T, TimeSpan?>? expireAfter, int limitSizeTo, IScheduler? scheduler = null)
-        : this(source.Select(t => new[] { t }), expireAfter, limitSizeTo, scheduler)
+    public ToObservableChangeSet(
+        IObservable<TObject> source,
+        Func<TObject, TimeSpan?>? expireAfter,
+        int limitSizeTo,
+        IScheduler? scheduler)
     {
+        _expireAfter = expireAfter;
+        _limitSizeTo = limitSizeTo;
+        _scheduler = scheduler ?? Scheduler.Default;
+
+        _source = Observable.Create<IEnumerable<TObject>>(observer =>
+        {
+            // Reusable buffer, to avoid allocating per-item
+            var buffer = new TObject[1];
+
+            return source.SubscribeSafe(Observer.Create<TObject>(
+                onNext: item =>
+                {
+                    buffer[0] = item;
+                    observer.OnNext(buffer);
+                },
+                onError: observer.OnError,
+                onCompleted: observer.OnCompleted));
+        });
     }
 
-    public IObservable<IChangeSet<T>> Run() => Observable.Create<IChangeSet<T>>(
-            observer =>
+    public ToObservableChangeSet(
+        IObservable<IEnumerable<TObject>> source,
+        Func<TObject, TimeSpan?>? expireAfter,
+        int limitSizeTo,
+        IScheduler? scheduler)
+    {
+        _expireAfter = expireAfter;
+        _limitSizeTo = limitSizeTo;
+        _scheduler = scheduler ?? Scheduler.Default;
+        _source = source;
+    }
+
+    public IObservable<IChangeSet<TObject>> Run()
+        => Observable.Create<IChangeSet<TObject>>(observer => new Subscription(
+            source: _source,
+            expireAfter: _expireAfter,
+            limitSizeTo: _limitSizeTo,
+            observer: observer,
+            scheduler: _scheduler));
+
+    private readonly Func<TObject, TimeSpan?>? _expireAfter;
+    private readonly int _limitSizeTo;
+    private readonly IScheduler _scheduler;
+    private readonly IObservable<IEnumerable<TObject>> _source;
+
+    private sealed class Subscription
+        : IDisposable
+    {
+        public Subscription(
+            IObservable<IEnumerable<TObject>> source,
+            Func<TObject, TimeSpan?>? expireAfter,
+            int limitSizeTo,
+            IObserver<IChangeSet<TObject>> observer,
+            IScheduler scheduler)
+        {
+            _observer = observer;
+            _scheduler = scheduler;
+
+            if (limitSizeTo >= 0)
             {
-                var locker = new object();
-
-                var dataSource = new SourceList<T>();
-
-                // load local data source with current items
-                var populator = source.Synchronize(locker)
-                    .Subscribe(items =>
-                    {
-                        dataSource.Edit(innerList =>
-                        {
-                            innerList.AddRange(items);
-
-                            if (limitSizeTo > 0 && innerList.Count > limitSizeTo)
-                            {
-                                // remove oldest items [these will always be the first x in the list]
-                                var toRemove = innerList.Count - limitSizeTo;
-                                innerList.RemoveRange(0, toRemove);
-                            }
-                        });
-
-                    }, observer.OnError);
-
-                // handle time expiration
-                var timeExpiryDisposer = new CompositeDisposable();
-
-                DateTime Trim(DateTime date, long ticks) => new(date.Ticks - (date.Ticks % ticks), date.Kind);
-
-                if (expireAfter is not null)
+                _evictionState = new()
                 {
-                    var expiry = dataSource.Connect()
-                        .Transform(t =>
+                    LimitSizeTo = limitSizeTo,
+                    Queue = new(capacity: limitSizeTo)
+                };
+
+                _expirationState = (expireAfter is null)
+                    ? null
+                    : new()
+                    {
+                        RemovalsBuffer = new(),
+                        ExpireAfter = expireAfter,
+                        Queue = new(capacity: limitSizeTo)
+                    };
+            }
+            else
+            {
+                _expirationState = (expireAfter is null)
+                    ? null
+                    : new()
+                    {
+                        RemovalsBuffer = new(),
+                        ExpireAfter = expireAfter,
+                        Queue = new()
+                    };
+            }
+
+            _synchronizationGate = new();
+
+            _sourceSubscription = source
+                .Synchronize(_synchronizationGate)
+                .SubscribeSafe(Observer.Create<IEnumerable<TObject>>(
+                    onNext: items =>
+                    {
+                        try
                         {
-                            var removeAt = expireAfter?.Invoke(t);
+                            var now = _scheduler.Now;
 
-                            if (removeAt is null)
-                                return (Item: t, ExpireAt: DateTime.MaxValue);
+                            var hasExpirationQueueChanged = false;
 
-                            // get absolute expiry, and round by milliseconds to we can attempt to batch as many items into a single group
-                            var expireTime = Trim(_scheduler.Now.UtcDateTime.Add(removeAt.Value), TimeSpan.TicksPerMillisecond);
+                            var itemCount = items switch
+                            {
+                                ICollection<TObject> itemsCollection => itemsCollection.Count,
+                                IReadOnlyCollection<TObject> itemsCollection => itemsCollection.Count,
+                                _ => 0
+                            };
 
-                            return (Item: t, ExpireAt: expireTime);
-                        })
-                        .Filter(ei => ei.ExpireAt != DateTime.MaxValue)
-                        .GroupWithImmutableState(ei => ei.ExpireAt)
-                        .MergeMany(grouping => Observable.Timer(grouping.Key, _scheduler).Select(_ => grouping.Items.Select(x => x.Item).ToArray()))
-                        .Synchronize(locker)
-                        .Subscribe(items =>
+                            var changeSet = new ChangeSet<TObject>(capacity: (_evictionState is EvictionState evictionState)
+                                ? Math.Max(itemCount + evictionState.Queue.Count - evictionState.LimitSizeTo, 0)
+                                : itemCount);
+
+                            if (items is IReadOnlyList<TObject> itemsList)
+                            {
+                                for (var i = 0; i < itemsList.Count; ++i)
+                                    HandleIncomingItem(itemsList[i], now, changeSet, ref hasExpirationQueueChanged);
+                            }
+                            else
+                            {
+                                foreach (var item in items)
+                                    HandleIncomingItem(item, now, changeSet, ref hasExpirationQueueChanged);
+                            }
+
+                            if (hasExpirationQueueChanged)
+                                OnExpirationQueueChanged();
+
+                            observer.OnNext(changeSet);
+                        }
+                        catch (Exception error)
                         {
-                            dataSource.RemoveMany(items);
-                        });
+                            TearDownStates();
 
-                    timeExpiryDisposer.Add(expiry);
+                            observer.OnError(error);
+                        }
+                    },
+                    onError: error =>
+                    {
+                        TearDownStates();
+
+                        observer.OnError(error);
+                    },
+                    onCompleted: () =>
+                    {
+                        _hasSourceCompleted = true;
+
+                        // If there are pending expirations scheduled, wait to complete the stream until they're done
+                        if (_expirationState is null or { Queue: { Count: 0 } })
+                            observer.OnCompleted();
+                    }));
+        }
+
+        public void Dispose()
+        {
+            lock (_synchronizationGate)
+            {
+                _sourceSubscription.Dispose();
+
+                TearDownStates();
+            }
+        }
+
+        private static int CompareExpireAtToExpiration(DateTimeOffset expireAt, Expiration expiration)
+            => expireAt.CompareTo(expiration.ExpireAt);
+
+        private void HandleIncomingItem(
+            TObject item,
+            DateTimeOffset now,
+            ChangeSet<TObject> changeSet,
+            ref bool hasExpirationQueueChanged)
+        {
+            // Perform processing for eviction behavior, if applicable
+            if (_evictionState is EvictionState evictionState)
+            {
+                // Backwards compatibility
+                if (evictionState.LimitSizeTo is 0)
+                    return;
+
+                // If our size limit has been reached, evict the oldest item before adding a new one.
+                // Repeat removals until we drop below the limit, since items in the queue might have already expired.
+                if (evictionState.Queue.Count >= evictionState.LimitSizeTo)
+                {
+                    var itemToEvict = evictionState.Queue[0];
+                    evictionState.Queue.RemoveAt(0);
+
+                    // Need to synchronize the expiration queue, if applicable, to keep the indexes stored there correct.
+                    if (_expirationState is { Queue: var expirationQueue })
+                    {
+                        for (var i = 0; i < expirationQueue.Count;)
+                        {
+                            if (expirationQueue[i].Index == 0)
+                            {
+                                expirationQueue.RemoveAt(i);
+                                continue;
+                            }
+
+                            var expiration = expirationQueue[i];
+                            --expiration.Index;
+                            expirationQueue[i] = expiration;
+
+                            ++i;
+                        }
+                    }
+
+                    changeSet.Add(new(
+                        reason: ListChangeReason.Remove,
+                        current: itemToEvict,
+                        index: 0));
+                    --_currentItemCount;
                 }
 
-                return new CompositeDisposable(
-                    dataSource,
-                    populator,
-                    timeExpiryDisposer,
-                    dataSource.Connect().SubscribeSafe(observer));
-            });
+                evictionState.Queue.Add(item);
+            }
+
+            // Perform processing for expiration behavior, if applicable
+            if (_expirationState is ExpirationState expirationState)
+            {
+                var expireAfter = expirationState.ExpireAfter.Invoke(item);
+                if (expireAfter is TimeSpan resolvedExpireAfter)
+                {
+                    // Truncate to milliseconds to promote batching expirations together.
+                    var expireAtTicks = now.UtcTicks + resolvedExpireAfter.Ticks;
+                    var expireAt = new DateTimeOffset(ticks: expireAtTicks - (expireAtTicks % TimeSpan.TicksPerMillisecond), offset: TimeSpan.Zero);
+
+                    var insertionIndex = expirationState.Queue.BinarySearch(expireAt, CompareExpireAtToExpiration);
+                    if (insertionIndex < 0)
+                        insertionIndex = ~insertionIndex;
+
+                    expirationState.Queue.Insert(
+                        index: insertionIndex,
+                        item: new()
+                        {
+                            ExpireAt = expireAt,
+                            Index = _currentItemCount,
+                            Item = item
+                        });
+
+                    hasExpirationQueueChanged = true;
+                }
+            }
+
+            changeSet.Add(new(
+                reason: ListChangeReason.Add,
+                current: item,
+                index: _currentItemCount));
+            ++_currentItemCount;
+        }
+
+        private void HandleScheduledExpiration()
+        {
+            var expirationState = _expirationState!.Value;
+
+            var now = _scheduler.Now;
+
+            // Buffer removals, so we can sort them and generate adjusted indexes, in the event of many items being removed at once.
+            // Also, so we can optimize away the changeSet allocation and publication, if possible.
+            // Also, so we can optimize removal from the queue as a range removal.
+            foreach (var expiration in expirationState.Queue)
+            {
+                if (expiration.ExpireAt > now)
+                    break;
+
+                expirationState.RemovalsBuffer.Add(new(
+                    key: expiration.Index,
+                    value: expiration.Item));
+            }
+
+            // It's theoretically possible to end up with no changes here,
+            // as the scheduler only promises "best effort" to cancel scheduled operations.
+            if (expirationState.RemovalsBuffer.Count is not 0)
+            {
+                expirationState.Queue.RemoveRange(0, expirationState.RemovalsBuffer.Count);
+
+                expirationState.RemovalsBuffer.Sort(static (x, y) => x.Key.CompareTo(y.Key));
+
+                var evictionQueue = _evictionState?.Queue;
+
+                var changeSet = new ChangeSet<TObject>(capacity: expirationState.RemovalsBuffer.Count);
+                for (var i = 0; i < expirationState.RemovalsBuffer.Count; ++i)
+                {
+                    var removal = expirationState.RemovalsBuffer[i];
+                    var indexToRemove = removal.Key - i;
+
+                    changeSet.Add(new(
+                        reason: ListChangeReason.Remove,
+                        current: removal.Value,
+                        index: indexToRemove));
+                    --_currentItemCount;
+
+                    // Adjust indexes for all remaining items in the queue.
+                    for (var j = 0; j < expirationState.Queue.Count; ++j)
+                    {
+                        var expiration = expirationState.Queue[j];
+                        if (expiration.Index > indexToRemove)
+                            --expiration.Index;
+                        expirationState.Queue[j] = expiration;
+                    }
+
+                    // Clear expiring items out of the eviction queue as well, if applicable.
+                    evictionQueue?.RemoveAt(indexToRemove);
+                }
+
+                expirationState.RemovalsBuffer.Clear();
+
+                _observer.OnNext(changeSet);
+            }
+
+            OnExpirationQueueChanged();
+        }
+
+        private void OnExpirationQueueChanged()
+        {
+            var expirationState = _expirationState!.Value;
+
+            // If there aren't any items queued to expire, check to see if the stream should be terminated (I.E. we just expired the last item).
+            // Otherwise, make sure we have an operation scheduled to handle the next expiration.
+            if (expirationState.Queue.Count is 0)
+            {
+                if (_hasSourceCompleted)
+                    _observer.OnCompleted();
+            }
+            else
+            {
+                // If there's already a scheduled operation, and it doesn't match the current next-item-to-expire time, wipe it out and re-schedule it.
+                var nextExpireAt = expirationState.Queue[0].ExpireAt;
+                if (_scheduledExpiration is ScheduledExpiration scheduledExpiration)
+                {
+                    if (scheduledExpiration.DueTime != nextExpireAt)
+                    {
+                        scheduledExpiration.Cancellation.Dispose();
+                        _scheduledExpiration = null;
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+
+                _scheduledExpiration = new()
+                {
+                    Cancellation = _scheduler.Schedule(
+                        state: this,
+                        dueTime: nextExpireAt,
+                        action: static (_, @this) =>
+                        {
+                            lock (@this._synchronizationGate)
+                            {
+                                @this._scheduledExpiration = null;
+
+                                @this.HandleScheduledExpiration();
+                            }
+
+                            return Disposable.Empty;
+                        }),
+                    DueTime = nextExpireAt
+                };
+            }
+        }
+
+        private void TearDownStates()
+        {
+            _scheduledExpiration?.Cancellation.Dispose();
+            _scheduledExpiration = null;
+
+            _evictionState?.Queue.Clear();
+
+            _expirationState?.Queue.Clear();
+        }
+
+        private readonly EvictionState? _evictionState;
+        private readonly ExpirationState? _expirationState;
+        private readonly IObserver<IChangeSet<TObject>> _observer;
+        private readonly IScheduler _scheduler;
+        private readonly IDisposable _sourceSubscription;
+        private readonly object _synchronizationGate;
+
+        private int _currentItemCount;
+        private bool _hasSourceCompleted;
+        private ScheduledExpiration? _scheduledExpiration;
+
+        private struct EvictionState
+        {
+            public int LimitSizeTo { get; set; }
+
+            public List<TObject> Queue { get; set; }
+        }
+
+        private struct Expiration
+        {
+            public DateTimeOffset ExpireAt { get; set; }
+
+            public int Index { get; set; }
+
+            public TObject Item { get; set; }
+        }
+
+        private struct ExpirationState
+        {
+            public List<KeyValuePair<int, TObject>> RemovalsBuffer { get; set; }
+
+            public Func<TObject, TimeSpan?> ExpireAfter { get; set; }
+
+            public List<Expiration> Queue { get; set; }
+        }
+
+        private struct ScheduledExpiration
+        {
+            public IDisposable Cancellation { get; set; }
+
+            public DateTimeOffset DueTime { get; set; }
+        }
+    }
 }

--- a/src/DynamicData/List/Internal/TransformAsync.cs
+++ b/src/DynamicData/List/Internal/TransformAsync.cs
@@ -77,7 +77,7 @@ internal class TransformAsync<TSource, TDestination>
                 case ListChangeReason.Add:
                     {
                         var change = item.Item;
-                        if (change.CurrentIndex < 0 | change.CurrentIndex >= transformed.Count)
+                        if (change.CurrentIndex < 0 || change.CurrentIndex >= transformed.Count)
                         {
                             var container =
                                 await _containerFactory(item.Item.Current, Optional<TDestination>.None,
@@ -143,7 +143,7 @@ internal class TransformAsync<TSource, TDestination>
                 case ListChangeReason.Remove:
                     {
                         var change = item.Item;
-                        bool hasIndex = change.CurrentIndex >= 0;
+                        var hasIndex = change.CurrentIndex >= 0;
 
                         if (hasIndex)
                         {
@@ -191,7 +191,7 @@ internal class TransformAsync<TSource, TDestination>
                 case ListChangeReason.Moved:
                     {
                         var change = item.Item;
-                        bool hasIndex = change.CurrentIndex >= 0;
+                        var hasIndex = change.CurrentIndex >= 0;
                         if (!hasIndex)
                         {
                             throw new UnspecifiedIndexException("Cannot move as an index was not specified");

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1142,10 +1142,7 @@ public static class ObservableListEx
     /// <exception cref="ArgumentNullException">Parameter was null.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> source, IComparer<TObject> comparer)
         where TObject : notnull
-        where TKey : notnull
-    {
-        return source.Connect().MergeChangeSets(comparer: comparer);
-    }
+        where TKey : notnull => source.Connect().MergeChangeSets(comparer: comparer);
 
     /// <summary>
     /// Merges all of the Cache Observable ChangeSets into a single ChangeSets while correctly handling multiple Keys and removal of the parent items.
@@ -1159,10 +1156,7 @@ public static class ObservableListEx
     /// <exception cref="ArgumentNullException">Parameter was null.</exception>
     public static IObservable<IChangeSet<TObject, TKey>> MergeChangeSets<TObject, TKey>(this IObservableList<IObservable<IChangeSet<TObject, TKey>>> source, IEqualityComparer<TObject>? equalityComparer = null, IComparer<TObject>? comparer = null)
         where TObject : notnull
-        where TKey : notnull
-    {
-        return source.Connect().MergeChangeSets(equalityComparer, comparer);
-    }
+        where TKey : notnull => source.Connect().MergeChangeSets(equalityComparer, comparer);
 
     /// <summary>
     /// Merges all of the Cache Observable ChangeSets into a single ChangeSets while correctly handling multiple Keys and removal of the parent items.
@@ -1317,7 +1311,7 @@ public static class ObservableListEx
     public static IObservable<IChangeSet<TObject>> OnItemRefreshed<TObject>(this IObservable<IChangeSet<TObject>> source, Action<TObject> refreshAction)
         where TObject : notnull
     {
-        Action<TObject> refreshAction2 = refreshAction;
+        var refreshAction2 = refreshAction;
         if (source == null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -1328,13 +1322,8 @@ public static class ObservableListEx
             throw new ArgumentNullException(nameof(refreshAction));
         }
 
-        return source.Do(delegate(IChangeSet<TObject> changes)
-        {
-            changes.Where((Change<TObject> c) => c.Reason == ListChangeReason.Refresh).ForEach(delegate(Change<TObject> c)
-            {
-                refreshAction2(c.Item.Current);
-            });
-        });
+        return source.Do((IChangeSet<TObject> changes) =>
+            changes.Where((Change<TObject> c) => c.Reason == ListChangeReason.Refresh).ForEach((Change<TObject> c) => refreshAction2(c.Item.Current)));
     }
 
     /// <summary>

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1808,7 +1808,7 @@ public static class ObservableListEx
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <param name="source">The source.</param>
-    /// <param name="limitSizeTo">Remove the oldest items when the size has reached this limit.</param>
+    /// <param name="limitSizeTo">Remove the oldest items when the size has reached this limit. Supply -1 to disable size limiting.</param>
     /// <param name="scheduler">The scheduler (only used for time expiry).</param>
     /// <returns>An observable which emits a change set.</returns>
     /// <exception cref="System.ArgumentNullException">source
@@ -1832,7 +1832,7 @@ public static class ObservableListEx
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <param name="source">The source.</param>
     /// <param name="expireAfter">Specify on a per object level the maximum time before an object expires from a cache.</param>
-    /// <param name="limitSizeTo">Remove the oldest items when the size has reached this limit.</param>
+    /// <param name="limitSizeTo">Remove the oldest items when the size has reached this limit. Supply -1 to disable size limiting.</param>
     /// <param name="scheduler">The scheduler (only used for time expiry).</param>
     /// <returns>An observable which emits a change set.</returns>
     /// <exception cref="System.ArgumentNullException">source
@@ -1891,7 +1891,7 @@ public static class ObservableListEx
     /// or
     /// keySelector.</exception>
     public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this IObservable<IEnumerable<T>> source, Func<T, TimeSpan?> expireAfter, IScheduler? scheduler = null)
-        where T : notnull => ToObservableChangeSet(source, expireAfter, 0, scheduler);
+        where T : notnull => ToObservableChangeSet(source, expireAfter, -1, scheduler);
 
     /// <summary>
     /// Converts the observable to an observable change set, allowing size and time limit to be specified.


### PR DESCRIPTION
Re-designed the .ToObservableChangeSet() operator for both caches and lists, for better independence, proper error handling, and improved performance. Resolves #635.

I worry I went a little overboard with the complexity, so I would definitely appreciate a couple reviews on this.

The good news is the complexity isn't without benefit, according to the benchmarks I wrote previously:

### ToObservableChangeSet_Cache (Before)
```
| Method                     | itemCount | sizeLimit | Mean          | Error       | StdDev      | Median        | Gen0      | Gen1    | Allocated  |
|--------------------------- |---------- |---------- |--------------:|------------:|------------:|--------------:|----------:|--------:|-----------:|
| AddsUpdatesAndFinalization | 0         | -1        |      2.036 us |   0.0396 us |   0.0501 us |      2.015 us |    0.6104 |       - |    2.51 KB |
| AddsUpdatesAndFinalization | 0         | 0         |      1.991 us |   0.0127 us |   0.0106 us |      1.991 us |    0.6104 |       - |    2.51 KB |
| AddsUpdatesAndFinalization | 0         | 1         |      5.630 us |   0.0610 us |   0.0476 us |      5.614 us |    1.4267 |       - |    5.84 KB |
| AddsUpdatesAndFinalization | 1         | 1         |      7.303 us |   0.1317 us |   0.1167 us |      7.278 us |    1.8158 |       - |    7.44 KB |
| AddsUpdatesAndFinalization | 10        | -1        |      5.446 us |   0.0308 us |   0.0273 us |      5.439 us |    1.7319 |       - |     7.1 KB |
| AddsUpdatesAndFinalization | 10        | 1         |     80.155 us |   0.1413 us |   0.1104 us |     80.168 us |    7.4463 |       - |   30.31 KB |
| AddsUpdatesAndFinalization | 10        | 5         |     16.161 us |   0.3204 us |   0.5939 us |     15.945 us |    4.6082 |       - |   18.89 KB |
| AddsUpdatesAndFinalization | 10        | 10        |     16.592 us |   0.3907 us |   1.1211 us |     16.100 us |    4.6082 |       - |   18.89 KB |
| AddsUpdatesAndFinalization | 100       | -1        |     33.464 us |   0.2536 us |   0.1980 us |     33.429 us |   12.0239 |       - |   49.13 KB |
| AddsUpdatesAndFinalization | 100       | 10        |    810.529 us |  11.1528 us |  10.9536 us |    811.366 us |   83.0078 |       - |  338.29 KB |
| AddsUpdatesAndFinalization | 100       | 50        |    101.668 us |   1.9407 us |   2.9636 us |    100.624 us |   34.0576 |  0.2441 |  139.48 KB |
| AddsUpdatesAndFinalization | 100       | 100       |    105.010 us |   2.1004 us |   6.0263 us |    102.394 us |   34.0576 |  0.2441 |  139.48 KB |
| AddsUpdatesAndFinalization | 1000      | -1        |    319.496 us |   3.9503 us |   3.5019 us |    318.270 us |  108.8867 |       - |   446.1 KB |
| AddsUpdatesAndFinalization | 1000      | 100       | 11,868.026 us | 224.6409 us | 230.6897 us | 11,895.656 us | 2046.8750 | 15.6250 | 8168.74 KB |
| AddsUpdatesAndFinalization | 1000      | 500       |    924.165 us |  17.7331 us |  17.4163 us |    918.035 us |  308.5938 |  0.9766 | 1262.84 KB |
| AddsUpdatesAndFinalization | 1000      | 1000      |    937.450 us |  14.7725 us |  13.8182 us |    937.429 us |  308.5938 |  1.9531 | 1262.85 KB |
```

### ToObservableChangeSet_Cache (After)
```
| Method                     | itemCount | sizeLimit | Mean         | Error       | StdDev       | Median       | Gen0    | Gen1   | Allocated |
|--------------------------- |---------- |---------- |-------------:|------------:|-------------:|-------------:|--------:|-------:|----------:|
| AddsUpdatesAndFinalization | 0         | -1        |     644.1 ns |     5.68 ns |      4.74 ns |     643.5 ns |  0.3405 |      - |   1.39 KB |
| AddsUpdatesAndFinalization | 0         | 0         |     648.7 ns |     2.76 ns |      2.44 ns |     649.3 ns |  0.3557 |      - |   1.45 KB |
| AddsUpdatesAndFinalization | 0         | 1         |     724.6 ns |     9.34 ns |      8.28 ns |     727.7 ns |  0.4072 |      - |   1.66 KB |
| AddsUpdatesAndFinalization | 1         | 1         |   1,038.8 ns |    14.46 ns |     11.29 ns |   1,036.5 ns |  0.4578 |      - |   1.88 KB |
| AddsUpdatesAndFinalization | 10        | -1        |   2,996.8 ns |    35.32 ns |     29.49 ns |   2,989.6 ns |  0.7172 |      - |   2.94 KB |
| AddsUpdatesAndFinalization | 10        | 1         |   3,694.9 ns |    39.52 ns |     35.04 ns |   3,693.8 ns |  0.8392 |      - |   3.43 KB |
| AddsUpdatesAndFinalization | 10        | 5         |   3,366.2 ns |    50.23 ns |     41.95 ns |   3,353.1 ns |  0.8850 |      - |   3.64 KB |
| AddsUpdatesAndFinalization | 10        | 10        |   3,298.6 ns |    38.84 ns |     34.43 ns |   3,281.5 ns |  1.0300 |      - |   4.21 KB |
| AddsUpdatesAndFinalization | 100       | -1        |  22,892.2 ns |   246.48 ns |    205.82 ns |  22,903.7 ns |  4.5776 |      - |  18.79 KB |
| AddsUpdatesAndFinalization | 100       | 10        |  31,186.4 ns |   609.49 ns |    792.51 ns |  30,959.0 ns |  4.8828 |      - |  20.06 KB |
| AddsUpdatesAndFinalization | 100       | 50        |  27,228.6 ns |   736.77 ns |  2,172.38 ns |  26,546.7 ns |  6.2866 |      - |  25.79 KB |
| AddsUpdatesAndFinalization | 100       | 100       |  25,842.7 ns |   516.26 ns |    756.72 ns |  25,779.1 ns |  6.9275 |      - |  28.42 KB |
| AddsUpdatesAndFinalization | 1000      | -1        | 219,860.6 ns | 2,138.89 ns |  1,786.07 ns | 219,290.6 ns | 32.9590 | 0.2441 | 135.16 KB |
| AddsUpdatesAndFinalization | 1000      | 100       | 304,533.5 ns | 6,081.91 ns | 11,571.46 ns | 302,311.4 ns | 45.4102 |      - | 186.45 KB |
| AddsUpdatesAndFinalization | 1000      | 500       | 284,497.8 ns | 6,103.96 ns | 17,901.87 ns | 284,901.1 ns | 58.5938 | 0.4883 | 240.85 KB |
| AddsUpdatesAndFinalization | 1000      | 1000      | 262,644.1 ns | 5,225.24 ns | 13,765.36 ns | 256,853.2 ns | 66.4063 |      - | 272.36 KB |
```

### ToObservableChangeSet_List (Before)
```
| Method                     | itemCount | sizeLimit | Mean       | Error     | StdDev    | Median     | Gen0     | Allocated |
|--------------------------- |---------- |---------- |-----------:|----------:|----------:|-----------:|---------:|----------:|
| AddsUpdatesAndFinalization | 0         | -1        |   1.251 us | 0.0110 us | 0.0098 us |   1.246 us |   0.4826 |   1.98 KB |
| AddsUpdatesAndFinalization | 0         | 0         |   1.271 us | 0.0245 us | 0.0430 us |   1.258 us |   0.4826 |   1.98 KB |
| AddsUpdatesAndFinalization | 0         | 1         |   1.234 us | 0.0132 us | 0.0110 us |   1.231 us |   0.4826 |   1.98 KB |
| AddsUpdatesAndFinalization | 1         | 1         |   1.614 us | 0.0301 us | 0.0566 us |   1.594 us |   0.5894 |   2.41 KB |
| AddsUpdatesAndFinalization | 10        | -1        |   4.140 us | 0.0951 us | 0.2804 us |   4.306 us |   1.5030 |   6.14 KB |
| AddsUpdatesAndFinalization | 10        | 1         |   4.815 us | 0.0951 us | 0.1640 us |   4.774 us |   1.9989 |   8.18 KB |
| AddsUpdatesAndFinalization | 10        | 5         |   4.590 us | 0.0670 us | 0.0523 us |   4.583 us |   1.7776 |   7.27 KB |
| AddsUpdatesAndFinalization | 10        | 10        |   3.841 us | 0.0660 us | 0.0811 us |   3.820 us |   1.5030 |   6.14 KB |
| AddsUpdatesAndFinalization | 100       | -1        |  25.062 us | 0.1847 us | 0.1542 us |  25.051 us |  10.4980 |  42.95 KB |
| AddsUpdatesAndFinalization | 100       | 10        |  35.845 us | 0.6984 us | 0.8833 us |  35.535 us |  15.5640 |   63.8 KB |
| AddsUpdatesAndFinalization | 100       | 50        |  31.572 us | 0.6178 us | 0.8661 us |  31.202 us |  13.3057 |  54.53 KB |
| AddsUpdatesAndFinalization | 100       | 100       |  25.368 us | 0.5032 us | 0.4942 us |  25.149 us |  10.4980 |  42.95 KB |
| AddsUpdatesAndFinalization | 1000      | -1        | 239.723 us | 3.5975 us | 3.1891 us | 239.451 us |  99.6094 | 408.61 KB |
| AddsUpdatesAndFinalization | 1000      | 100       | 345.873 us | 5.4681 us | 4.8473 us | 344.242 us | 151.3672 | 619.52 KB |
| AddsUpdatesAndFinalization | 1000      | 500       | 301.902 us | 3.5411 us | 3.1391 us | 300.495 us | 128.4180 | 525.68 KB |
| AddsUpdatesAndFinalization | 1000      | 1000      | 240.624 us | 2.6498 us | 2.6025 us | 239.769 us |  99.6094 | 408.61 KB |
```

### ToObservableChangeSet_List (After)
```
| Method                     | itemCount | sizeLimit | Mean         | Error       | StdDev       | Median       | Gen0    | Allocated |
|--------------------------- |---------- |---------- |-------------:|------------:|-------------:|-------------:|--------:|----------:|
| AddsUpdatesAndFinalization | 0         | -1        |     623.4 ns |     9.80 ns |      8.69 ns |     622.2 ns |  0.3223 |   1.32 KB |
| AddsUpdatesAndFinalization | 0         | 0         |     650.0 ns |    11.67 ns |     30.32 ns |     639.9 ns |  0.3309 |   1.35 KB |
| AddsUpdatesAndFinalization | 0         | 1         |     688.4 ns |    15.82 ns |     45.38 ns |     669.8 ns |  0.3386 |   1.38 KB |
| AddsUpdatesAndFinalization | 1         | 1         |     798.6 ns |     9.56 ns |      7.98 ns |     799.7 ns |  0.3729 |   1.52 KB |
| AddsUpdatesAndFinalization | 10        | -1        |   1,907.0 ns |    34.82 ns |     32.57 ns |   1,901.5 ns |  0.6084 |   2.49 KB |
| AddsUpdatesAndFinalization | 10        | 1         |   2,260.1 ns |    21.61 ns |     19.16 ns |   2,256.5 ns |  0.8354 |   3.42 KB |
| AddsUpdatesAndFinalization | 10        | 5         |   2,284.9 ns |    36.09 ns |     32.00 ns |   2,280.9 ns |  0.7706 |   3.16 KB |
| AddsUpdatesAndFinalization | 10        | 10        |   2,131.4 ns |    25.93 ns |     24.25 ns |   2,134.0 ns |  0.6905 |   2.82 KB |
| AddsUpdatesAndFinalization | 100       | -1        |  12,564.9 ns |   242.45 ns |    226.78 ns |  12,515.7 ns |  3.1891 |  13.04 KB |
| AddsUpdatesAndFinalization | 100       | 10        |  20,089.4 ns |   465.09 ns |  1,349.32 ns |  19,689.4 ns |  5.3101 |   21.8 KB |
| AddsUpdatesAndFinalization | 100       | 50        |  16,454.8 ns |   231.03 ns |    204.80 ns |  16,408.3 ns |  4.6692 |  19.15 KB |
| AddsUpdatesAndFinalization | 100       | 100       |  14,790.8 ns |   293.89 ns |    632.64 ns |  14,580.3 ns |  3.8605 |  15.83 KB |
| AddsUpdatesAndFinalization | 1000      | -1        | 119,876.9 ns | 1,871.73 ns |  1,461.32 ns | 119,863.6 ns | 28.8086 | 118.51 KB |
| AddsUpdatesAndFinalization | 1000      | 100       | 204,914.5 ns | 6,514.90 ns | 19,209.33 ns | 202,398.3 ns | 50.2930 | 205.67 KB |
| AddsUpdatesAndFinalization | 1000      | 500       | 187,847.0 ns | 6,420.04 ns | 18,929.64 ns | 182,274.3 ns | 43.7012 | 179.11 KB |
| AddsUpdatesAndFinalization | 1000      | 1000      | 144,470.2 ns | 3,321.84 ns |  9,149.32 ns | 140,413.5 ns | 35.6445 | 145.91 KB |
```

TL;DR, this shows a solid 50% reduction in runtime and memory usage, for the list operator, and 70% reduction in runtime with a 50% reduction in memory usage, for the cache operator.

Although, the values in the "Allocations" column are suspicious, to me. It says we're allocating 1.39kB for constructing a stream that we then never emit any items into? I dunno how that possibly makes sense, but I'm assuming the numbers are still relevant, in comparison to what they were before.