### PR TITLE
Binding options - allow system wide options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,6 +28,7 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_prefer_collection_expression = true:suggestion
 
 [project.json]
 indent_size = 2
@@ -492,7 +493,7 @@ dotnet_diagnostic.SA1202.severity = silent
 
 dotnet_diagnostic.SA1203.severity = error
 
-dotnet_diagnostic.SA1204.severity = error
+dotnet_diagnostic.SA1204.severity = none
 
 dotnet_diagnostic.SA1205.severity = error
 
@@ -548,7 +549,7 @@ dotnet_diagnostic.SA1400.severity = error
 
 dotnet_diagnostic.SA1401.severity = error
 
-dotnet_diagnostic.SA1402.severity = error
+dotnet_diagnostic.SA1402.severity = none
 
 dotnet_diagnostic.SA1403.severity = error
 
@@ -697,6 +698,7 @@ dotnet_diagnostic.SX1309S.severity=silent
 csharp_style_namespace_declarations = block_scoped:silent
 csharp_style_prefer_method_group_conversion = true:silent
 csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/src/DynamicData.Tests/Binding/IObservableListBindListFixture.cs
+++ b/src/DynamicData.Tests/Binding/IObservableListBindListFixture.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
-
+using System.Reactive.Linq;
 using DynamicData.Binding;
 using DynamicData.Tests.Domain;
 
@@ -29,6 +31,98 @@ public class IObservableListBindListFixture : IDisposable
 
         _observableListNotifications = _list.Connect().AsAggregator();
     }
+
+    [Fact]
+    public void ResetThresholdsForBinding_ObservableCollection()
+    {
+        var people = _generator.Take(100).ToArray();
+
+        // check whether reset is fired with different params
+        var test1 = Test();
+        var test2 = Test(new BindingOptions(95));
+        var test3 = Test(new BindingOptions(105, ResetOnFirstTimeLoad: false));
+        var test4 = Test(BindingOptions.NeverFireReset());
+
+
+        test1.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test2.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test3.action.Should().Be(NotifyCollectionChangedAction.Add);
+        test4.action.Should().Be(NotifyCollectionChangedAction.Add);
+
+        return;
+
+        (NotifyCollectionChangedAction action, ObservableCollectionExtended<Person> list) Test(BindingOptions? options = null)
+        {
+            _source.Clear();
+
+            NotifyCollectionChangedAction? result = null;
+
+            var list = new ObservableCollectionExtended<Person>();
+            using var listEvents = list.ObserveCollectionChanges().Take(1)
+                .Select(e => e.EventArgs.Action)
+                .Subscribe(events =>
+                {
+                    result = events;
+                });
+
+
+            var binder = options == null
+                ? _source.Connect().Bind(list).Subscribe()
+                : _source.Connect().Bind(list, options.Value).Subscribe();
+
+            _source.AddRange(people);
+            binder.Dispose();
+
+            return (result!.Value, list);
+        }
+    }
+
+    [Fact]
+    public void ResetThresholdsForBinding_ReadonlyObservableCollection()
+    {
+        var people = _generator.Take(100).ToArray();
+
+
+        // check whether reset is fired with different params
+        var test1 = Test();
+        var test2 = Test(new BindingOptions(95));
+        var test3 = Test(new BindingOptions(105, ResetOnFirstTimeLoad: false));
+        var test4 = Test(BindingOptions.NeverFireReset());
+
+
+        test1.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test2.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test3.action.Should().Be(NotifyCollectionChangedAction.Add);
+        test4.action.Should().Be(NotifyCollectionChangedAction.Add);
+
+        return;
+
+        (NotifyCollectionChangedAction action, ReadOnlyObservableCollection<Person> list) Test(BindingOptions? options = null)
+        {
+            _source.Clear();
+
+            NotifyCollectionChangedAction? result = null;
+            ReadOnlyObservableCollection<Person> list;
+            //var list = new ObservableCollectionExtended<Person>();
+
+            var binder = options == null
+                ? _source.Connect().Bind(out list).Subscribe()
+                : _source.Connect().Bind(out list, options.Value).Subscribe();
+
+            using var listEvents = list.ObserveCollectionChanges().Take(1)
+                .Select(e => e.EventArgs.Action)
+                .Subscribe(events =>
+                {
+                    result = events;
+                });
+
+            _source.AddRange(people);
+            binder.Dispose();
+            return (result!.Value, list);
+        }
+    }
+
+
 
     [Fact]
     public void AddRange()

