### PR TITLE
TransformAsync enhancements

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1823,11 +1823,23 @@ namespace DynamicData
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, System.Threading.Tasks.Task<TDestination>> transformFactory, DynamicData.TransformAsyncOptions options)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, System.Threading.Tasks.Task<TDestination>> transformFactory, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, DynamicData.TransformAsyncOptions options)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, DynamicData.TransformAsyncOptions options)
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
@@ -1879,11 +1891,23 @@ namespace DynamicData
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, DynamicData.TransformAsyncOptions options)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, DynamicData.TransformAsyncOptions options)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, DynamicData.TransformAsyncOptions options)
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
@@ -2419,6 +2443,13 @@ namespace DynamicData
         public void Dispose() { }
         public void Edit(System.Action<DynamicData.IExtendedList<T>> updateAction) { }
         public System.IObservable<DynamicData.IChangeSet<T>> Preview(System.Func<T, bool>? predicate = null) { }
+    }
+    public struct TransformAsyncOptions : System.IEquatable<DynamicData.TransformAsyncOptions>
+    {
+        public static readonly DynamicData.TransformAsyncOptions Default;
+        public TransformAsyncOptions(int? MaximumConcurrency, bool TransformOnRefresh) { }
+        public int? MaximumConcurrency { get; set; }
+        public bool TransformOnRefresh { get; set; }
     }
     [System.Serializable]
     public class UnspecifiedIndexException : System.Exception

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -5,7 +5,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
-
+using DynamicData.Binding;
 using DynamicData.Tests.Domain;
 
 using FluentAssertions;
@@ -93,7 +93,7 @@ public class TransformAsyncFixture
     public async Task RemoveFlowsToTheEnd()
     {
         var transform = 0;
-        var count = 500;
+        var count = 100;
         ReadOnlyObservableCollection<Person> collection;
 
         var cache = new SourceCache<Person, string>(p => p.Name);
@@ -121,9 +121,8 @@ public class TransformAsyncFixture
             cache.RemoveKey(p.Name);
         }
 
-        while (transform != count)
-            await Task.Delay(100);
-        await Task.Delay(3000);
+        await collection.ToObservableChangeSet().Take(count * 2);
+
         collection.Count.Should().Be(0);
     }
 

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -254,8 +254,10 @@ public class TransformAsyncFixture
 
     }
 
-    [Fact]
-    public async Task WithMaxConcurrency()
+    
+    [Theory, InlineData(10), InlineData(100)]
+
+    public async Task WithMaxConcurrency(int maxConcurrency)
     {
         /* We need to test whether the max concurrency has any effect.
 
@@ -266,8 +268,6 @@ public class TransformAsyncFixture
         */
 
         const int transformCount = 100;
-        const int maxConcurrency = 10;
-
 
         using var source = new SourceCache<Person, string>(p => p.Name);
         using var results = source.Connect()

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -258,10 +258,8 @@ public class TransformAsyncFixture
 
         source.AddOrUpdate(Enumerable.Range(1, transformCount).Select(l => new Person("Person" + l, l)));
 
-       // var xxx = Observable.Timer(TimeSpan.FromSeconds(1)).Select(_=> Observable.Thr);
-
-       await results.Data.CountChanged.Where(c=>c == transformCount).Take(1)
-           .Timeout(TimeSpan.FromSeconds(2));
+        await results.Data.CountChanged.Where(c => c == transformCount).Take(1)
+            .Timeout(TimeSpan.FromSeconds(2));
     }
 
     private class TransformStub : IDisposable

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -6,9 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using DynamicData.Binding;
-using DynamicData.Cache;
 using DynamicData.Tests.Domain;
-using DynamicData.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -258,8 +256,7 @@ public class TransformAsyncFixture
 
         source.AddOrUpdate(Enumerable.Range(1, transformCount).Select(l => new Person("Person" + l, l)));
 
-        await results.Data.CountChanged.Where(c => c == transformCount).Take(1)
-            .Timeout(TimeSpan.FromSeconds(2));
+        await results.Data.CountChanged.Where(c => c == transformCount).Take(1);
     }
 
     private class TransformStub : IDisposable

--- a/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
@@ -235,10 +235,11 @@ public class TransformSafeAsyncFixture
                 , TransformAsyncOptions.Default with { MaximumConcurrency = maxConcurrency })
             .AsAggregator();
 
+
         source.AddOrUpdate(Enumerable.Range(1, transformCount).Select(l => new Person("Person" + l, l)));
 
