### PR TITLE
List-to-List MergeManyChangeSets

### DIFF
--- a/src/DynamicData.Tests/Domain/Animal.cs
+++ b/src/DynamicData.Tests/Domain/Animal.cs
@@ -15,18 +15,11 @@ public enum AnimalFamily
     Bird
 }
 
-public class Animal : AbstractNotifyPropertyChanged
+public class Animal(string name, string type, AnimalFamily family, bool include = true) : AbstractNotifyPropertyChanged
 {
-    private bool _includeInResults;
+    private bool _includeInResults = include;
 
-    public Animal(string name, string type, AnimalFamily family)
-    {
-        Name = name;
-        Type = type;
-        Family = family;
-    }
-
-    public AnimalFamily Family { get; }
+    public AnimalFamily Family { get; } = family;
 
     public bool IncludeInResults
     {
@@ -34,7 +27,7 @@ public class Animal : AbstractNotifyPropertyChanged
         set => SetAndRaise(ref _includeInResults, value);
     }
 
-    public string Name { get; }
+    public string Name { get; } = name;
 
-    public string Type { get; }
+    public string Type { get; } = type;
 }

--- a/src/DynamicData.Tests/Domain/Animal.cs
+++ b/src/DynamicData.Tests/Domain/Animal.cs
@@ -30,4 +30,8 @@ public class Animal(string name, string type, AnimalFamily family, bool include 
     public string Name { get; } = name;
 
     public string Type { get; } = type;
+
+    public string FormalName => $"{Name} the {Type}";
+
+    public override string ToString() => $"{FormalName} ({Family})";
 }

--- a/src/DynamicData.Tests/Domain/AnimalOwner.cs
+++ b/src/DynamicData.Tests/Domain/AnimalOwner.cs
@@ -1,0 +1,15 @@
+﻿
+using System;
+
+namespace DynamicData.Tests.Domain;
+
+internal class AnimalOwner(string name) : IDisposable
+{
+    public Guid Id { get; } = Guid.NewGuid();
+
+    public string Name => name;
+
+    public ISourceList<Animal> Animals { get; } = new SourceList<Animal>();
+
+    public void Dispose() => Animals.Dispose();
+}

--- a/src/DynamicData.Tests/Domain/Fakers.cs
+++ b/src/DynamicData.Tests/Domain/Fakers.cs
@@ -1,0 +1,53 @@
+﻿using Bogus;
+
+namespace DynamicData.Tests.Domain;
+
+internal static class Fakers
+{
+    const int MinAnimals = 3;
+#if DEBUG
+    const int MaxAnimals = 7;
+#else
+    const int MaxAnimals = 23;
+#endif
+
+    private static readonly string[][] AnimalTypeNames =
+    [
+        // Mammal
+        ["Dog", "Cat", "Ferret", "Hamster", "Gerbil", "Cavie", "Mouse", "Pot-Bellied Pig"],
+
+        // Reptile
+        ["Corn Snake", "Python", "Gecko", "Skink", "Monitor Lizard", "Chameleon", "Tortoise", "Box Turtle", "Iguana"],
+
+        // Fish
+        ["Betta", "Goldfish", "Angelfish", "Catfish", "Guppie", "Mollie", "Neon Tetra", "Platie", "Koi"],
+
+        // Amphibian
+        ["Frog", "Toad", "Salamander"],
+
+        // Bird
+        ["Parakeet", "Cockatoo", "Parrot", "Finch", "Conure", "Lovebird", "Cockatiel"],
+    ];
+
+    public static Faker<Animal> Animal { get; } =
+        new Faker<Animal>()
+            .CustomInstantiator(faker =>
+            {
+                var family = faker.PickRandom<AnimalFamily>();
+                var type = faker.PickRandom(AnimalTypeNames[(int)family]);
+                var name = $"{faker.Commerce.ProductAdjective()} the {type}";
+
+                return new Animal(name, type, family);
+            });
+
+    public static Faker<AnimalOwner> AnimalOwner { get; } =
+        new Faker<AnimalOwner>()
+            .CustomInstantiator(faker =>
+            {
+                var result = new AnimalOwner(faker.Person.FullName);
+
+                result.Animals.AddRange(Animal.Generate(faker.Random.Number(MinAnimals, MaxAnimals)));
+
+                return result;
+            });
+}

