### PR TITLE
Benchmarks Enhancements and Organization

### DIFF
--- a/src/DynamicData.Benchmarks/Cache/EditDiff.cs
+++ b/src/DynamicData.Benchmarks/Cache/EditDiff.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+
+using BenchmarkDotNet.Attributes;
+
+using DynamicData.Kernel;
+
+namespace DynamicData.Benchmarks.Cache;
+
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class EditDiff
+{
+    public const int MaxItems
+        = 1097;
+
+    [Benchmark]
+    [Arguments(7, 3, 5)]
+    [Arguments(233, 113, MaxItems)]
+    [Arguments(233, 0, MaxItems)]
+    [Arguments(233, 233, MaxItems)]
+    [Arguments(2521, 1187, MaxItems)]
+    [Arguments(2521, 0, MaxItems)]
+    [Arguments(2521, 2521, MaxItems)]
+    [Arguments(5081, 2683, MaxItems)]
+    [Arguments(5081, 0, MaxItems)]
+    [Arguments(5081, 5081, MaxItems)]
+    public void AddsRemovesAndUpdates(int collectionSize, int updateSize, int maxItems)
+    {
+        using var subscription = Enumerable
+            .Range(1, maxItems - 1)
+            .Select(n => n * (collectionSize - updateSize))
+            .Select(index => Person.CreateRange(index, updateSize, "Overlap")
+                .Concat(Person.CreateRange(index + updateSize, collectionSize - updateSize, "Name")))
+            .Prepend(Person.CreateRange(0, collectionSize, "Name"))
+            .ToObservable()
+            .EditDiff(p => p.Id)
+            .Subscribe();
+    }
+
+    [Benchmark]
+    [Arguments(7)]
+    [Arguments(MaxItems)]
+    public void OptionalAddsAndRemoves(int maxItems)
+    {
+        using var subscription = Enumerable
+            .Range(0, MaxItems)
+            .Select(n => (n % 2) == 0
+                ? new Person(n, "Name")
+                : Optional.None<Person>())
+            .ToObservable()
+            .EditDiff(p => p.Id)
+            .Subscribe();
+    }
+
+    private class Person
+    {
+        public static IReadOnlyList<Person> CreateRange(int baseId, int count, string baseName)
+            => Enumerable
+                .Range(baseId, count)
+                .Select(i => new Person(i, baseName + i))
+                .ToArray();
+
+        public Person(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+    }
+}

--- a/src/DynamicData.Benchmarks/Cache/TransformMany.cs
+++ b/src/DynamicData.Benchmarks/Cache/TransformMany.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+
+using BenchmarkDotNet.Attributes;
+
+namespace DynamicData.Benchmarks.Cache;
+
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class TransformMany
+{
+    [Benchmark]
+    public void Perf()
+    {
+        var children = Enumerable
+            .Range(1, 10000)
+            .Select(i => new Child(
+                id: i,
+                name: $"Child #{i}"))
+            .ToArray();
+
+        var childIndex = 0;
+        var parents = Enumerable
+            .Range(1, 5000)
+            .Select(i => new Parent(
+                id: i,
+                children: new[]
+                {
+                    children[childIndex++],
+                    children[childIndex++]
+                }))
+            .ToArray();
+
+        using var source = new SourceCache<Parent, int>(x => x.Id);
+
+        using var subscription = source
+            .Connect()
+            .TransformMany(p => p.Children, c => c.Name)
+            .Subscribe();
+
+        source.AddOrUpdate(parents);
+    }
+
+    private class Parent
+    {
+        public Parent(
+            int id,
+            IEnumerable<Child> children)
+        {
+            Id = id;
+            Children = children.ToArray();
+        }
+
+        public int Id { get; }
+
+        public IReadOnlyList<Child> Children { get; }
+    }
+
+    private class Child
+    {
+        public Child(
+            int id,
+            string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+    }
+}

--- a/src/DynamicData.Benchmarks/DynamicData.Benchmarks.csproj
+++ b/src/DynamicData.Benchmarks/DynamicData.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>;1591;1701;1702;1705;CA1822;CA1001</NoWarn>
   </PropertyGroup>
@@ -19,6 +20,6 @@
     <ProjectReference Include="..\DynamicData\DynamicData.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="BenchmarkDotNet.Artifacts\" />
+    <None Include="BenchmarkDotNet.Artifacts\**\*" />
   </ItemGroup>
 </Project>

--- a/src/DynamicData.Benchmarks/Program.cs
+++ b/src/DynamicData.Benchmarks/Program.cs
@@ -2,12 +2,25 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.IO;
+using System.Runtime.CompilerServices;
+
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace DynamicData.Benchmarks
 {
     public static class Program
     {
-        public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        public static void Main(string[] args)
+            => BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .Run(args, DefaultConfig.Instance
+                    .WithArtifactsPath(Path.Combine(
+                        GetProjectRootDirectory(),
+                        Path.GetFileName(DefaultConfig.Instance.ArtifactsPath))));
+
+        private static string GetProjectRootDirectory([CallerFilePath] string? callerFilePath = null)
+            => Path.GetDirectoryName(callerFilePath)!;
     }
 }

--- a/src/DynamicData.Tests/Cache/EditDiffChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Cache/EditDiffChangeSetFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using FluentAssertions;
@@ -116,42 +115,6 @@ public class EditDiffChangeSetFixture
 
         // then
         receivedError.Should().Be(failSource ? testException : default);
-    }
-
-    [Trait("Performance", "Manual run only")]
-    [Theory]
-    [InlineData(7, 3, 5)]
-    [InlineData(233, 113, MaxItems)]
-    [InlineData(233, 0, MaxItems)]
-    [InlineData(233, 233, MaxItems)]
-    [InlineData(2521, 1187, MaxItems)]
-    [InlineData(2521, 0, MaxItems)]
-    [InlineData(2521, 2521, MaxItems)]
-    [InlineData(5081, 2683, MaxItems)]
-    [InlineData(5081, 0, MaxItems)]
-    [InlineData(5081, 5081, MaxItems)]
-    public void Perf(int collectionSize, int updateSize, int maxItems)
-    {
-        Debug.Assert(updateSize <= collectionSize);
-
-        // having
-        var enumerables = Enumerable.Range(1, maxItems - 1)
-            .Select(n => n * (collectionSize - updateSize))
-            .Select(index => CreatePeople(index, updateSize, "Overlap")
-                                                            .Concat(CreatePeople(index + updateSize, collectionSize - updateSize, "Name")))
-            .Prepend(CreatePeople(0, collectionSize, "Name"));
-        var enumObservable = enumerables.ToObservable();
-
-        // when
-        var observableChangeSet = enumObservable.EditDiff(p => p.Id);
-        using var results = observableChangeSet.AsAggregator();
-
-        // then
-        results.Data.Count.Should().Be(collectionSize);
-        results.Messages.Count.Should().Be(maxItems);
-        results.Summary.Overall.Adds.Should().Be((collectionSize * maxItems) - (updateSize * (maxItems - 1)));
-        results.Summary.Overall.Removes.Should().Be((collectionSize - updateSize) * (maxItems - 1));
-        results.Summary.Overall.Updates.Should().Be(updateSize * (maxItems - 1));
     }
 
     private static Person CreatePerson(int id, string name) => new(id, name);

--- a/src/DynamicData.Tests/Cache/EditDiffChangeSetOptionalFixture.cs
+++ b/src/DynamicData.Tests/Cache/EditDiffChangeSetOptionalFixture.cs
@@ -184,28 +184,6 @@ public class EditDiffChangeSetOptionalFixture
         receivedError.Should().Be(failSource ? testException : default);
     }
 