-        await results.Data.CountChanged.Where(c => c == transformCount).Take(1)
-            .Timeout(TimeSpan.FromSeconds(2));
+
+        await results.Data.CountChanged.Where(c => c == transformCount).Take(1);
 
         errorCount.Should().Be(0);
     }

--- a/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
@@ -5,17 +5,14 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
-
+using DynamicData.Cache;
 using DynamicData.Kernel;
 using DynamicData.Tests.Domain;
-
 using FluentAssertions;
-
 using Xunit;
 
 namespace DynamicData.Tests.Cache;
 
-[Obsolete("Not obsolete - test commented out due to test run freezing on Appveyor")]
 public class TransformSafeAsyncFixture
 {
     [Fact]
@@ -41,165 +38,211 @@ public class TransformSafeAsyncFixture
         }
     }
 
-    //[Fact]
-    //public void ReTransformSelected()
-    //{
-    //    var people = Enumerable.Range(1, 10).Select(i => new Person("Name" + i, i)).ToArray();
-    //    var forceTransform = new Subject<Func<Person, bool>>();
+    [Fact]
+    public void ReTransformSelected()
+    {
+        var people = Enumerable.Range(1, 10).Select(i => new Person("Name" + i, i)).ToArray();
+        var forceTransform = new Subject<Func<Person, bool>>();
 
-    //    using (var stub = new TransformStub(forceTransform))
-    //    {
-    //        stub.Source.AddOrUpdate(people);
-    //        forceTransform.OnNext(person => person.Age <= 5);
+        using var stub = new TransformStub(forceTransform);
+        stub.Source.AddOrUpdate(people);
+        forceTransform.OnNext(person => person.Age <= 5);
 
-    //        stub.Results.Messages.Count.Should().Be(2);
-    //        stub.Results.Messages[1].Updates.Should().Be(5);
+        stub.Results.Messages.Count.Should().Be(2);
+        stub.Results.Messages[1].Updates.Should().Be(5);
 
-    //        for (int i = 1; i <= 5; i++)
-    //        {
-    //            var original = stub.Results.Messages[0].ElementAt(i - 1).Current;
-    //            var updated = stub.Results.Messages[1].ElementAt(i - 1).Current;
-    //            updated.Should().Be(original);
-    //            ReferenceEquals(original, updated).Should().BeFalse();
-    //        }
-    //    }
-    //}
+        for (int i = 1; i <= 5; i++)
+        {
+            var original = stub.Results.Messages[0].ElementAt(i - 1).Current;
+            var updated = stub.Results.Messages[1].ElementAt(i - 1).Current;
+            updated.Should().Be(original);
+            ReferenceEquals(original, updated).Should().BeFalse();
+        }
+    }
 
-    //[Fact]
-    //public async Task Add()
-    //{
-    //    using (var stub = new TransformStub())
-    //    {
-    //        var person = new Person("Adult1", 50);
-    //        stub.Source.AddOrUpdate(person);
+    [Fact]
+    public async Task Add()
+    {
+        using var stub = new TransformStub();
+        var person = new Person("Adult1", 50);
+        stub.Source.AddOrUpdate(person);
 
-    //        stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
-    //        stub.Results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
+        stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
+        stub.Results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
 
-    //        var firstPerson = await stub.TransformFactory(person);
+        var firstPerson = await stub.TransformFactory(person);
 
-    //        stub.Results.Data.Items.First().Should().Be(firstPerson, "Should be same person");
-    //    }
-    //}
+        stub.Results.Data.Items.First().Should().Be(firstPerson, "Should be same person");
+    }
 
-    //[Fact]
-    //public void Remove()
-    //{
-    //    const string key = "Adult1";
-    //    var person = new Person(key, 50);
+    [Fact]
+    public void Remove()
+    {
+        const string key = "Adult1";
+        var person = new Person(key, 50);
 
-    //    using (var stub = new TransformStub())
-    //    {
-    //        stub.Source.AddOrUpdate(person);
-    //        stub.Source.Remove(key);
+        using var stub = new TransformStub();
+        stub.Source.AddOrUpdate(person);
+        stub.Source.Remove(key);
 
-    //        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
-    //        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
-    //        stub.Results.Messages[0].Adds.Should().Be(1, "Should be 80 addes");
-    //        stub.Results.Messages[1].Removes.Should().Be(1, "Should be 80 removes");
-    //        stub.Results.Data.Count.Should().Be(0, "Should be nothing cached");
-    //    }
-    //}
+        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
+        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
+        stub.Results.Messages[0].Adds.Should().Be(1, "Should be 80 adds");
+        stub.Results.Messages[1].Removes.Should().Be(1, "Should be 80 removes");
+        stub.Results.Data.Count.Should().Be(0, "Should be nothing cached");
+    }
 