--- a/src/DynamicData.Tests/Domain/Fakers.cs
+++ b/src/DynamicData.Tests/Domain/Fakers.cs
@@ -35,7 +35,7 @@ internal static class Fakers
             {
                 var family = faker.PickRandom<AnimalFamily>();
                 var type = faker.PickRandom(AnimalTypeNames[(int)family]);
-                var name = $"{faker.Commerce.ProductAdjective()} the {type}";
+                var name = faker.Commerce.ProductAdjective();
 
                 return new Animal(name, type, family);
             });

--- a/src/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/src/DynamicData.Tests/DynamicData.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618;CA1801;CA1063;CS8767;CS8602;CS8618;IDE1006</NoWarn>
@@ -14,8 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />

--- a/src/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/src/DynamicData.Tests/DynamicData.Tests.csproj
@@ -12,7 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace DynamicData.Tests.List;
 
-public sealed class MergeManyCacheChangeSetsFixture : IDisposable
+public sealed class MergeManyChangeSetsCacheFixture : IDisposable
 {
 #if DEBUG
     const int MarketCount = 3;
@@ -36,7 +36,7 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
 
     private readonly ChangeSetAggregator<IMarket> _marketListResults;
 
-    public MergeManyCacheChangeSetsFixture()
+    public MergeManyChangeSetsCacheFixture()
     {
         _marketListResults = _marketList.Connect().AsAggregator();
     }
@@ -748,18 +748,4 @@ public sealed class MergeManyCacheChangeSetsFixture : IDisposable
         _marketList.Dispose();
         _marketList.Clear();
     }
