### PR TITLE
Fixed ambiguous overloads for `ObservableCacheEx.ExpireAfter()` and `ObservableListEx.ExpireAfter()`.

### DIFF
--- a/src/DynamicData.Benchmarks/Cache/ExpireAfter_Cache_ForSource.cs
+++ b/src/DynamicData.Benchmarks/Cache/ExpireAfter_Cache_ForSource.cs
@@ -67,8 +67,8 @@ public class ExpireAfter_Cache_ForSource
 
         using var subscription = source
             .ExpireAfter(
-                timeSelector:   static item => item.Lifetime,
-                interval:       null)
+                timeSelector:       static item => item.Lifetime,
+                pollingInterval:    null)
             .Subscribe();
 
         PerformRandomizedEdits(source);

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1301,19 +1301,13 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, System.TimeSpan?> timeSelector)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this DynamicData.ISourceCache<TObject, TKey> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.Reactive.Concurrency.IScheduler? scheduler = null)
-            where TObject :  notnull
-            where TKey :  notnull { }
-        public static System.IObservable<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this DynamicData.ISourceCache<TObject, TKey> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.TimeSpan? interval = default)
-            where TObject :  notnull
-            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.Reactive.Concurrency.IScheduler scheduler)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.TimeSpan? pollingInterval)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this DynamicData.ISourceCache<TObject, TKey> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.TimeSpan? pollingInterval, System.Reactive.Concurrency.IScheduler? scheduler)
+        public static System.IObservable<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>>> ExpireAfter<TObject, TKey>(this DynamicData.ISourceCache<TObject, TKey> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.TimeSpan? pollingInterval = default, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> ExpireAfter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, System.TimeSpan?> timeSelector, System.TimeSpan? pollingInterval, System.Reactive.Concurrency.IScheduler scheduler)

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -2310,8 +2310,6 @@ namespace DynamicData
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<T>> Except<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, params System.IObservable<DynamicData.IChangeSet<T>>[] others)
             where T :  notnull { }
-        public static System.IObservable<System.Collections.Generic.IEnumerable<T>> ExpireAfter<T>(this DynamicData.ISourceList<T> source, System.Func<T, System.TimeSpan?> timeSelector, System.Reactive.Concurrency.IScheduler? scheduler = null)
-            where T :  notnull { }
         public static System.IObservable<System.Collections.Generic.IEnumerable<T>> ExpireAfter<T>(this DynamicData.ISourceList<T> source, System.Func<T, System.TimeSpan?> timeSelector, System.TimeSpan? pollingInterval = default, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<T>> Filter<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, bool> predicate)

--- a/src/DynamicData.Tests/Cache/ExpireAfterFixture.ForSource.cs
+++ b/src/DynamicData.Tests/Cache/ExpireAfterFixture.ForSource.cs
@@ -550,7 +550,7 @@ public static partial class ExpireAfterFixture
             => FluentActions.Invoking(() => ObservableCacheEx.ExpireAfter(
                     source: (null as ISourceCache<TestItem, int>)!,
                     timeSelector: static _ => default,
-                    interval: null))
+                    pollingInterval: null))
                 .Should().Throw<ArgumentNullException>();
 
         [Fact]
@@ -620,7 +620,7 @@ public static partial class ExpireAfterFixture
         public void TimeSelectorIsNull_ThrowsException()
             => FluentActions.Invoking(() => CreateTestSource().ExpireAfter(
                     timeSelector: null!,
-                    interval: null))
+                    pollingInterval: null))
                 .Should().Throw<ArgumentNullException>();
 
         [Fact]

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -658,25 +658,6 @@ public static class ObservableListEx
     /// <typeparam name="T">The type of the item.</typeparam>
     /// <param name="source">The source.</param>
     /// <param name="timeSelector">Selector returning when to expire the item. Return null for non-expiring item.</param>
-    /// <param name="scheduler">The scheduler.</param>
-    /// <returns>An observable which emits the enumerable of items.</returns>
-    public static IObservable<IEnumerable<T>> ExpireAfter<T>(
-                this ISourceList<T> source,
-                Func<T, TimeSpan?> timeSelector,
-                IScheduler? scheduler = null)
-            where T : notnull
-        => List.Internal.ExpireAfter<T>.Create(
-            source: source,
-            timeSelector: timeSelector,
-            pollingInterval: null,
-            scheduler: scheduler);
-
-    /// <summary>
-    /// Removes items from the cache according to the value specified by the time selector function.
-    /// </summary>
-    /// <typeparam name="T">The type of the item.</typeparam>
-    /// <param name="source">The source.</param>
-    /// <param name="timeSelector">Selector returning when to expire the item. Return null for non-expiring item.</param>
     /// <param name="pollingInterval">Enter the polling interval to optimise expiry timers, if omitted 1 timer is created for each unique expiry time.</param>
     /// <param name="scheduler">The scheduler.</param>
     /// <returns>An observable which emits the enumerable of items.</returns>


### PR DESCRIPTION
Also moved `EnsureUniqueKeys()` into proper order.

Currently, the following code produces an ambigous method error at compile-time, for the call to `.ExpireAfter()`.

```cs
var source = new SourceCache<string, int>(x => x.GetHashCode());

var result = source.ExpireAfter(_ => TimeSpan.FromSeconds(1));
```

Since any fix for this would be a breaking change, I've implemented it by just consolidating all of the overloads into one method, for simplicity.

The issue itself is relatively minor, as it can be easily worked-around by doing...

```cs
var source = new SourceCache<string, int>(x => x.GetHashCode());

var result = source.ExpireAfter(
    timeSelector: _ => TimeSpan.FromSeconds(1),
    interval: null);
```

or

```cs
var source = new SourceCache<string, int>(x => x.GetHashCode());

var result = source.ExpireAfter(
    timeSelector: _ => TimeSpan.FromSeconds(1),
    scheduler: null);
```

Since this is a breaking change with low impact, I would propose NOT merging this until we already have a major-version change queued up, due to other issues or enhancements.