-    //[Fact]
-    //public void Update()
-    //{
-    //    const string key = "Adult1";
-    //    var newperson = new Person(key, 50);
-    //    var updated = new Person(key, 51);
+    [Fact]
+    public void Update()
+    {
+        const string key = "Adult1";
+        var newperson = new Person(key, 50);
+        var updated = new Person(key, 51);
 
-    //    using (var stub = new TransformStub())
-    //    {
-    //        stub.Source.AddOrUpdate(newperson);
-    //        stub.Source.AddOrUpdate(updated);
+        using (var stub = new TransformStub())
+        {
+            stub.Source.AddOrUpdate(newperson);
+            stub.Source.AddOrUpdate(updated);
 
-    //        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
-    //        stub.Results.Messages[0].Adds.Should().Be(1, "Should be 1 adds");
-    //        stub.Results.Messages[1].Updates.Should().Be(1, "Should be 1 update");
-    //    }
-    //}
+            stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
+            stub.Results.Messages[0].Adds.Should().Be(1, "Should be 1 adds");
+            stub.Results.Messages[1].Updates.Should().Be(1, "Should be 1 update");
+        }
+    }
 
-    //[Fact]
-    //public async Task BatchOfUniqueUpdates()
-    //{
-    //    var people = Enumerable.Range(1, 100).Select(i => new Person("Name" + i, i)).ToArray();
-    //    using (var stub = new TransformStub())
-    //    {
-    //        stub.Source.AddOrUpdate(people);
+    [Fact]
+    public async Task BatchOfUniqueUpdates()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person("Name" + i, i)).ToArray();
+        using var stub = new TransformStub();
+        stub.Source.AddOrUpdate(people);
 
-    //        stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
-    //        stub.Results.Messages[0].Adds.Should().Be(100, "Should return 100 adds");
+        stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
+        stub.Results.Messages[0].Adds.Should().Be(100, "Should return 100 adds");
 
-    //        var result = await Task.WhenAll(people.Select(stub.TransformFactory));
-    //        var transformed = result.OrderBy(p => p.Age).ToArray();
-    //        stub.Results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(stub.Results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
-    //    }
-    //}
+        var result = await Task.WhenAll(people.Select(stub.TransformFactory));
+        var transformed = result.OrderBy(p => p.Age).ToArray();
+        stub.Results.Data.Items.OrderBy(p => p.Age).Should().BeEquivalentTo(stub.Results.Data.Items.OrderBy(p => p.Age), "Incorrect transform result");
+    }
 
-    //[Fact]
-    //public async Task SameKeyChanges()
-    //{
-    //    using (var stub = new TransformStub())
-    //    {
-    //        var people = Enumerable.Range(1, 10).Select(i => new Person("Name", i)).ToArray();
+    [Fact]
+    public async Task SameKeyChanges()
+    {
+        using var stub = new TransformStub();
+        var people = Enumerable.Range(1, 10).Select(i => new Person("Name", i)).ToArray();
 
-    //        stub.Source.AddOrUpdate(people);
+        stub.Source.AddOrUpdate(people);
 
-    //        stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
-    //        stub.Results.Messages[0].Adds.Should().Be(1, "Should return 1 adds");
-    //        stub.Results.Messages[0].Updates.Should().Be(9, "Should return 9 adds");
-    //        stub.Results.Data.Count.Should().Be(1, "Should result in 1 record");
+        stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
+        stub.Results.Messages[0].Adds.Should().Be(1, "Should return 1 adds");
+        stub.Results.Messages[0].Updates.Should().Be(9, "Should return 9 adds");
+        stub.Results.Data.Count.Should().Be(1, "Should result in 1 record");
 
-    //        var lastTransformed = await stub.TransformFactory(people.Last());
-    //        var onlyItemInCache = stub.Results.Data.Items.First();
+        var lastTransformed = await stub.TransformFactory(people.Last());
+        var onlyItemInCache = stub.Results.Data.Items.First();
 
-    //        onlyItemInCache.Should().Be(lastTransformed, "Incorrect transform result");
-    //    }
-    //}
+        onlyItemInCache.Should().Be(lastTransformed, "Incorrect transform result");
+    }
 
