### PR TITLE
C#11 Polyfills: `required` and `init`

### DIFF
--- a/src/DynamicData/Polyfills/CompilerFeatureRequiredAttribute.cs
+++ b/src/DynamicData/Polyfills/CompilerFeatureRequiredAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace System.Runtime.CompilerServices;
+
+// Allows use of the C#11 `required` keyword, internally within this library, when targeting frameworks older than .NET 7.
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+internal sealed class CompilerFeatureRequiredAttribute
+    : Attribute
+{
+    public CompilerFeatureRequiredAttribute(string featureName)
+        => FeatureName = featureName;
+
+    public string FeatureName { get; }
+
+    public bool IsOptional { get; init; }
+
+    public const string RefStructs
+        = nameof(RefStructs);
+
+    public const string RequiredMembers
+        = nameof(RequiredMembers);
+}

--- a/src/DynamicData/Polyfills/IsExternalInit.cs
+++ b/src/DynamicData/Polyfills/IsExternalInit.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace System.Runtime.CompilerServices;
+
+// Allows use of the C#11 `init` keyword, internally within this library, when targeting frameworks older than .NET 5.
+internal sealed class IsExternalInit
+{
+}

--- a/src/DynamicData/Polyfills/RequiredMemberAttribute.cs
+++ b/src/DynamicData/Polyfills/RequiredMemberAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices;
+
+// Allows use of the C#11 `required` keyword, internally within this library, when targeting frameworks older than .NET 7.
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal sealed class RequiredMemberAttribute
+    : Attribute
+{
+}


### PR DESCRIPTION
Added "polyfills" to allow internal usage of some C#11 compiler features, including the `required` and `init` keywords.