-}
-
-internal static class Extensions
-{
-    public static T With<T>(this T item, Action<T> action)
-    {
-        action(item);
-        return item;
-    }
-
-    public static IObservable<T> ForceFail<T>(this IObservable<T> source, int count, Exception? e) =>
-        (e is not null)
-            ? source.Take(count).Concat(Observable.Throw<T>(e))
-            : source;
 }

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
@@ -1,0 +1,446 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using Bogus;
+using DynamicData.Kernel;
+using DynamicData.Tests.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.List;
+
+public sealed class MergeManyChangeSetsListFixture : IDisposable
+{
+#if DEBUG
+    const int InitialOwnerCount = 7;
+    const int AddRangeSize = 5;
+    const int RemoveRangeSize = 3;
+#else
+    const int InitialOwnerCount = 103;
+    const int AddRangeSize = 53;
+    const int RemoveRangeSize = 37;
+#endif
+
+    private readonly ISourceList<AnimalOwner> _animalOwners = new SourceList<AnimalOwner>();
+    private readonly IObservableList<Animal> _animals;
+    private readonly ChangeSetAggregator<AnimalOwner> _animalOwnerResults;
+    private readonly ChangeSetAggregator<Animal> _animalChangeSetResults;
+    private readonly ChangeSetAggregator<Animal> _animalResults;
+    private readonly IDisposable _disposable;
+    private readonly Randomizer _randomizer;
+
+    public MergeManyChangeSetsListFixture()
+    {
+        Randomizer.Seed = new Random(0x12291977);
+        _randomizer = new Randomizer();
+        _animalOwners.AddRange(Fakers.AnimalOwner.Generate(InitialOwnerCount));
+
+        var sharedAnimalChanges = _animalOwners.Connect().MergeManyChangeSets(owner => owner.Animals.Connect()).Publish();
+        _animalOwnerResults = _animalOwners.Connect().AsAggregator();
+        _animalChangeSetResults = sharedAnimalChanges.AsAggregator();
+        _animals = sharedAnimalChanges.AsObservableList();
+        _animalResults = _animals.Connect().AsAggregator();
+        _disposable = sharedAnimalChanges.Connect();
+    }
+
+    [Fact]
+    public void ResultContainsAllInitialChildren()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsChildrenFromParentsAddedWithAddRange()
+    {
+        // Arrange
+        var addThese = Fakers.AnimalOwner.Generate(AddRangeSize);
+
+        // Act
+        _animalOwners.AddRange(addThese);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + AddRangeSize);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + AddRangeSize);
+        addThese.SelectMany(added => added.Animals.Items).ForEach(added => _animals.Items.Should().Contain(added));
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsChildrenFromParentsAddedWithAdd()
+    {
+        // Arrange
+        var addThis = Fakers.AnimalOwner.Generate();
+
+        // Act
+        _animalOwners.Add(addThis);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + 1);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        addThis.Animals.Items.ForEach(added => _animals.Items.Should().Contain(added));
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsChildrenFromParentsAddedWithInsert()
+    {
+        // Arrange
+        var insertIndex = _randomizer.Number(_animalOwners.Count);
+        var insertThis = Fakers.AnimalOwner.Generate();
+
+        // Act
+        _animalOwners.Insert(insertIndex, insertThis);
+
+        // Assert
+        _animalOwners.Items.ElementAt(insertIndex).Should().Be(insertThis);
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + 1);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        insertThis.Animals.Items.ForEach(added => _animals.Items.Should().Contain(added));
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenFromParentsRemovedWithRemove()
+    {
+        // Arrange
+        var removeThis = _randomizer.ListItem(_animalOwners.Items.ToList());
+
+        // Act
+        _animalOwners.Remove(removeThis);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - 1);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        removeThis.Animals.Items.ForEach(removed => _animals.Items.Should().NotContain(removed));
+        CheckResultContents();
+        removeThis.Dispose();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenFromParentsRemovedWithRemoveAt()
+    {
+        // Arrange
+        var removeIndex = _randomizer.Number(_animalOwners.Count - 1);
+        var removeThis = _animalOwners.Items.ElementAt(removeIndex);
+
+        // Act
+        _animalOwners.RemoveAt(removeIndex);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - 1);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        removeThis.Animals.Items.ForEach(removed => _animals.Items.Should().NotContain(removed));
+        CheckResultContents();
+        removeThis.Dispose();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenFromParentsRemovedWithRemoveRange()
+    {
+        // Arrange
+        var removeIndex = _randomizer.Number(_animalOwners.Count - RemoveRangeSize - 1);
+        var removeThese = _animalOwners.Items.Skip(removeIndex).Take(RemoveRangeSize);
+
+        // Act
+        _animalOwners.RemoveRange(removeIndex, RemoveRangeSize);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - RemoveRangeSize);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + RemoveRangeSize);
+        removeThese.SelectMany(owner => owner.Animals.Items).ForEach(removed => _animals.Items.Should().NotContain(removed));
+        CheckResultContents();
+        removeThese.ForEach(owner => owner.Dispose());
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenFromParentsRemovedWithRemoveMany()
+    {
+        // Arrange
+        var removeThese = _randomizer.ListItems(_animalOwners.Items.ToList(), RemoveRangeSize);
+
+        // Act
+        _animalOwners.RemoveMany(removeThese);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - RemoveRangeSize);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + RemoveRangeSize);
+        removeThese.SelectMany(owner => owner.Animals.Items).ForEach(removed => _animals.Items.Should().NotContain(removed));
+        CheckResultContents();
+        removeThese.ForEach(owner => owner.Dispose());
+    }
+
+    [Fact]
+    public void ResultContainsCorrectItemsAfterParentReplacement()
+    {
+        // Arrange
+        var replaceThis = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var withThis = Fakers.AnimalOwner.Generate();
+
+        // Act
+        _animalOwners.Replace(replaceThis, withThis);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount); // Owner Count should not change
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 2); // +2 = 1 Message removing animals from old value, +1 message adding from new value
+        replaceThis.Animals.Items.ForEach(removed => _animals.Items.Should().NotContain(removed));
+        withThis.Animals.Items.ForEach(added => _animals.Items.Should().Contain(added));
+        CheckResultContents();
+        replaceThis.Dispose();
+    }
+
+    [Fact]
+    public void ResultEmptyIfSourceIsCleared()
+    {
+        // Arrange
+        var items = _animalOwners.Items.ToList();
+
+        // Act
+        _animalOwners.Clear();
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(0);
+        _animalResults.Data.Count.Should().Be(0);
+        CheckResultContents();
+        items.ForEach(owner => owner.Dispose());
+    }
+
+    [Fact]
+    public void ResultContainsChildrenAddedWithAddRange()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var addThese = Fakers.Animal.Generate(AddRangeSize);
+        var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
+
+        // Act
+        randomOwner.Animals.AddRange(addThese);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        addThese.ForEach(animal => _animals.Items.Should().Contain(animal));
+        _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + AddRangeSize);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsChildrenAddedWithAdd()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var addThis = Fakers.Animal.Generate();
+        var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
+
+        // Act
+        randomOwner.Animals.Add(addThis);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animals.Items.Should().Contain(addThis);
+        _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + 1);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsChildrenAddedWithInsert()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var insertIndex = _randomizer.Number(randomOwner.Animals.Items.Count());
+        var insertThis = Fakers.Animal.Generate();
+        var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
+
+        // Act
+        randomOwner.Animals.Insert(insertIndex, insertThis);
+
+        // Assert
+        randomOwner.Animals.Items.ElementAt(insertIndex).Should().Be(insertThis);
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animals.Items.Should().Contain(insertThis);
+        _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + 1);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenRemovedWithRemove()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var removeThis = _randomizer.ListItem(randomOwner.Animals.Items.ToList());
+        var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
+
+        // Act
+        randomOwner.Animals.Remove(removeThis);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animals.Items.Should().NotContain(removeThis);
+        _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount - 1);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenRemovedWithRemoveAt()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var removeIndex = _randomizer.Number(randomOwner.Animals.Count - 1);
+        var removeThis = randomOwner.Animals.Items.ElementAt(removeIndex);
+        var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
+
+        // Act
+        randomOwner.Animals.RemoveAt(removeIndex);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animals.Items.Should().NotContain(removeThis);
+        _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount - 1);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenRemovedWithRemoveRange()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var removeCount = _randomizer.Number(1, randomOwner.Animals.Count - 1);
+        var removeIndex = _randomizer.Number(randomOwner.Animals.Count - removeCount - 1);
+        var removeThese = randomOwner.Animals.Items.Skip(removeIndex).Take(removeCount);
+
+        // Act
+        randomOwner.Animals.RemoveRange(removeIndex, removeCount);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        removeThese.ForEach(removed => randomOwner.Animals.Items.Should().NotContain(removed));
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainChildrenRemovedWithRemoveMany()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var removeCount = _randomizer.Number(1, randomOwner.Animals.Count - 1);
+        var removeThese = _randomizer.ListItems(randomOwner.Animals.Items.ToList(), removeCount);
+
+        // Act
+        randomOwner.Animals.RemoveMany(removeThese);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        removeThese.ForEach(removed => randomOwner.Animals.Items.Should().NotContain(removed));
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsCorrectItemsAfterChildReplacement()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var replaceThis = _randomizer.ListItem(randomOwner.Animals.Items.ToList());
+        var withThis = Fakers.Animal.Generate();
+
+        // Act
+        randomOwner.Animals.Replace(replaceThis, withThis);
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        randomOwner.Animals.Items.Should().NotContain(replaceThis);
+        randomOwner.Animals.Items.Should().Contain(withThis);
+        CheckResultContents();
+    }
+
+    [Fact]
+    public void ResultContainsCorrectItemsAfterChildClear()
+    {
+        // Arrange
+        var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
+        var removedAnimals = randomOwner.Animals.Items.ToList();
+
+        // Act
+        randomOwner.Animals.Clear();
+
+        // Assert
+        _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
+        _animalChangeSetResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        randomOwner.Animals.Count.Should().Be(0);
+        removedAnimals.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
+        CheckResultContents();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void ResultCompletesOnlyWhenSourceAndAllChildrenComplete(bool completeSource, bool completeChildren)
+    {
+        // Arrange
+
+        // Act
+        _animalOwners.Items.Skip(completeChildren ? 0 : 1).ForEach(owner => owner.Dispose());
+        if (completeSource)
+        {
+            _animalOwners.Dispose();
+        }
+
+        // Assert
+        _animalOwnerResults.IsCompleted.Should().Be(completeSource);
+        _animalChangeSetResults.IsCompleted.Should().Be(completeSource && completeChildren);
+    }
+
+    [Fact]
+    public void ResultFailsIfSourceFails()
+    {
+        // Arrange
+        var expectedError = new Exception("Expected");
+        var throwObservable = Observable.Throw<IChangeSet<AnimalOwner>>(expectedError);
+        using var results = _animalOwners.Connect().Concat(throwObservable).MergeManyChangeSets(owner => owner.Animals.Connect()).AsAggregator();
+
+        // Act
+        _animalOwners.Dispose();
+
+        // Assert
+        results.Exception.Should().Be(expectedError);
+    }
+
+    private void CheckResultContents()
+    {
+        var expectedOwners = _animalOwners.Items.ToList();
+        var expectedAnimals = expectedOwners.SelectMany(owner => owner.Animals.Items).ToList();
+
+        // These should be subsets of each other, so check one subset and the size
+        expectedOwners.Should().BeSubsetOf(_animalOwnerResults.Data.Items);
+        _animalOwnerResults.Data.Items.Count().Should().Be(expectedOwners.Count);
+
+        // These should be subsets of each other, so check one subset and the size
+        expectedAnimals.Should().BeSubsetOf(_animalResults.Data.Items);
+        _animalResults.Data.Items.Count().Should().Be(expectedAnimals.Count);
+    }
+
+    public void Dispose()
+    {
+        _animalOwners.Items.ForEach(owner => owner.Dispose());
+        _animalOwners.Dispose();
+        _animals.Dispose();
+        _animalOwnerResults.Dispose();
+        _animalResults.Dispose();
+        _animalChangeSetResults.Dispose();
+        _disposable.Dispose();
+    }
+}