-    //[Fact]
-    //public void Clear()
-    //{
-    //    using (var stub = new TransformStub())
-    //    {
-    //        var people = Enumerable.Range(1, 100).Select(l => new Person("Name" + l, l)).ToArray();
+    [Fact]
+    public void Clear()
+    {
+        using var stub = new TransformStub();
+        var people = Enumerable.Range(1, 100).Select(l => new Person("Name" + l, l)).ToArray();
 
-    //        stub.Source.AddOrUpdate(people);
-    //        stub.Source.Clear();
+        stub.Source.AddOrUpdate(people);
+        stub.Source.Clear();
 
-    //        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
-    //        stub.Results.Messages[0].Adds.Should().Be(100, "Should be 80 addes");
-    //        stub.Results.Messages[1].Removes.Should().Be(100, "Should be 80 removes");
-    //        stub.Results.Data.Count.Should().Be(0, "Should be nothing cached");
-    //    }
-    //}
+        stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
+        stub.Results.Messages[0].Adds.Should().Be(100, "Should be 80 addes");
+        stub.Results.Messages[1].Removes.Should().Be(100, "Should be 80 removes");
+        stub.Results.Data.Count.Should().Be(0, "Should be nothing cached");
+    }
 
-    //[Fact]
-    //public void HandleError()
-    //{
-    //    using (var stub = new TransformStub(p =>
-    //    {
-    //        if (p.Age <= 50)
-    //            return new PersonWithGender(p, p.Age % 2 == 0 ? "M" : "F");
+    [Fact]
+    public void HandleError()
+    {
+        using var stub = new TransformStub(p =>
+        {
+            if (p.Age <= 50)
+                return new PersonWithGender(p, p.Age % 2 == 0 ? "M" : "F");
 
-    //        throw new Exception("Broken");
-    //    }))
-    //    {
-    //        var people = Enumerable.Range(1, 100).Select(l => new Person("Name" + l, l)).ToArray();
-    //        stub.Source.AddOrUpdate(people);
+            throw new Exception("Broken");
+        });
+        var people = Enumerable.Range(1, 100).Select(l => new Person("Name" + l, l)).ToArray();
+        stub.Source.AddOrUpdate(people);
 
-    //        stub.Results.Error.Should().BeNull();
+        stub.Results.Error.Should().BeNull();
 
-    //        Exception? error = null;
-    //        stub.Source.Connect()
-    //            .Subscribe(changes => { }, ex => error = ex);
+        Exception? error = null;
+        stub.Source.Connect()
+            .Subscribe(changes => { }, ex => error = ex);
 
-    //        error.Should().BeNull();
+        error.Should().BeNull();
 
-    //        stub.HandledErrors.Count.Should().Be(50);
-    //        stub.Results.Data.Count.Should().Be(50);
-    //    }
-    //}
+        stub.HandledErrors.Count.Should().Be(50);
+        stub.Results.Data.Count.Should().Be(50);
+    }
+
+    [Theory, InlineData(true), InlineData(false)]
+    public void TransformOnRefresh(bool transformOnRefresh)
+    {
+        int errorCount = 0;
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var results = source.Connect()
+            .AutoRefresh()
+            .TransformAsync((p, key) => Task.FromResult(new PersonWithAgeGroup(p, p.Age < 18 ? "Child" : "Adult")), TransformAsyncOptions.Default with { TransformOnRefresh = transformOnRefresh }).AsAggregator();
+
+        var person = new Person("SomeOne", 16);
+        source.AddOrUpdate(person);
+
+        results.Data.Count.Should().Be(1);
+        results.Data.Lookup("SomeOne").Value.AgeGroup.Should().Be("Child");
+
+        person.Age = 21;
+
+
+        results.Data.Count.Should().Be(1);
+        results.Data.Lookup("SomeOne").Value.AgeGroup.Should().Be(transformOnRefresh ? "Adult" : "Child");
+        errorCount.Should().Be(0);
+    }
+
+
+    [Theory, InlineData(10), InlineData(100)]
+
+    public async Task WithMaxConcurrency(int maxConcurrency)
+    {
+        /* We need to test whether the max concurrency has any effect.
+
+             If  maxConcurrency == 100, this test takes a little more than 100 ms
+             If maxConcurrency = 10, this test takes a little more than 1s 
+
+            So it works, but how can it be tested in a scientific way ??
+        */
+
+        int errorCount = 0;
+        const int transformCount = 100;
+
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var results = source.Connect()
+            .TransformSafeAsync(async (p, key) =>
+                {
+                    await Task.Delay(100);
+
+                    return new PersonWithAgeGroup(p, p.Age < 18 ? "Child" : "Adult");
+                }
+                , error => { errorCount++; }
+                , TransformAsyncOptions.Default with { MaximumConcurrency = maxConcurrency })
+            .AsAggregator();
+
+        source.AddOrUpdate(Enumerable.Range(1, transformCount).Select(l => new Person("Person" + l, l)));
+
+        await results.Data.CountChanged.Where(c => c == transformCount).Take(1)
+            .Timeout(TimeSpan.FromSeconds(2));
+
+        errorCount.Should().Be(0);
+    }
+
 
     private class TransformStub : IDisposable
     {

--- a/src/DynamicData.Tests/Domain/PersonWithGender.cs
+++ b/src/DynamicData.Tests/Domain/PersonWithGender.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 namespace DynamicData.Tests.Domain;
+public record PersonWithAgeGroup(Person Person, string AgeGroup);
 
 public class PersonWithGender : IEquatable<PersonWithGender>
 {

--- a/src/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/src/DynamicData.Tests/DynamicData.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618;CA1801;CA1812;CA1816;CA1063;CS8767;CS8602;CS8618;IDE1006</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/src/DynamicData.Tests/DynamicData.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.0.1" />
+    <PackageReference Include="Bogus" Version="35.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(XunitVersion)" />

--- a/src/DynamicData/Binding/TransformAsyncOptions.cs
+++ b/src/DynamicData/Binding/TransformAsyncOptions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace DynamicData.Binding;
+
+/// <summary>
+/// Options for TransformAsync and TransformSafeAsync.
+/// </summary>
+/// <param name="MaximumConcurrency">The maximum number of tasks in flight at once.</param>
+/// <param name="TransformOnRefresh">Should a new transform be applied when a refresh event is received.</param>
+public record struct TransformAsyncOptions(int? MaximumConcurrency = null, bool TransformOnRefresh = false)
+{
+    /// <summary>
+    /// Options with WithTransformOnRefresh = true.
+    /// </summary>
+    public static readonly TransformAsyncOptions WithTransformOnRefresh = new(TransformOnRefresh: true);
+
+    /// <summary>
+    /// Specify maximum concurrency only.
+    /// </summary>
+    /// <param name="maximumConcurrency">The maximum concurrency.</param>
+    /// <returns>A TransformAsyncOptions object.</returns>
+    public static TransformAsyncOptions WithMaximumConcurrency(int maximumConcurrency) => new(maximumConcurrency);
+}

--- a/src/DynamicData/Cache/Internal/TransformAsync.cs
+++ b/src/DynamicData/Cache/Internal/TransformAsync.cs
@@ -52,7 +52,7 @@ internal class TransformAsync<TDestination, TSource, TKey>(
     private IObservable<IChangeSet<TDestination, TKey>> DoTransform(
         ChangeAwareCache<TransformedItemContainer, TKey> cache, IChangeSet<TSource, TKey> changes)
     {
-        return changes.Select(change => Observable.Defer(() => Transform(change).ToObservable()))
+        return changes.Select(change => Observable.FromAsync(() => Transform(change)))
             .Merge(maximumConcurrency ?? int.MaxValue)
             .ToArray()
             .Select(transformed => ProcessUpdates(cache, transformed));

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -4765,6 +4765,87 @@ public static class ObservableCacheEx
     }
 
     /// <summary>
+    /// Projects each update item to a new form using the specified transform function.
+    /// </summary>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="transformFactory">The transform factory.</param>
+    /// <param name="options">The transform options.</param>
+    /// <returns>
+    /// A transformed update collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">source
+    /// or
+    /// transformFactory.</exception>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Task<TDestination>> transformFactory, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+
+        return source.TransformAsync((current, _, _) => transformFactory(current), options);
+    }
+
+    /// <summary>
+    /// Projects each update item to a new form using the specified transform function.
+    /// </summary>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="transformFactory">The transform factory.</param>
+    /// <param name="options">The transform options.</param>
+    /// <returns>
+    /// A transformed update collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">source
+    /// or
+    /// transformFactory.</exception>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<TDestination>> transformFactory, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+
+        return source.TransformAsync((current, _, key) => transformFactory(current, key), options);
+    }
+
+    /// <summary>
+    /// Projects each update item to a new form using the specified transform function.
+    /// </summary>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="transformFactory">The transform factory.</param>
+    /// <param name="options">The transform options.</param>
+    /// <returns>
+    /// A transformed update collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">source
+    /// or
+    /// transformFactory.</exception>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+
+        return new TransformAsync<TDestination, TSource, TKey>(source, transformFactory, null, null, options.MaximumConcurrency, options.TransformOnRefresh).Run();
+    }
+
+    /// <summary>
     /// Equivalent to a select many transform. To work, the key must individually identify each child.
     /// </summary>
     /// <typeparam name="TDestination">The type of the destination.</typeparam>