--- a/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheSortedFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionBindCacheSortedFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reactive.Linq;
@@ -8,7 +9,6 @@ using DynamicData.Binding;
 using DynamicData.Tests.Domain;
 
 using FluentAssertions;
-
 using Xunit;
 
 namespace DynamicData.Tests.Binding;
@@ -17,11 +17,11 @@ public class ObservableCollectionBindCacheSortedFixture : IDisposable
 {
     private readonly IDisposable _binder;
 
-    private readonly ObservableCollectionExtended<Person> _collection = new ObservableCollectionExtended<Person>();
+    private readonly ObservableCollectionExtended<Person> _collection;
 
     private readonly IComparer<Person> _comparer = SortExpressionComparer<Person>.Ascending(p => p.Name);
 
-    private readonly RandomPersonGenerator _generator = new RandomPersonGenerator();
+    private readonly RandomPersonGenerator _generator = new();
 
     private readonly ISourceCache<Person, string> _source;
 
@@ -30,6 +30,99 @@ public class ObservableCollectionBindCacheSortedFixture : IDisposable
         _collection = new ObservableCollectionExtended<Person>();
         _source = new SourceCache<Person, string>(p => p.Name);
         _binder = _source.Connect().Sort(_comparer, resetThreshold: 25).Bind(_collection).Subscribe();
+    }
+
+
+    [Fact]
+    public void ResetThresholdsForBinding_ObservableCollection()
+    {
+        var people = _generator.Take(100).ToArray();
+
+
+
+        // check whether reset is fired with different params
+        var test1 = Test();
+        var test2 = Test(new BindingOptions(95));
+        var test3 = Test(new BindingOptions(105, ResetOnFirstTimeLoad: false));
+        var test4 = Test(BindingOptions.NeverFireReset());
+
+
+        test1.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test2.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test3.action.Should().Be(NotifyCollectionChangedAction.Add);
+        test4.action.Should().Be(NotifyCollectionChangedAction.Add);
+
+        return;
+
+        (NotifyCollectionChangedAction action, ObservableCollectionExtended<Person> list) Test(BindingOptions? options = null)
+        {
+            _source.Clear();
+
+            NotifyCollectionChangedAction? result = null;
+
+            var list = new ObservableCollectionExtended<Person>();
+            using var listEvents = list.ObserveCollectionChanges().Take(1)
+                .Select(e => e.EventArgs.Action)
+                .Subscribe(events =>
+                {
+                    result = events;
+                });
+
+
+            var binder = options == null
+                ? _source.Connect().Sort(_comparer).Bind(list).Subscribe()
+                : _source.Connect().Sort(_comparer).Bind(list, options.Value).Subscribe();
+
+            _source.AddOrUpdate(people);
+            binder.Dispose();
+
+            return (result!.Value, list);
+        }
+    }
+
+    [Fact]
+    public void ResetThresholdsForBinding_ReadonlyObservableCollection()
+    {
+        var people = _generator.Take(100).ToArray();
+
+
+        // check whether reset is fired with different params
+        var test1 = Test();
+        var test2 = Test(new BindingOptions(95));
+        var test3 = Test(new BindingOptions(105, ResetOnFirstTimeLoad: false));
+        var test4 = Test(BindingOptions.NeverFireReset());
+
+
+        test1.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test2.action.Should().Be(NotifyCollectionChangedAction.Reset);
+        test3.action.Should().Be(NotifyCollectionChangedAction.Add);
+        test4.action.Should().Be(NotifyCollectionChangedAction.Add);
+
+        return;
+
+        (NotifyCollectionChangedAction action, ReadOnlyObservableCollection<Person> list) Test(BindingOptions? options = null)
+        {
+            _source.Clear();
+
+            NotifyCollectionChangedAction? result = null;
+            ReadOnlyObservableCollection<Person> list;
+            //var list = new ObservableCollectionExtended<Person>();
+
+            var binder = options == null 
+                ? _source.Connect().Sort(_comparer).Bind(out list).Subscribe() 
+                : _source.Connect().Sort(_comparer).Bind(out list, options.Value).Subscribe();
+
+            using var listEvents = list.ObserveCollectionChanges().Take(1)
+                .Select(e => e.EventArgs.Action)
+                .Subscribe(events =>
+                {
+                    result = events;
+                });
+
+            _source.AddOrUpdate(people);
+            binder.Dispose();
+            return (result!.Value, list);
+        }
     }
 
     [Fact]