--- a/src/DynamicData/List/Internal/ChangeSetCache.cs
+++ b/src/DynamicData/List/Internal/ChangeSetCache.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+
+namespace DynamicData.List.Internal;
+
+internal class ChangeSetCache<TObject>
+    where TObject : notnull
+{
+    public ChangeSetCache(IObservable<IChangeSet<TObject>> source) =>
+        Source = source.Do(List.Clone);
+
+    public List<TObject> List { get; } = [];
+
+    public IObservable<IChangeSet<TObject>> Source { get; }
+}

--- a/src/DynamicData/List/Internal/ChangeSetMergeTracker.cs
+++ b/src/DynamicData/List/Internal/ChangeSetMergeTracker.cs
@@ -42,6 +42,10 @@ internal class ChangeSetMergeTracker<TObject>
                 case ListChangeReason.Clear:
                     OnClear(change);
                     break;
+
+                case ListChangeReason.Moved:
+                    // Ignore move changes because nothing can be done due to the indexes being different in the merged result
+                    break;
             }
         }
 
@@ -76,5 +80,4 @@ internal class ChangeSetMergeTracker<TObject>
             observer.OnNext(changeSet);
         }
     }
-
 }

--- a/src/DynamicData/List/Internal/ChangeSetMergeTracker.cs
+++ b/src/DynamicData/List/Internal/ChangeSetMergeTracker.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace DynamicData.List.Internal;
+
+internal class ChangeSetMergeTracker<TObject>
+    where TObject : notnull
+{
+    private readonly ChangeAwareList<TObject> _resultList = new();
+
+    public void ProcessChangeSet(IChangeSet<TObject> changes, IObserver<IChangeSet<TObject>> observer)
+    {
+        foreach (var change in changes)
+        {
+            switch (change.Reason)
+            {
+                case ListChangeReason.Add:
+                    OnItemAdded(change.Item);
+                    break;
+
+                case ListChangeReason.Remove:
+                    OnItemRemoved(change.Item);
+                    break;
+
+                case ListChangeReason.Replace:
+                    OnItemReplaced(change.Item);
+                    break;
+
+                case ListChangeReason.Refresh:
+                    OnItemRefreshed(change.Item);
+                    break;
+
+                case ListChangeReason.AddRange:
+                    OnRangeAdded(change.Range);
+                    break;
+
+                case ListChangeReason.RemoveRange:
+                    OnRangeRemoved(change.Range);
+                    break;
+
+                case ListChangeReason.Clear:
+                    OnClear(change);
+                    break;
+            }
+        }
+
+        EmitChanges(observer);
+    }
+
+    public void RemoveItems(IList<TObject> sourceList, IObserver<IChangeSet<TObject>> observer)
+    {
+        _resultList.Remove(sourceList);
+        EmitChanges(observer);
+    }
+
+    private void OnClear(Change<TObject> change) => _resultList.ClearOrRemoveMany(change);
+
+    private void OnItemAdded(ItemChange<TObject> item) => _resultList.Add(item.Current);
+
+    private void OnItemRefreshed(ItemChange<TObject> item) => _resultList.Refresh(item.Current);
+
+    private void OnItemRemoved(ItemChange<TObject> item) => _resultList.Remove(item.Current);
+
+    private void OnItemReplaced(ItemChange<TObject> item) => _resultList.ReplaceOrAdd(item.Previous.Value, item.Current);
+
+    private void OnRangeAdded(RangeChange<TObject> range) => _resultList.AddRange(range);
+
+    private void OnRangeRemoved(RangeChange<TObject> range) => _resultList.Remove(range);
+
+    private void EmitChanges(IObserver<IChangeSet<TObject>> observer)
+    {
+        var changeSet = _resultList.CaptureChanges();
+        if (changeSet.Count != 0)
+        {
+            observer.OnNext(changeSet);
+        }
+    }
+
+}