@@ -5088,6 +5169,93 @@ public static class ObservableCacheEx
         errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
 
         return new TransformAsync<TDestination, TSource, TKey>(source, transformFactory, errorHandler, forceTransform).Run();
+    }
+
+    /// <summary>
+    /// Projects each update item to a new form using the specified transform function.
+    /// </summary>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="transformFactory">The transform factory.</param>
+    /// <param name="errorHandler">The error handler.</param>
+    /// <param name="options">Additional transform options.</param>
+    /// <returns>
+    /// A transformed update collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">source
+    /// or
+    /// transformFactory.</exception>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+        errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
+
+        return source.TransformSafeAsync((current, _, _) => transformFactory(current), errorHandler, options);
+    }
+
+    /// <summary>
+    /// Projects each update item to a new form using the specified transform function.
+    /// </summary>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="transformFactory">The transform factory.</param>
+    /// <param name="errorHandler">The error handler.</param>
+    /// <param name="options">Additional transform options.</param>
+    /// <returns>
+    /// A transformed update collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">source
+    /// or
+    /// transformFactory.</exception>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+        errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
+
+        return source.TransformSafeAsync((current, _, key) => transformFactory(current, key), errorHandler, options);
+    }
+
+    /// <summary>
+    /// Projects each update item to a new form using the specified transform function.
+    /// </summary>
+    /// <typeparam name="TDestination">The type of the destination.</typeparam>
+    /// <typeparam name="TSource">The type of the source.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="transformFactory">The transform factory.</param>
+    /// <param name="errorHandler">The error handler.</param>
+    /// <param name="options">Additional transform options.</param>
+    /// <returns>
+    /// A transformed update collection.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">source
+    /// or
+    /// transformFactory.</exception>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+        errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
+
+        return new TransformAsync<TDestination, TSource, TKey>(source, transformFactory, errorHandler, null, options.MaximumConcurrency, options.TransformOnRefresh).Run();
     }
 
     /// <summary>