--- a/src/DynamicData/Binding/BindingListAdaptor.cs
+++ b/src/DynamicData/Binding/BindingListAdaptor.cs
@@ -28,7 +28,7 @@ namespace DynamicData.Binding
         /// </summary>
         /// <param name="list">The list of items to add to the adapter.</param>
         /// <param name="refreshThreshold">The threshold before a reset is issued.</param>
-        public BindingListAdaptor(BindingList<T> list, int refreshThreshold = 25)
+        public BindingListAdaptor(BindingList<T> list, int refreshThreshold = BindingOptions.DefaultResetThreshold)
         {
             _list = list ?? throw new ArgumentNullException(nameof(list));
             _refreshThreshold = refreshThreshold;
@@ -80,7 +80,7 @@ namespace DynamicData.Binding
         /// </summary>
         /// <param name="list">The list of items to adapt.</param>
         /// <param name="refreshThreshold">The threshold before the refresh is triggered.</param>
-        public BindingListAdaptor(BindingList<TObject> list, int refreshThreshold = 25)
+        public BindingListAdaptor(BindingList<TObject> list, int refreshThreshold = BindingOptions.DefaultResetThreshold)
         {
             _list = list ?? throw new ArgumentNullException(nameof(list));
             _refreshThreshold = refreshThreshold;

--- a/src/DynamicData/Binding/BindingOptions.cs
+++ b/src/DynamicData/Binding/BindingOptions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace DynamicData.Binding;
+
+/// <summary>
+/// System wide default values for binding operators.
+/// </summary>
+/// <param name="UseReplaceForUpdates">The reset threshold ie the number of changes before a reset is fired.</param>
+/// <param name="ResetOnFirstTimeLoad"> Should a reset be fired for a first time load.This option is due to historic reasons where a reset would be fired for the first time load regardless of the number of changes.</param>
+/// <param name="UseReplaceForUpdates"> When possible, should replace be used instead of remove and add.</param>
+public record struct BindingOptions(int ResetThreshold, bool UseReplaceForUpdates = true, bool ResetOnFirstTimeLoad = true)
+{
+    /// <summary>
+    /// Creates binding options to never fire a reset event.
+    /// </summary>
+    /// <param name="useReplaceForUpdates"> When possible, should replace be used instead of remove and add.</param>
+    /// <returns> The binding options.</returns>
+    public static BindingOptions NeverFireReset(bool useReplaceForUpdates = true)
+    {
+        return new BindingOptions(int.MaxValue, useReplaceForUpdates, false);
+    }
+}
+
+/// <summary>
+/// System wide default values for binding operators.
+/// </summary>
+public static class DynamicDataOptions
+{
+    /// <summary>
+    /// Gets or sets the default values for all binding operations.
+    /// </summary>
+    public static BindingOptions Binding { get; set; } = new(25);
+}

--- a/src/DynamicData/Binding/BindingOptions.cs
+++ b/src/DynamicData/Binding/BindingOptions.cs
@@ -7,17 +7,32 @@ namespace DynamicData.Binding;
 /// <summary>
 /// System wide default values for binding operators.
 /// </summary>
-/// <param name="UseReplaceForUpdates">The reset threshold ie the number of changes before a reset is fired.</param>
+/// <param name="ResetThreshold">The reset threshold ie the number of changes before a reset is fired.</param>
 /// <param name="ResetOnFirstTimeLoad"> Should a reset be fired for a first time load.This option is due to historic reasons where a reset would be fired for the first time load regardless of the number of changes.</param>
 /// <param name="UseReplaceForUpdates"> When possible, should replace be used instead of remove and add.</param>
-public record struct BindingOptions(int ResetThreshold, bool UseReplaceForUpdates = true, bool ResetOnFirstTimeLoad = true)
+public record struct BindingOptions(int ResetThreshold, bool UseReplaceForUpdates = BindingOptions.DefaultUseReplaceForUpdates, bool ResetOnFirstTimeLoad = BindingOptions.DefaultResetOnFirstTimeLoad)
 {
+    /// <summary>
+    /// The system wide factory settings default ResetThreshold.
+    /// </summary>
+    public const int DefaultResetThreshold = 25;
+
+    /// <summary>
+    /// The system wide factory settings default UseReplaceForUpdates value.
+    /// </summary>
+    public const bool DefaultUseReplaceForUpdates = true;
+
+    /// <summary>
+    /// The system wide factory settings default ResetOnFirstTimeLoad value.
+    /// </summary>
+    public const bool DefaultResetOnFirstTimeLoad = true;
+
     /// <summary>
     /// Creates binding options to never fire a reset event.
     /// </summary>
     /// <param name="useReplaceForUpdates"> When possible, should replace be used instead of remove and add.</param>
     /// <returns> The binding options.</returns>
-    public static BindingOptions NeverFireReset(bool useReplaceForUpdates = true)
+    public static BindingOptions NeverFireReset(bool useReplaceForUpdates = DefaultResetOnFirstTimeLoad)
     {
         return new BindingOptions(int.MaxValue, useReplaceForUpdates, false);
     }
@@ -31,5 +46,5 @@ public static class DynamicDataOptions
     /// <summary>
     /// Gets or sets the default values for all binding operations.
     /// </summary>
-    public static BindingOptions Binding { get; set; } = new(25);
+    public static BindingOptions Binding { get; set; } = new(BindingOptions.DefaultResetThreshold);
 }

--- a/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
@@ -20,7 +20,12 @@ namespace DynamicData.Binding;
 /// <param name="allowReplace"> Use replace instead of remove / add for updates. </param>
 /// <param name="resetOnFirstTimeLoad"> Should a reset be fired for a first time load.This option is due to historic reasons where a reset would be fired for the first time load regardless of the number of changes.</param>
 /// <exception cref="System.ArgumentNullException">collection.</exception>
-public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection, int refreshThreshold, bool allowReplace = true, bool resetOnFirstTimeLoad = true) : IChangeSetAdaptor<T>
+public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection, int refreshThreshold,
+#pragma warning disable CS9113 // Parameter is unread.
+    bool allowReplace = true,
+#pragma warning restore CS9113 // Parameter is unread.
+    bool resetOnFirstTimeLoad = true) : IChangeSetAdaptor<T>
+
     where T : notnull
 {
     private readonly IObservableCollection<T> _collection = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -31,7 +36,7 @@ public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection,
     /// </summary>
     /// <param name="collection">The collection.</param>
     public ObservableCollectionAdaptor(IObservableCollection<T> collection)
-        : this(collection, DynamicDataOptions.BindingOptions)
+        : this(collection, DynamicDataOptions.Binding)
     {
     }
 
@@ -41,7 +46,7 @@ public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection,
     /// <param name="options"> The binding options.</param>
     /// <param name="collection">The collection.</param>
     public ObservableCollectionAdaptor(IObservableCollection<T> collection, BindingOptions options)
-        : this(collection, options.ResetThreshold, options.UseReplaceForUpdates, options.UseReplaceForUpdates)
+        : this(collection, options.ResetThreshold, options.UseReplaceForUpdates, options.ResetOnFirstTimeLoad)
     {
     }
 
@@ -97,7 +102,7 @@ public class ObservableCollectionAdaptor<TObject, TKey>(int refreshThreshold = 2
     /// </summary>
     /// <param name="options"> The binding options.</param>
     public ObservableCollectionAdaptor(BindingOptions options)
-        : this(options.ResetThreshold, options.UseReplaceForUpdates, options.UseReplaceForUpdates)
+        : this(options.ResetThreshold, options.UseReplaceForUpdates, options.ResetOnFirstTimeLoad)
     {
     }
 

--- a/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/ObservableCollectionAdaptor.cs
@@ -16,13 +16,34 @@ namespace DynamicData.Binding;
 /// Initializes a new instance of the <see cref="ObservableCollectionAdaptor{T}"/> class.
 /// </remarks>
 /// <param name="collection">The collection.</param>
-/// <param name="refreshThreshold">The refresh threshold.</param>
+/// <param name="refreshThreshold">The number of changes before a Reset event is used.</param>
+/// <param name="allowReplace"> Use replace instead of remove / add for updates. </param>
+/// <param name="resetOnFirstTimeLoad"> Should a reset be fired for a first time load.This option is due to historic reasons where a reset would be fired for the first time load regardless of the number of changes.</param>
 /// <exception cref="System.ArgumentNullException">collection.</exception>
-public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection, int refreshThreshold = 25) : IChangeSetAdaptor<T>
+public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection, int refreshThreshold, bool allowReplace = true, bool resetOnFirstTimeLoad = true) : IChangeSetAdaptor<T>
     where T : notnull
 {
     private readonly IObservableCollection<T> _collection = collection ?? throw new ArgumentNullException(nameof(collection));
     private bool _loaded;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableCollectionAdaptor{TObject}"/> class.
+    /// </summary>
+    /// <param name="collection">The collection.</param>
+    public ObservableCollectionAdaptor(IObservableCollection<T> collection)
+        : this(collection, DynamicDataOptions.BindingOptions)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableCollectionAdaptor{TObject}"/> class.
+    /// </summary>
+    /// <param name="options"> The binding options.</param>
+    /// <param name="collection">The collection.</param>
+    public ObservableCollectionAdaptor(IObservableCollection<T> collection, BindingOptions options)
+        : this(collection, options.ResetThreshold, options.UseReplaceForUpdates, options.UseReplaceForUpdates)
+    {
+    }
 
     /// <summary>
     /// Maintains the specified collection from the changes.
@@ -35,7 +56,7 @@ public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection,
             throw new ArgumentNullException(nameof(changes));
         }
 
