### PR TITLE
fix: Re-optimise capture of empty change.

### DIFF
--- a/src/DynamicData/Cache/ChangeAwareCache.cs
+++ b/src/DynamicData/Cache/ChangeAwareCache.cs
@@ -90,7 +90,7 @@ public sealed class ChangeAwareCache<TObject, TKey> : ICache<TObject, TKey>
     {
         if (_changes.Count == 0)
         {
-            return [];
+            return ChangeSet<TObject, TKey>.Empty;
         }
 
         var copy = _changes;


### PR DESCRIPTION
Auto formatting to latest features de-optimised the capture of an empty change set.  It is better to re-use the same instance of an empty list than to keep creating new one,