-    [Trait("Performance", "Manual run only")]
-    [Theory]
-    [InlineData(7)]
-    [InlineData(MaxItems)]
-    public void Perf(int maxItems)
-    {
-        // having
-        var optionals = Enumerable.Range(0, maxItems).Select(n => (n % 2) == 0 ? CreatePerson(n, "Name") : s_noPerson);
-        var optObservable = optionals.ToObservable();
-
-        // when
-        var observableChangeSet = optObservable.EditDiff(p => p.Id);
-        using var results = observableChangeSet.AsAggregator();
-
-        // then
-        results.Data.Count.Should().Be(1);
-        results.Messages.Count.Should().Be(maxItems);
-        results.Summary.Overall.Adds.Should().Be((maxItems / 2) + ((maxItems % 2) == 0 ? 0 : 1));
-        results.Summary.Overall.Removes.Should().Be(maxItems / 2);
-        results.Summary.Overall.Updates.Should().Be(0);
-    }
-
     private static Optional<Person> CreatePerson(int id, string name) => Optional.Some(new Person(id, name));
 
     private class PersonComparer : IEqualityComparer<Person>

--- a/src/DynamicData.Tests/Cache/TransformManyObservableCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformManyObservableCacheFixture.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using DynamicData.Binding;
@@ -184,36 +182,6 @@ public class TransformManyObservableCollectionFixture
 
         parent.Children.Add(new Person("child2", 2));
         collection.Count.Should().Be(2);
-    }
-
-    [Fact]
-    [Trait("Performance", "Manual run only")]
-    public void Perf()
-    {
-        var children = Enumerable.Range(1, 10000).Select(i => new Person("Name" + i, i)).ToArray();
-
-        var childIndex = 0;
-        var parents = Enumerable.Range(1, 5000).Select(
-            i =>
-            {
-                var parent = new Parent(
-                    i,
-                    new[]
-                    {
-                        children[childIndex],
-                        children[childIndex + 1]
-                    });
-
-                childIndex += 2;
-                return parent;
-            }).ToArray();
-
-        var sw = new Stopwatch();
-
-        using var source = new SourceCache<Parent, int>(x => x.Id);
-        using var sut = source.Connect().Do(_ => sw.Start()).TransformMany(p => p.Children, c => c.Name).Do(_ => sw.Stop()).Subscribe(c => Console.WriteLine($"Changes = {c.Count:N0}"));
-        source.AddOrUpdate(parents);
-        Console.WriteLine($"{sw.ElapsedMilliseconds}");
     }
 
     [Fact]


### PR DESCRIPTION
Fixed broken setup for displaying Benchmark artifacts in Solution Explorer.

Moved performance tests in the .Tests project over to the .Benchmarks project.

Total test runtime (on my machine) is now roughly 18.5 seconds, down from 1.1 minutes.