-        if (changes.TotalChanges - changes.Refreshes > refreshThreshold || !_loaded)
+        if (changes.TotalChanges - changes.Refreshes > refreshThreshold || (!_loaded && resetOnFirstTimeLoad))
         {
             using (_collection.SuspendNotifications())
             {
@@ -45,6 +66,7 @@ public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection,
         }
         else
         {
+            // TODO: pass in allowReplace to handle replace vs remove / add
             _collection.Clone(changes);
         }
     }
@@ -61,13 +83,23 @@ public class ObservableCollectionAdaptor<T>(IObservableCollection<T> collection,
 /// </remarks>
 /// <param name="refreshThreshold">The threshold before a reset notification is triggered.</param>
 /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates. </param>
+/// <param name="resetOnFirstTimeLoad"> Should a reset be fired for a first time load.This option is due to historic reasons where a reset would be fired for the first time load regardless of the number of changes.</param>
 [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Same class name, only generic difference.")]
-public class ObservableCollectionAdaptor<TObject, TKey>(int refreshThreshold = 25, bool useReplaceForUpdates = false) : IObservableCollectionAdaptor<TObject, TKey>
+public class ObservableCollectionAdaptor<TObject, TKey>(int refreshThreshold = 25, bool useReplaceForUpdates = true, bool resetOnFirstTimeLoad = true) : IObservableCollectionAdaptor<TObject, TKey>
     where TObject : notnull
     where TKey : notnull
 {
     private readonly Cache<TObject, TKey> _cache = new();
     private bool _loaded;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableCollectionAdaptor{TObject, TKey}"/> class.
+    /// </summary>
+    /// <param name="options"> The binding options.</param>
+    public ObservableCollectionAdaptor(BindingOptions options)
+        : this(options.ResetThreshold, options.UseReplaceForUpdates, options.UseReplaceForUpdates)
+    {
+    }
 
     /// <summary>
     /// Maintains the specified collection from the changes.
@@ -88,7 +120,7 @@ public class ObservableCollectionAdaptor<TObject, TKey>(int refreshThreshold = 2
 
         _cache.Clone(changes);
 
-        if (changes.Count - changes.Refreshes > refreshThreshold || !_loaded)
+        if (changes.Count - changes.Refreshes > refreshThreshold || (!_loaded && resetOnFirstTimeLoad))
         {
             _loaded = true;
             using (collection.SuspendNotifications())

--- a/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
@@ -33,7 +33,7 @@ public class SortedObservableCollectionAdaptor<TObject, TKey>(int refreshThresho
     /// </summary>
     /// <param name="options"> The binding options.</param>
     public SortedObservableCollectionAdaptor(BindingOptions options)
-        : this(options.ResetThreshold, options.UseReplaceForUpdates, options.UseReplaceForUpdates)
+        : this(options.ResetThreshold, options.UseReplaceForUpdates, options.ResetOnFirstTimeLoad)
     {
     }
 
@@ -58,7 +58,16 @@ public class SortedObservableCollectionAdaptor<TObject, TKey>(int refreshThresho
         {
             case SortReason.ComparerChanged:
             case SortReason.Reset:
-                using (collection.SuspendNotifications())
+
+                // Multiply items count by 2 as we need to clear existing items
+                if (changes.SortedItems.Count * 2 > refreshThreshold)
+                {
+                    using (collection.SuspendNotifications())
+                    {
+                        collection.Load(changes.SortedItems.Select(kv => kv.Value));
+                    }
+                }
+                else
                 {
                     collection.Load(changes.SortedItems.Select(kv => kv.Value));
                 }

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -600,15 +600,8 @@ public static class ObservableCacheEx
         where TObject : notnull
         where TKey : notnull
     {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (destination is null)
-        {
-            throw new ArgumentNullException(nameof(destination));
-        }
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
 
         return source.Bind(destination, new ObservableCollectionAdaptor<TObject, TKey>(refreshThreshold));
     }
@@ -627,20 +620,9 @@ public static class ObservableCacheEx
         where TObject : notnull
         where TKey : notnull
     {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (destination is null)
-        {
-            throw new ArgumentNullException(nameof(destination));
-        }
-
-        if (updater is null)
-        {
-            throw new ArgumentNullException(nameof(updater));
-        }
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+        if (updater is null) throw new ArgumentNullException(nameof(updater));
 
         return Observable.Create<IChangeSet<TObject, TKey>>(
             observer =>
@@ -653,103 +635,6 @@ public static class ObservableCacheEx
                         return changes;
                     }).SubscribeSafe(observer);
             });
-    }
-
-    /// <summary>
-    ///  Binds the results to the specified observable collection using the default update algorithm.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <param name="source">The source.</param>
-    /// <param name="destination">The destination.</param>
-    /// <returns>An observable which will emit change sets.</returns>
-    /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination)
-        where TObject : notnull
-        where TKey : notnull
-    {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (destination is null)
-        {
-            throw new ArgumentNullException(nameof(destination));
-        }
-
-        var updater = new SortedObservableCollectionAdaptor<TObject, TKey>();
-        return source.Bind(destination, updater);
-    }
-
-    /// <summary>
-    /// Binds the results to the specified binding collection using the specified update algorithm.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <param name="source">The source.</param>
-    /// <param name="destination">The destination.</param>
-    /// <param name="updater">The updater.</param>
-    /// <returns>An observable which will emit change sets.</returns>
-    /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, ISortedObservableCollectionAdaptor<TObject, TKey> updater)
-        where TObject : notnull
-        where TKey : notnull
-    {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        if (destination is null)
-        {
-            throw new ArgumentNullException(nameof(destination));
-        }
-
-        if (updater is null)
-        {
-            throw new ArgumentNullException(nameof(updater));
-        }
-
-        return Observable.Create<ISortedChangeSet<TObject, TKey>>(
-            observer =>
-            {
-                var locker = new object();
-                return source.Synchronize(locker).Select(
-                    changes =>
-                    {
-                        updater.Adapt(changes, destination);
-                        return changes;
-                    }).SubscribeSafe(observer);
-            });
-    }
-
-    /// <summary>
-    /// Binds the results to the specified readonly observable collection using the default update algorithm.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <param name="source">The source.</param>
-    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
-    /// <param name="resetThreshold">The number of changes before a reset event is called on the observable collection.</param>
-    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates.  NB: Some platforms to not support replace notifications for binding.</param>
-    /// <param name="adaptor">Specify an adaptor to change the algorithm to update the target collection.</param>
-    /// <returns>An observable which will emit change sets.</returns>
-    /// <exception cref="System.ArgumentNullException">source.</exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, bool useReplaceForUpdates = true, ISortedObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
-        where TObject : notnull
-        where TKey : notnull
-    {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        var target = new ObservableCollectionExtended<TObject>();
-        var result = new ReadOnlyObservableCollection<TObject>(target);
-        var updater = adaptor ?? new SortedObservableCollectionAdaptor<TObject, TKey>(resetThreshold, useReplaceForUpdates);
-        readOnlyObservableCollection = result;
-        return source.Bind(target, updater);
     }
 
     /// <summary>
@@ -778,6 +663,132 @@ public static class ObservableCacheEx
         var updater = adaptor ?? new ObservableCollectionAdaptor<TObject, TKey>(resetThreshold, useReplaceForUpdates);
         readOnlyObservableCollection = result;
         return source.Bind(target, updater);
+    }
+
+    /// <summary>
+    ///  Binds the results to the specified observable collection using the default update algorithm.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="destination">The destination.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    /// <exception cref="System.ArgumentNullException">source.</exception>
+    public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+
+        return source.Bind(destination, DynamicDataOptions.BindingOptions);
+    }
+
+    /// <summary>
+    ///  Binds the results to the specified observable collection using the default update algorithm.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="destination">The destination.</param>
+    /// <param name="options"> The binding options.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    /// <exception cref="System.ArgumentNullException">source.</exception>
+    public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, BindingOptions options)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+
+        var updater = new SortedObservableCollectionAdaptor<TObject, TKey>(options);
+        return source.Bind(destination, updater);
+    }
+
+    /// <summary>
+    /// Binds the results to the specified binding collection using the specified update algorithm.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="destination">The destination.</param>
+    /// <param name="updater">The updater.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    /// <exception cref="System.ArgumentNullException">source.</exception>
+    public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, IObservableCollection<TObject> destination, ISortedObservableCollectionAdaptor<TObject, TKey> updater)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+        if (updater is null) throw new ArgumentNullException(nameof(updater));
+
+        return Observable.Create<ISortedChangeSet<TObject, TKey>>(
+            observer =>
+            {
+                var locker = new object();
+                return source.Synchronize(locker).Select(
+                    changes =>
+                    {
+                        updater.Adapt(changes, destination);
+                        return changes;
+                    }).SubscribeSafe(observer);
+            });
+    }
+
+    /// <summary>
+    /// Binds the results to the specified readonly observable collection using the default update algorithm.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
+    /// <param name="options"> The binding options.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    /// <exception cref="System.ArgumentNullException">source.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, BindingOptions options)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        var target = new ObservableCollectionExtended<TObject>();
+        var result = new ReadOnlyObservableCollection<TObject>(target);
+        var updater = new SortedObservableCollectionAdaptor<TObject, TKey>(options);
+        readOnlyObservableCollection = result;
+        return source.Bind(target, updater);
+    }
+
+    /// <summary>
+    /// Binds the results to the specified readonly observable collection using the default update algorithm.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
+    /// <param name="resetThreshold">The number of changes before a reset event is called on the observable collection.</param>
+    /// <param name="useReplaceForUpdates"> Use replace instead of remove / add for updates.  NB: Some platforms to not support replace notifications for binding.</param>
+    /// <param name="adaptor">Specify an adaptor to change the algorithm to update the target collection.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    /// <exception cref="System.ArgumentNullException">source.</exception>
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, bool useReplaceForUpdates = true, ISortedObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+
+        // if user has not specified different defaults, use system wide defaults instead.
+        // This is a hack to retro fit system wide defaults which override the hard coded defaults above
+        adaptor ??= resetThreshold == 25 && useReplaceForUpdates
+            ? new SortedObservableCollectionAdaptor<TObject, TKey>(DynamicDataOptions.BindingOptions)
+            : new SortedObservableCollectionAdaptor<TObject, TKey>(resetThreshold, useReplaceForUpdates, DynamicDataOptions.BindingOptions.ResetOnFirstTimeLoad);
+
+        var target = new ObservableCollectionExtended<TObject>();
+        readOnlyObservableCollection = new ReadOnlyObservableCollection<TObject>(target);
+        return source.Bind(target, adaptor);
     }
 
 #if SUPPORTS_BINDINGLIST
