### PR TITLE
housekeeping: Run sonar cloud coverage results locally after PR build completed

### DIFF
--- a/.github/workflows/pr-test-coverage.yml
+++ b/.github/workflows/pr-test-coverage.yml
@@ -1,10 +1,9 @@
 name: Test Coverage and Quality
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
 
 jobs:
 
@@ -15,7 +14,7 @@ jobs:
         configuration: [Release] # future support for more coverage
 
     runs-on: windows-latest  
-
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Further optimisations may be to cache the results from the build and copy across.