--- a/src/DynamicData/Cache/TransformAsyncOptions.cs
+++ b/src/DynamicData/Cache/TransformAsyncOptions.cs
@@ -1,24 +1,18 @@
 ﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-namespace DynamicData.Binding;
+namespace DynamicData;
 
 /// <summary>
 /// Options for TransformAsync and TransformSafeAsync.
 /// </summary>
 /// <param name="MaximumConcurrency">The maximum number of tasks in flight at once.</param>
 /// <param name="TransformOnRefresh">Should a new transform be applied when a refresh event is received.</param>
-public record struct TransformAsyncOptions(int? MaximumConcurrency = null, bool TransformOnRefresh = false)
+public record struct TransformAsyncOptions(int? MaximumConcurrency, bool TransformOnRefresh)
 {
     /// <summary>
-    /// Options with WithTransformOnRefresh = true.
+    /// The default transform async option values, with is unlimited concurrency and do not transform on reset.
     /// </summary>
-    public static readonly TransformAsyncOptions WithTransformOnRefresh = new(TransformOnRefresh: true);
-
-    /// <summary>
-    /// Specify maximum concurrency only.
-    /// </summary>
-    /// <param name="maximumConcurrency">The maximum concurrency.</param>
     /// <returns>A TransformAsyncOptions object.</returns>
-    public static TransformAsyncOptions WithMaximumConcurrency(int maximumConcurrency) => new(maximumConcurrency);
+    public static readonly TransformAsyncOptions Default = new(null, false);
 }


### PR DESCRIPTION
1. Improve implementation of TransformAsync 
2. Add max concurrency param to prevent unbounded parallelisation.
3. Add transform on refresh overloads
4. Improve slow running concurrency test
5. Use TransformAsyncOptions for primitive objects - also include for Safe variants.

TODO:

1. ~Deal with large number of overloads required to include the extra optional params~
2. ~Maybe scrap 1 and use a TransformOptions object (similar to BindingOptions) and move away from the bewildering number of overloads.~

@dwcullop this is what I meant regarding using pure rx to handle the async.