@@ -812,10 +823,6 @@ public static class ObservableCacheEx
 
         return source.Adapt(new BindingListAdaptor<TObject, TKey>(bindingList, resetThreshold));
     }
-
-#endif
-
-#if SUPPORTS_BINDINGLIST
 
     /// <summary>
     /// Binds a clone of the observable change set to the target observable collection.
@@ -3665,12 +3672,14 @@ public static class ObservableCacheEx
             throw new ArgumentNullException(nameof(refreshAction));
         }
 
-        return source.Do(delegate(IChangeSet<TObject, TKey> changes)
+        return source.Do(changes =>
         {
-            changes.Where((Change<TObject, TKey> c) => c.Reason == ChangeReason.Refresh).ForEach(delegate(Change<TObject, TKey> c)
+            foreach (var change in changes.ToConcreteType())
             {
-                refreshAction2(c.Current);
-            });
+                if (change.Reason != ChangeReason.Refresh) continue;
+
+                refreshAction2(change.Current);
+            }
         });
     }
 

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -285,7 +285,7 @@ public static class ObservableListEx
     /// or
     /// targetCollection.
     /// </exception>
-    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, IObservableCollection<T> targetCollection, int resetThreshold = 25)
+    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, IObservableCollection<T> targetCollection, int resetThreshold = BindingOptions.DefaultResetThreshold)
         where T : notnull
     {
         if (source is null)
@@ -300,9 +300,9 @@ public static class ObservableListEx
 
         // if user has not specified different defaults, use system wide defaults instead.
         // This is a hack to retro fit system wide defaults which override the hard coded defaults above
-        var defaults = DynamicDataOptions.BindingOptions;
+        var defaults = DynamicDataOptions.Binding;
 
-        var options = resetThreshold == 25
+        var options = resetThreshold == BindingOptions.DefaultResetThreshold
             ? defaults
             : defaults with { ResetThreshold = resetThreshold };
 
@@ -347,7 +347,7 @@ public static class ObservableListEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>A continuation of the source stream.</returns>
-    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, out ReadOnlyObservableCollection<T> readOnlyObservableCollection, int resetThreshold = 25)
+    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, out ReadOnlyObservableCollection<T> readOnlyObservableCollection, int resetThreshold = BindingOptions.DefaultResetThreshold)
         where T : notnull
     {
         if (source is null)
@@ -357,8 +357,8 @@ public static class ObservableListEx
 
         // if user has not specified different defaults, use system wide defaults instead.
         // This is a hack to retro fit system wide defaults which override the hard coded defaults above
-        var defaults = DynamicDataOptions.BindingOptions;
-        var options = resetThreshold == 25
+        var defaults = DynamicDataOptions.Binding;
+        var options = resetThreshold == BindingOptions.DefaultResetThreshold
             ? defaults
             : defaults with { ResetThreshold = resetThreshold };
 
@@ -403,7 +403,7 @@ public static class ObservableListEx
     /// targetCollection.
     /// </exception>
     /// <returns>An observable which emits the change set.</returns>
-    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, BindingList<T> bindingList, int resetThreshold = 25)
+    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, BindingList<T> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
         where T : notnull
     {
         if (source is null)


### PR DESCRIPTION
Allow system wide binding option defaults + add capability to suppress reset for first time load,

Currently binding options like reset threshold can be specified at the bind operator.  For example, 

```cs
myObservableChangeSet.Bind(var out myCollection, resetThreshold:100);
```
The limitation here is you may want to specify system wide defaults, which will eliminate the need to specify the threshold on every bind instance. To solve this problem, static system wide options have been introduced.

```cs
DynamicDataOptions.Binding = new BindingOptions(100)
```
which means

```cs
myObservableChangeSet.Bind(var out myCollection);
```
will have a default threshold of 100, without the need to specify it.

There are additional options on BindingObject:

**UseReplaceForUpdates**  - some control suites / platforms cannot handle replace events on the observable collection. If not true, replace and add new is used, 
**ResetOnFirstTimeLoad**  - similar to above, some control suites cannot handle a reset event so there's an option to prevent reset on first time load.

These options can be applied globally or at an individual bind level:

```cs
myObservableChangeSet.Bind(var out myCollection, new BindingOptions(100, ResetOnFirstTimeLoad : false);

// or to prevent reset completely and not just for the first time load
myObservableChangeSet.Bind(var out myCollection, new BindingOptions(100, BindingOptions.NeverFireReset());
```
Tests to follow, and there should be no breaking changes.





