### PR TITLE
Feature:  Stress Tests for List-to-List MergeManyChangeSets

### DIFF
--- a/src/DynamicData.Tests/Utilities/FakerExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/FakerExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Concurrency;
+using Bogus;
+
+namespace DynamicData.Tests.Utilities;
+
+internal static class FakerExtensions
+{
+    public static IObservable<T> IntervalGenerate<T>(this Faker<T> faker, Randomizer randomizer, TimeSpan maxTime, IScheduler? scheduler = null)
+         where T : class =>
+            randomizer.Interval(maxTime, scheduler).Select(_ => faker.Generate());
+
+    public static IObservable<T> IntervalGenerate<T>(this Faker<T> faker, TimeSpan period, IScheduler? scheduler = null)
+         where T : class =>
+            Observable.Interval(period, scheduler ?? DefaultScheduler.Instance).Select(_ => faker.Generate());
+}

--- a/src/DynamicData.Tests/Utilities/ObservableEx.cs
+++ b/src/DynamicData.Tests/Utilities/ObservableEx.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
-using Bogus;
 
 namespace DynamicData.Tests.Utilities;
 
@@ -37,12 +35,4 @@ internal static class ObservableEx
 
             return ScheduleFirst(scheduler ?? DefaultScheduler.Instance);
         });
-
-    public static IObservable<T> IntervalGenerate<T>(this Faker<T> faker, Randomizer randomizer, TimeSpan maxTime, IScheduler? scheduler = null)
-         where T : class =>
-            randomizer.Interval(maxTime, scheduler).Select(_ => faker.Generate());
-
-    public static IObservable<T> IntervalGenerate<T>(this Faker<T> faker, TimeSpan period, IScheduler? scheduler = null)
-         where T : class =>
-            Observable.Interval(period, scheduler ?? DefaultScheduler.Instance).Select(_ => faker.Generate());
 }

--- a/src/DynamicData.Tests/Utilities/ObservableExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/ObservableExtensions.cs
@@ -95,19 +95,16 @@ internal static class ObservableExtensions
         });
 
     // Emits "parallel" number of values that add up to "count"
-    private static IEnumerable<int> Distribute(int count, int parallel)
-    {
-        if (count <= parallel)
+    private static IEnumerable<int> Distribute(int count, int parallel) =>
+        (count, parallel, count / parallel) switch
         {
-            return Enumerable.Repeat(1, count);
-        }
+            // Not enough count for each parallel, so just return as many as needed
+            (int c, int p, _) when c <= p => Enumerable.Repeat(1, c),
 
-        if ((count % parallel) == 0)
-        {
-            return Enumerable.Repeat(count / parallel, parallel);
-        }
+            // Divides equally, so return the ratio for the parallel quantity
+            (int c, int p, int ratio) when (c % p) == 0 => Enumerable.Repeat(ratio, p),
 
-        var num = count / parallel;
-        return Enumerable.Repeat(num, parallel - 1).Append(count - (num * (parallel - 1)));
-    }
+            // Doesn't divide equally, so return the ratio for the parallel quantity, and the remainder for the last one
+            (int c, int p, int ratio) => Enumerable.Repeat(ratio, p - 1).Append(c - (ratio * (p - 1))),
+        };
 }

--- a/src/DynamicData.Tests/Utilities/ObservableExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/ObservableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 
@@ -18,4 +19,35 @@ internal static class ObservableExtensions
         e is not null
             ? source.Take(count).Concat(Observable.Throw<T>(e))
             : source;
+
+    /// <summary>
+    /// Creates an observable that parallelizes some given work by taking the source observable, creates multiple subscriptions, limiting each to a certain number of values, and 
+    /// attaching some work to be done in parallel to each before merging them back together.
+    /// </summary>
+    /// <typeparam name="T">Input Observable type.</typeparam>
+    /// <typeparam name="U">Output Observable type.</typeparam>
+    /// <param name="source">Source Observable.</param>
+    /// <param name="count">Total number of values to process.</param>
+    /// <param name="parallel">Total number of subscriptions to create.</param>
+    /// <param name="fnAttachParallelWork">Function to append work to be done before the merging.</param>
+    /// <returns>An Observable that contains the values resulting from the work performed.</returns>
+    public static IObservable<U> Parallelize<T, U>(this IObservable<T> source, int count, int parallel, Func<IObservable<T>, IObservable<U>> fnAttachParallelWork) =>
+        Observable.Merge(Distribute(count, parallel).Select(n => fnAttachParallelWork(source.Take(n))));
+
+    // Emits "parallel" number of values that add up to "count"
+    private static IEnumerable<int> Distribute(int count, int parallel)
+    {
+        if (count <= parallel)
+        {
+            return Enumerable.Repeat(1, count);
+        }
+
+        if ((count % parallel) == 0)
+        {
+            return Enumerable.Repeat(count / parallel, parallel);
+        }
+
+        var num = count / parallel;
+        return Enumerable.Repeat(num, parallel - 1).Append(count - (num * (parallel - 1)));
+    }
 }

--- a/src/DynamicData.Tests/Utilities/StressAddRemoveExtensions.cs
+++ b/src/DynamicData.Tests/Utilities/StressAddRemoveExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace DynamicData.Tests.Utilities;

--- a/src/DynamicData/Cache/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyListChangeSets.cs
@@ -11,7 +11,7 @@ namespace DynamicData.Cache.Internal;
 /// <summary>
 /// Operator that is similiar to MergeMany but intelligently handles List ChangeSets.
 /// </summary>
-internal sealed class MergeManyListChangeSets<TObject, TKey, TDestination>(IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination>>> selector, IEqualityComparer<TDestination>? equalityComparer = null)
+internal sealed class MergeManyListChangeSets<TObject, TKey, TDestination>(IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<IChangeSet<TDestination>>> selector, IEqualityComparer<TDestination>? equalityComparer)
     where TObject : notnull
     where TKey : notnull
     where TDestination : notnull

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -1055,7 +1055,7 @@ public static class ObservableListEx
             throw new ArgumentNullException(nameof(observableSelector));
         }
 
-        return new MergeManyListChangeSets<TObject, TDestination>(source, observableSelector).Run();
+        return new MergeManyListChangeSets<TObject, TDestination>(source, observableSelector, equalityComparer).Run();
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
- Migrates the stress tests from the Cache-List version of MergeManyChangeSets test fixture to the List-List version, but consolidates them so they don't take so long to run
- Applies improvements made to the Cache-List version as well to keep them in sync
- Aligns implementation of List-List with the Cache-List version (removes use of intermediate SourceList)
- Fixes minor bug in the List-List version where it wasn't passing the `IEqualityComparer` implementation to the internal class