--- a/src/DynamicData/List/Internal/ChangeSetMergeTracker.cs
+++ b/src/DynamicData/List/Internal/ChangeSetMergeTracker.cs
@@ -48,9 +48,9 @@ internal class ChangeSetMergeTracker<TObject>
         EmitChanges(observer);
     }
 
-    public void RemoveItems(IList<TObject> sourceList, IObserver<IChangeSet<TObject>> observer)
+    public void RemoveItems(IEnumerable<TObject> removeItems, IObserver<IChangeSet<TObject>> observer)
     {
-        _resultList.Remove(sourceList);
+        _resultList.Remove(removeItems);
         EmitChanges(observer);
     }
 

--- a/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace DynamicData.List.Internal;
+
+internal class MergeManyListChangeSets<TObject, TDestination>(IObservable<IChangeSet<TObject>> source, Func<TObject, IObservable<IChangeSet<TDestination>>> selector)
+    where TObject : notnull
+    where TDestination : notnull
+{
+    public IObservable<IChangeSet<TDestination>> Run() => Observable.Create<IChangeSet<TDestination>>(
+            observer =>
+            {
+                var locker = new object();
+
+                // Transform to an observable list of cached lists
+                var sourceListofLists = source
+                                            .Transform(obj => new ChangeSetCache<TDestination>(selector(obj)))
+                                            .Synchronize(locker)
+                                            .AsObservableList();
+
+                var shared = sourceListofLists.Connect().Publish();
+
+                // This is manages all of the changes
+                var changeTracker = new ChangeSetMergeTracker<TDestination>();
+
+                // Berge the items back together
+                var allChanges = shared.MergeMany(mc => mc.Source.RemoveIndex())
+                                                 .Synchronize(locker)
+                                                 .Subscribe(
+                                                        changes => changeTracker.ProcessChangeSet(changes, observer),
+                                                        observer.OnError,
+                                                        observer.OnCompleted);
+
+                // When a source item is removed, all of its sub-items need to be removed
+                var removedItems = shared
+                    .OnItemRemoved(mc => changeTracker.RemoveItems(mc.List, observer))
+                    .Subscribe();
+
+                return new CompositeDisposable(sourceListofLists, allChanges, removedItems, shared.Connect());
+            });
+}

