### PR TITLE
Feature: TestObserver<T>

### DIFF
--- a/src/DynamicData.Tests/Utilities/RawAnonymousObservable.cs
+++ b/src/DynamicData.Tests/Utilities/RawAnonymousObservable.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace DynamicData.Tests.Utilities;
+
+internal static class RawAnonymousObservable
+{
+    public static RawAnonymousObservable<T> Create<T>(Func<IObserver<T>, IDisposable> onSubscribe)
+        => new(onSubscribe);
+}
+
+// Allows bypassing of safeguards implemented within Observable.Create<T>(), for testing.
+internal class RawAnonymousObservable<T>
+    : IObservable<T>
+{
+    private readonly Func<IObserver<T>, IDisposable> _onSubscribe;
+
+    public RawAnonymousObservable(Func<IObserver<T>, IDisposable> onSubscribe)
+        => _onSubscribe = onSubscribe;
+
+    public IDisposable Subscribe(IObserver<T> observer)
+        => _onSubscribe.Invoke(observer);
+}

--- a/src/DynamicData.Tests/Utilities/RawAnonymousObserver.cs
+++ b/src/DynamicData.Tests/Utilities/RawAnonymousObserver.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace DynamicData.Tests.Utilities;
+
+internal static class RawAnonymousObserver
+{
+    public static RawAnonymousObserver<T> Create<T>(
+            Action<T> onNext,
+            Action<Exception> onError,
+            Action onCompleted)
+        => new(
+            onNext: onNext,
+            onError: onError,
+            onCompleted: onCompleted);
+}
+
+// Allows bypassing of safeguards implemented within Observer.Create<T>(), for testing.
+internal class RawAnonymousObserver<T>
+    : IObserver<T>
+{
+    private readonly Action _onCompleted;
+    private readonly Action<Exception> _onError;
+    private readonly Action<T> _onNext;
+
+    public RawAnonymousObserver(
+        Action<T> onNext,
+        Action<Exception> onError,
+        Action onCompleted)
+    {
+        _onNext = onNext;
+        _onError = onError;
+        _onCompleted = onCompleted;
+    }
+
+    public void OnCompleted()
+        => _onCompleted.Invoke();
+    
+    public void OnError(Exception error)
+        => _onError.Invoke(error);
+    
+    public void OnNext(T value)
+        => _onNext.Invoke(value);
+}

--- a/src/DynamicData.Tests/Utilities/TestableObserver.cs
+++ b/src/DynamicData.Tests/Utilities/TestableObserver.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Concurrency;
+
+using Microsoft.Reactive.Testing;
+
+namespace DynamicData.Tests.Utilities;
+
+public static class TestableObserver
+{
+    public static TestableObserver<T> Create<T>(IScheduler? scheduler = null)
+        => new(scheduler ?? DefaultScheduler.Instance);
+}
+
+// Not using any existing Observer class, or Observer.Create<T>() to bypass normal RX safeguards, which prevent out-of-sequence notifications.
+public sealed class TestableObserver<T>
+    : ITestableObserver<T>
+{
+    private readonly List<Recorded<Notification<T>>> _messages;
+    private readonly IScheduler _scheduler;
+
+    public TestableObserver(IScheduler scheduler)
+    {
+        _messages = new();
+        _scheduler = scheduler;
+    }
+
+    public IList<Recorded<Notification<T>>> Messages
+        => _messages;
+
+    void IObserver<T>.OnCompleted()
+        => _messages.Add(new(
+            time: _scheduler.Now.Ticks,
+            value: Notification.CreateOnCompleted<T>()));
+    
+    void IObserver<T>.OnError(Exception error)
+        => _messages.Add(new(
+            time: _scheduler.Now.Ticks,
+            value: Notification.CreateOnError<T>(error)));
+
+    void IObserver<T>.OnNext(T value)
+        => _messages.Add(new(
+            time: _scheduler.Now.Ticks,
+            value: Notification.CreateOnNext(value)));
+}

--- a/src/DynamicData.Tests/Utilities/TestableObserverExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/TestableObserverExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+
+using FluentAssertions;
+
+using Microsoft.Reactive.Testing;
+
+namespace DynamicData.Tests.Utilities;
+
+internal static class TestableObserverExtensions
+{
+    public static IEnumerable<Recorded<Notification<T>>> EnumerateInvalidNotifications<T>(this ITestableObserver<T> observer)
+        => observer.Messages
+            .SkipWhile(message => message.Value.Kind is NotificationKind.OnNext)
+            .Skip(1);
+
+    public static IEnumerable<T> EnumerateRecordedValues<T>(this ITestableObserver<T> observer)
+        => observer.Messages
+            .TakeWhile(message => message.Value.Kind is NotificationKind.OnNext)
+            .Select(message => message.Value.Value);
+
+    public static Exception? TryGetRecordedError<T>(this ITestableObserver<T> observer)
+        => observer.Messages
+            .Where(message => message.Value.Kind is NotificationKind.OnError)
+            .Select(message => message.Value.Exception)
+            .FirstOrDefault();
+
+    public static bool TryGetRecordedCompletion<T>(this ITestableObserver<T> observer)
+        => observer.Messages
+            .Where(message => message.Value.Kind is NotificationKind.OnCompleted)
+            .Any();
+}

--- a/src/DynamicData.Tests/Utilities/UnsynchronizedNotificationException.cs
+++ b/src/DynamicData.Tests/Utilities/UnsynchronizedNotificationException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Reactive;
+
+namespace DynamicData.Tests.Utilities;
+
+public class UnsynchronizedNotificationException<T>
+    : Exception
+{
+    public UnsynchronizedNotificationException()
+        : base("Unsynchronized notification received: Another notification is already being processed")
+    { }
+
+    public required Notification<T> IncomingNotification { get; init; }
+
+    public required Notification<T> PriorNotification { get; init; }
+}


### PR DESCRIPTION
Implemented `TestObserver<T>` as a testing utility for aggregating notifications from any arbitrary observable stream.

This is something I ended up wanting to support testing for the `ExpireAfter()` operator (the version that operates on `ISourceCache<TObject, TKey>` and `ISourceList<T>` directly, and emits sets of removed items, rather than full changesets).

I tried using the `ITestingObserver<T>` API from `Microsoft.Reactive.Testing` first, but I found it way to cumbersome, in the fact that it doesn't actually aggregate notifications to allow easy checking for errors or completions, and it is only usable if you setup ALL your test arrangements and actions to run through a `TestScheduler`.

I wanted an easy way to:
* Inspect the sequence of emitted items.
* Check if an error occurred.
* Check if completion occurred.
* Validate general correctness of the stream, I.E. only one error or completion should ever occur, and no notifications should ever follow them.

In other words, I wanted what `ChangeSetAggregator` does.

Right now, I just put this in the testing project. I figured it doesn't *really* belong in the main package, if it's not something that supports DynamicData operators or testing, directly, but I could definitely move it, if anyone thinks it's useful as part of the public API. If so, I'd remove the dependency on `Microsoft.Reactive.Testing.Recorded<T>`.
