### PR TITLE
Feature:  Stress Tests for Cache-Cache MergeManyChangeSets

### DIFF
--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheFixture.cs
@@ -51,9 +51,9 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
     [Theory]
     [InlineData(5, 7)]
     [InlineData(10, 50)]
-    [InlineData(10, 1_000)]
+    [InlineData(10, 100)]
     [InlineData(200, 500)]
-    [InlineData(1_000, 10)]
+    [InlineData(100, 10)]
     public async Task MultiThreadedStressTest(int marketCount, int priceCount)
     {
         using var priceResults = _marketCache.Connect().MergeManyChangeSets(market => market.LatestPrices).AsAggregator();
@@ -808,12 +808,10 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
 
         // These should be subsets of each other
         expectedMarkets.Should().BeSubsetOf(marketResults.Data.Items);
-        marketResults.Data.Items.Should().BeSubsetOf(expectedMarkets);
         marketResults.Data.Items.Count().Should().Be(expectedMarkets.Count);
 
         // These should be subsets of each other
         expectedPrices.Should().BeSubsetOf(priceResults.Data.Items);
-        priceResults.Data.Items.Should().BeSubsetOf(expectedPrices);
         priceResults.Data.Items.Count().Should().Be(expectedPrices.Count);
     }
 

--- a/src/DynamicData.Tests/Domain/Market.cs
+++ b/src/DynamicData.Tests/Domain/Market.cs
@@ -39,6 +39,10 @@ internal class Market : IMarket, IDisposable
     {
     }
 
+    public Market(string name) : this(name, Guid.NewGuid())
+    {
+    }
+
     public string Name { get; }
 
     public Guid Id { get; }

--- a/src/DynamicData.Tests/Domain/MarketPrice.cs
+++ b/src/DynamicData.Tests/Domain/MarketPrice.cs
@@ -45,18 +45,26 @@ internal class MarketPrice
 
     public static decimal RandomPrice(Randomizer r, decimal basePrice, decimal offset) => r.Decimal(basePrice, basePrice + offset);
 
+    public override bool Equals(object? obj) => obj is MarketPrice price && Price == price.Price && TimeStamp.Equals(price.TimeStamp) && MarketId.Equals(price.MarketId) && ItemId == price.ItemId;
+
+    public override int GetHashCode() => HashCode.Combine(Price, TimeStamp, MarketId, ItemId);
+
+    public static bool operator ==(MarketPrice? left, MarketPrice? right) => EqualityComparer<MarketPrice>.Default.Equals(left, right);
+
+    public static bool operator !=(MarketPrice? left, MarketPrice? right) => !(left == right);
+
     private class CurrentPriceEqualityComparer : IEqualityComparer<MarketPrice>
     {
         public virtual bool Equals([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y) => x.MarketId.Equals(x.MarketId) && x.ItemId == y.ItemId && x.Price == y.Price;
         public int GetHashCode([DisallowNull] MarketPrice obj) => throw new NotImplementedException();
     }
 
-    private class TimeStampPriceEqualityComparer : CurrentPriceEqualityComparer, IEqualityComparer<MarketPrice>
+    private sealed class TimeStampPriceEqualityComparer : CurrentPriceEqualityComparer, IEqualityComparer<MarketPrice>
     {
         public override bool Equals([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y) => base.Equals(x, y) && x.TimeStamp == y.TimeStamp;
     }
 
-    private class LowestPriceComparer : IComparer<MarketPrice>
+    private sealed class LowestPriceComparer : IComparer<MarketPrice>
     {
         public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
         {
@@ -65,7 +73,7 @@ internal class MarketPrice
         }
     }
 
-    private class HighestPriceComparer : IComparer<MarketPrice>
+    private sealed class HighestPriceComparer : IComparer<MarketPrice>
     {
         public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
         {
@@ -74,7 +82,7 @@ internal class MarketPrice
         }
     }
 
-    private class LatestPriceComparer : IComparer<MarketPrice>
+    private sealed class LatestPriceComparer : IComparer<MarketPrice>
     {
         public int Compare([DisallowNull] MarketPrice x, [DisallowNull] MarketPrice y)
         {

--- a/src/DynamicData.Tests/Domain/MarketPrice.cs
+++ b/src/DynamicData.Tests/Domain/MarketPrice.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Bogus;
 
 namespace DynamicData.Tests.Domain;
 
@@ -41,6 +42,8 @@ internal class MarketPrice
     public override string ToString() => $"{ItemId:D5} - {Price:c} ({MarketId}) [{TimeStamp:HH:mm:ss.fffffff}]";
 
     public static decimal RandomPrice(Random r, decimal basePrice, decimal offset) => basePrice + (decimal)r.NextDouble() * offset;
+
+    public static decimal RandomPrice(Randomizer r, decimal basePrice, decimal offset) => r.Decimal(basePrice, basePrice + offset);
 
     private class CurrentPriceEqualityComparer : IEqualityComparer<MarketPrice>
     {


### PR DESCRIPTION
## Description
- Adds stress test and exception tests to the Cache-Cache version of MergeManyChangeSets
- Changes operator implementation locking strategy to align with List-List and Cache-List
- Updates Fixture to use more Randomizer instead of Random so results are deterministic
- Minor test code cleanup