--- a/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
@@ -11,7 +11,8 @@ internal class MergeManyListChangeSets<TObject, TDestination>(IObservable<IChang
     where TObject : notnull
     where TDestination : notnull
 {
-    public IObservable<IChangeSet<TDestination>> Run() => Observable.Create<IChangeSet<TDestination>>(
+    public IObservable<IChangeSet<TDestination>> Run() =>
+        Observable.Create<IChangeSet<TDestination>>(
             observer =>
             {
                 var locker = new object();

--- a/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
@@ -28,7 +28,7 @@ internal class MergeManyListChangeSets<TObject, TDestination>(IObservable<IChang
                 // This is manages all of the changes
                 var changeTracker = new ChangeSetMergeTracker<TDestination>();
 
-                // Berge the items back together
+                // Merge the items back together
                 var allChanges = shared.MergeMany(mc => mc.Source.RemoveIndex())
                                                  .Synchronize(locker)
                                                  .Subscribe(

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1139,7 +1139,26 @@ public static class ObservableListEx
     }
 
     /// <summary>
-    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TDestination, TDestinationKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Operator similiar to MergeMany except it is List ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TDestination}"/> and merges the result children together into a single stream of ChangeSets that correctly handles removal of the parent items and other changes to the source list.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <param name="source">The Source Observable ChangeSet.</param>
+    /// <param name="observableSelector">Factory Function used to create child changesets.</param>
+    /// <returns>The result from merging the children list changesets together.</returns>
+    /// <exception cref="ArgumentNullException">Parameter was null.</exception>
+    public static IObservable<IChangeSet<TDestination>> MergeManyChangeSets<TObject, TDestination>(this IObservable<IChangeSet<TObject>> source, Func<TObject, IObservable<IChangeSet<TDestination>>> observableSelector)
+        where TObject : notnull
+        where TDestination : notnull
+    {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        if (observableSelector == null) throw new ArgumentNullException(nameof(observableSelector));
+
+        return new MergeManyListChangeSets<TObject, TDestination>(source, observableSelector).Run();
+    }
+
+    /// <summary>
+    /// Operator similiar to MergeMany except it is Cache ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TDestination, TDestinationKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TDestination">The type of the destination.</typeparam>
@@ -1162,7 +1181,7 @@ public static class ObservableListEx
     }
 
     /// <summary>
-    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TDestination, TDestinationKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Operator similiar to MergeMany except it is Cache ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TDestination, TDestinationKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TDestination">The type of the destination.</typeparam>


### PR DESCRIPTION
## Description

Implements the `MergeManyChangeSets` operator for cases when both the Parent and Child ChangeSets are List Changes.  It requires only a single prototype:

```csharp
IObservable<IChangeSet<TDestination>> MergeManyChangeSets<TObject, TDestination>(this IObservable<IChangeSet<TObject>> source, Func<TObject, IObservable<IChangeSet<TDestination>>> observableSelector);
```

The implementation is very similar to the Cache version except the Change Tracker is much simpler because it doesn't have to deal with duplicate keys.

## Testing

In addition to verifying Null handling and OnComplete/OnError behavior, the Unit Tests cover the following operations for both the Source and Child lists:
1) Add
1) AddRange
1) Insert
1) Remove
1) RemoveAt
1) RemoveMany
1) RemoveRange
1) Replace
1) Clear

## Other Changes

Other changes include:
1) Adding use of `Bogus` library to generate test data
1) Various code modernization changes consistent with similar recent efforts
1) Minor comment improvements