### PR TITLE
Apply locking to fix  join race conditions. Fixes #787

### DIFF
--- a/src/DynamicData/Cache/Internal/FullJoin.cs
+++ b/src/DynamicData/Cache/Internal/FullJoin.cs
@@ -118,6 +118,9 @@ internal class FullJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(IObser
                     return joinedCache.CaptureChanges();
                 });
 
-                return new CompositeDisposable(leftLoader.Merge(rightLoader).SubscribeSafe(observer), leftCache, rightCache);
+                lock (locker)
+                {
+                    return new CompositeDisposable(leftLoader.Merge(rightLoader).SubscribeSafe(observer), leftCache, rightCache);
+                }
             });
 }

--- a/src/DynamicData/Cache/Internal/InnerJoin.cs
+++ b/src/DynamicData/Cache/Internal/InnerJoin.cs
@@ -41,7 +41,7 @@ internal class InnerJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(IObse
                 {
                     foreach (var change in changes.ToConcreteType())
                     {
-                        var leftCurent = change.Current;
+                        var leftCurrent = change.Current;
                         var rightLookup = rightGrouped.Lookup(change.Key);
 
                         if (rightLookup.HasValue)
@@ -52,7 +52,7 @@ internal class InnerJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(IObse
                                 case ChangeReason.Update:
                                     foreach (var keyvalue in rightLookup.Value.KeyValues)
                                     {
-                                        joinedCache.AddOrUpdate(_resultSelector((change.Key, keyvalue.Key), leftCurent, keyvalue.Value), (change.Key, keyvalue.Key));
+                                        joinedCache.AddOrUpdate(_resultSelector((change.Key, keyvalue.Key), leftCurrent, keyvalue.Value), (change.Key, keyvalue.Key));
                                     }
 
                                     break;
@@ -117,6 +117,9 @@ internal class InnerJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(IObse
                     return joinedCache.CaptureChanges();
                 });
 
-                return new CompositeDisposable(leftLoader.Merge(rightLoader).SubscribeSafe(observer), leftCache, rightCache, rightShare.Connect());
+                lock (locker)
+                {
+                    return new CompositeDisposable(leftLoader.Merge(rightLoader).SubscribeSafe(observer), leftCache, rightCache, rightShare.Connect());
+                }
             });
 }

--- a/src/DynamicData/Cache/Internal/LeftJoin.cs
+++ b/src/DynamicData/Cache/Internal/LeftJoin.cs
@@ -119,6 +119,9 @@ internal class LeftJoin<TLeft, TLeftKey, TRight, TRightKey, TDestination>(IObser
                         return joined.CaptureChanges();
                     });
 
-                return new CompositeDisposable(leftLoader.Merge(rightLoader).SubscribeSafe(observer), leftCache, rightCache);
+                lock (locker)
+                {
+                    return new CompositeDisposable(leftLoader.Merge(rightLoader).SubscribeSafe(observer), leftCache, rightCache);
+                }
             });
 }


### PR DESCRIPTION
Fixes race condition for cache joins.  See #787