### PR TITLE
Feature:  Improve Performance of MergeManyChangeSets with fewer changesets

### DIFF
--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheFixture.cs
@@ -230,7 +230,7 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
         _marketCacheResults.Data.Count.Should().Be(MarketCount);
         markets.Sum(m => m.PricesCache.Count).Should().Be(MarketCount * PricesPerMarket);
         results.Data.Count.Should().Be(MarketCount * PricesPerMarket);
-        results.Messages.Count.Should().Be(MarketCount);
+        results.Messages.Count.Should().Be(1);
         results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
         results.Summary.Overall.Removes.Should().Be(0);
         results.Summary.Overall.Updates.Should().Be(0);
@@ -390,17 +390,39 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
         // having
         var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
         using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
-        _marketCache.AddOrUpdate(markets);
         AddUniquePrices(markets);
+        _marketCache.AddOrUpdate(markets);
 
         // when
         _marketCache.Edit(updater => updater.RemoveKeys(updater.Keys.Take(RemoveCount)));
 
         // then
         _marketCacheResults.Data.Count.Should().Be(MarketCount - RemoveCount);
+        results.Messages.Count.Should().Be(2);
         results.Data.Count.Should().Be((MarketCount - RemoveCount) * PricesPerMarket);
         results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
         results.Summary.Overall.Removes.Should().Be(PricesPerMarket * RemoveCount);
+    }
+
+    [Fact]
+    public void ClearingParentEmitsSingleChangeSet()
+    {
+        // having
+        var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
+        using var results = _marketCache.Connect().MergeManyChangeSets(m => m.LatestPrices, MarketPrice.EqualityComparer).AsAggregator();
+        AddUniquePrices(markets);
+        _marketCache.AddOrUpdate(markets);
+
+        // when
+        _marketCache.Clear();
+
+        // then
+        _marketCacheResults.Data.Count.Should().Be(0);
+        results.Data.Count.Should().Be(0);
+        results.Messages.Count.Should().Be(2);
+        results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
+        results.Summary.Overall.Removes.Should().Be(MarketCount * PricesPerMarket);
+        results.Summary.Overall.Updates.Should().Be(0);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
@@ -228,7 +228,7 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
         _marketCacheResults.Data.Count.Should().Be(MarketCount);
         markets.Sum(m => m.PricesCache.Count).Should().Be(MarketCount * PricesPerMarket);
         results.Data.Count.Should().Be(MarketCount * PricesPerMarket);
-        results.Messages.Count.Should().Be(MarketCount);
+        results.Messages.Count.Should().Be(1);
         results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
         results.Summary.Overall.Removes.Should().Be(0);
         results.Summary.Overall.Updates.Should().Be(0);
@@ -263,8 +263,8 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
         // having
         var markets = Enumerable.Range(0, MarketCount).Select(n => new Market(n)).ToArray();
         using var results = ChangeSetByRating().AsAggregator();
-        _marketCache.AddOrUpdate(markets);
         markets.Select((m, index) => new { Market = m, Index = index }).ForEach(m => m.Market.SetPrices(m.Index * ItemIdStride, (m.Index * ItemIdStride) + PricesPerMarket, GetRandomPrice));
+        _marketCache.AddOrUpdate(markets);
 
         // when
         markets.ForEach(m => m.RefreshAllPrices(GetRandomPrice));
@@ -272,7 +272,7 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
         // then
         _marketCacheResults.Data.Count.Should().Be(MarketCount);
         results.Data.Count.Should().Be(MarketCount * PricesPerMarket);
-        results.Messages.Count.Should().Be(MarketCount * 2);
+        results.Messages.Count.Should().Be(MarketCount + 1);
         results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
         results.Summary.Overall.Removes.Should().Be(0);
         results.Summary.Overall.Updates.Should().Be(0);

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
@@ -161,7 +161,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount);
+        _animalResults.Messages.Count.Should().Be(1);
         CheckResultContents();
     }
 
@@ -176,7 +176,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + 1);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         addThis.Animals.Items.ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
     }
@@ -192,7 +192,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - 1);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         removeThis.Animals.Items.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();
         removeThis.Dispose();
@@ -209,7 +209,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - RemoveRangeSize);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + RemoveRangeSize);
+        _animalResults.Messages.Count.Should().Be(2);
         removeThese.SelectMany(owner => owner.Animals.Items).ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();
         removeThese.ForEach(owner => owner.Dispose());
@@ -227,7 +227,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount); // Owner Count should not change
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 2); // +2 = 1 Message removing animals from old value, +1 message adding from new value
+        _animalResults.Messages.Count.Should().Be(2); // +2 = 1 Message removing animals from old value, +1 message adding from new value
         replaceThis.Animals.Items.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         withThis.Animals.Items.ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
@@ -262,7 +262,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount * 2);
+        _animalResults.Messages.Count.Should().Be(2);
         totalAdded.ForEach(animal => _animalResults.Data.Items.Should().Contain(animal));
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + totalAdded.Count);
         CheckResultContents();
@@ -283,7 +283,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
         // Assert
         randomOwner.Animals.Items.ElementAt(insertIndex).Should().Be(insertThis);
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         _animalResults.Data.Items.Should().Contain(insertThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + 1);
         CheckResultContents();
@@ -302,7 +302,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         _animalResults.Data.Items.Should().NotContain(removeThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount - 1);
         CheckResultContents();
@@ -322,7 +322,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         _animalResults.Data.Items.Should().NotContain(removeThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount - 1);
         CheckResultContents();
@@ -342,7 +342,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         removeThese.ForEach(removed => randomOwner.Animals.Items.Should().NotContain(removed));
         CheckResultContents();
     }
@@ -360,7 +360,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         removeThese.ForEach(removed => randomOwner.Animals.Items.Should().NotContain(removed));
         CheckResultContents();
     }
@@ -378,7 +378,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         randomOwner.Animals.Items.Should().NotContain(replaceThis);
         randomOwner.Animals.Items.Should().Contain(withThis);
         CheckResultContents();
@@ -396,7 +396,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2);
         randomOwner.Animals.Count.Should().Be(0);
         removedAnimals.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
@@ -227,7 +227,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount); // Owner Count should not change
-        _animalResults.Messages.Count.Should().Be(2); // +2 = 1 Message removing animals from old value, +1 message adding from new value
+        _animalResults.Messages.Count.Should().Be(2); // 2 = Initial Add and one changeset with remove old items / add new items
         replaceThis.Animals.Items.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         withThis.Animals.Items.ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
@@ -262,7 +262,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(2);
+        _animalResults.Messages.Count.Should().Be(1 + InitialOwnerCount); // Initial + 1 for each Range Added
         totalAdded.ForEach(animal => _animalResults.Data.Items.Should().Contain(animal));
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + totalAdded.Count);
         CheckResultContents();

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
@@ -198,7 +198,7 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
         _marketListResults.Data.Count.Should().Be(MarketCount);
         markets.Sum(m => m.PricesCache.Count).Should().Be(MarketCount * PricesPerMarket);
         results.Data.Count.Should().Be(MarketCount * PricesPerMarket);
-        results.Messages.Count.Should().Be(MarketCount);
+        results.Messages.Count.Should().Be(1);
         results.Summary.Overall.Adds.Should().Be(MarketCount * PricesPerMarket);
         results.Summary.Overall.Removes.Should().Be(0);
         results.Summary.Overall.Updates.Should().Be(0);
@@ -823,8 +823,6 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
         _marketListResults.Dispose();
         DisposeMarkets();
     }
-
-    private void AddUniquePrices(Market[] markets) => markets.ForEach(m => m.AddUniquePrices(PricesPerMarket, _ => GetRandomPrice()));
 
     private void CheckResultContents(ChangeSetAggregator<IMarket> marketResults, ChangeSetAggregator<MarketPrice, int> priceResults)
     {

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
@@ -165,7 +165,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + AddRangeSize);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + AddRangeSize);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for additional add
         addThese.SelectMany(added => added.Animals.Items).ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
     }

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
@@ -150,7 +150,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount);
+        _animalResults.Messages.Count.Should().Be(1);
         CheckResultContents();
     }
 
@@ -181,7 +181,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + 1);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for additional add
         addThis.Animals.Items.ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
     }
@@ -199,7 +199,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
         // Assert
         _animalOwners.Items.ElementAt(insertIndex).Should().Be(insertThis);
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount + 1);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for additional add
         insertThis.Animals.Items.ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
     }
@@ -215,7 +215,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - 1);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         removeThis.Animals.Items.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();
         removeThis.Dispose();
@@ -233,7 +233,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - 1);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         removeThis.Animals.Items.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();
         removeThis.Dispose();
@@ -251,7 +251,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - RemoveRangeSize);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + RemoveRangeSize);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         removeThese.SelectMany(owner => owner.Animals.Items).ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();
         removeThese.ForEach(owner => owner.Dispose());
@@ -268,7 +268,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount - RemoveRangeSize);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + RemoveRangeSize);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         removeThese.SelectMany(owner => owner.Animals.Items).ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();
         removeThese.ForEach(owner => owner.Dispose());
@@ -286,7 +286,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount); // Owner Count should not change
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 2); // +2 = 1 Message removing animals from old value, +1 message adding from new value
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         replaceThis.Animals.Items.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         withThis.Animals.Items.ForEach(added => _animalResults.Data.Items.Should().Contain(added));
         CheckResultContents();
@@ -305,6 +305,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(0);
         _animalResults.Data.Count.Should().Be(0);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         CheckResultContents();
         items.ForEach(owner => owner.Dispose());
     }
@@ -322,7 +323,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for additional add
         addThese.ForEach(animal => _animalResults.Data.Items.Should().Contain(animal));
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + AddRangeSize);
         CheckResultContents();
@@ -341,7 +342,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         _animalResults.Data.Items.Should().Contain(addThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + 1);
         CheckResultContents();
@@ -362,7 +363,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
         // Assert
         randomOwner.Animals.Items.ElementAt(insertIndex).Should().Be(insertThis);
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for additional add
         _animalResults.Data.Items.Should().Contain(insertThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount + 1);
         CheckResultContents();
@@ -381,7 +382,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         _animalResults.Data.Items.Should().NotContain(removeThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount - 1);
         CheckResultContents();
@@ -401,7 +402,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         _animalResults.Data.Items.Should().NotContain(removeThis);
         _animalOwners.Items.Sum(owner => owner.Animals.Count).Should().Be(initialCount - 1);
         CheckResultContents();
@@ -421,7 +422,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         removeThese.ForEach(removed => randomOwner.Animals.Items.Should().NotContain(removed));
         CheckResultContents();
     }
@@ -439,7 +440,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         removeThese.ForEach(removed => randomOwner.Animals.Items.Should().NotContain(removed));
         CheckResultContents();
     }
@@ -457,7 +458,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for update
         randomOwner.Animals.Items.Should().NotContain(replaceThis);
         randomOwner.Animals.Items.Should().Contain(withThis);
         CheckResultContents();
@@ -475,7 +476,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // Assert
         _animalOwnerResults.Data.Count.Should().Be(InitialOwnerCount);
-        _animalResults.Messages.Count.Should().Be(InitialOwnerCount + 1);
+        _animalResults.Messages.Count.Should().Be(2); // 1 for initial add, 1 for removing
         randomOwner.Animals.Count.Should().Be(0);
         removedAnimals.ForEach(removed => _animalResults.Data.Items.Should().NotContain(removed));
         CheckResultContents();

--- a/src/DynamicData/Cache/Internal/ChangeSetMergeTracker.cs
+++ b/src/DynamicData/Cache/Internal/ChangeSetMergeTracker.cs
@@ -13,7 +13,7 @@ internal sealed class ChangeSetMergeTracker<TObject, TKey>(Func<IEnumerable<Chan
 {
     private readonly ChangeAwareCache<TObject, TKey> _resultCache = new();
 
-    public void RemoveItems(IEnumerable<KeyValuePair<TKey, TObject>> items, IObserver<IChangeSet<TObject, TKey>> observer)
+    public void RemoveItems(IEnumerable<KeyValuePair<TKey, TObject>> items, IObserver<IChangeSet<TObject, TKey>>? observer = null)
     {
         var sourceCaches = selectCaches().ToArray();
 
@@ -34,10 +34,13 @@ internal sealed class ChangeSetMergeTracker<TObject, TKey>(Func<IEnumerable<Chan
             }
         }
 
-        EmitChanges(observer);
+        if (observer != null)
+        {
+            EmitChanges(observer);
+        }
     }
 
-    public void RefreshItems(IEnumerable<TKey> keys, IObserver<IChangeSet<TObject, TKey>> observer)
+    public void RefreshItems(IEnumerable<TKey> keys, IObserver<IChangeSet<TObject, TKey>>? observer = null)
     {
         var sourceCaches = selectCaches().ToArray();
 
@@ -58,10 +61,13 @@ internal sealed class ChangeSetMergeTracker<TObject, TKey>(Func<IEnumerable<Chan
             }
         }
 
-        EmitChanges(observer);
+        if (observer != null)
+        {
+            EmitChanges(observer);
+        }
     }
 
-    public void ProcessChangeSet(IChangeSet<TObject, TKey> changes, IObserver<IChangeSet<TObject, TKey>> observer)
+    public void ProcessChangeSet(IChangeSet<TObject, TKey> changes, IObserver<IChangeSet<TObject, TKey>>? observer = null)
     {
         var sourceCaches = selectCaches().ToArray();
 
@@ -87,10 +93,13 @@ internal sealed class ChangeSetMergeTracker<TObject, TKey>(Func<IEnumerable<Chan
             }
         }
 
-        EmitChanges(observer);
+        if (observer != null)
+        {
+            EmitChanges(observer);
+        }
     }
 
-    private void EmitChanges(IObserver<IChangeSet<TObject, TKey>> observer)
+    public void EmitChanges(IObserver<IChangeSet<TObject, TKey>> observer)
     {
         var changeSet = _resultCache.CaptureChanges();
         if (changeSet.Count != 0)

--- a/src/DynamicData/Cache/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyListChangeSets.cs
@@ -4,6 +4,7 @@
 
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using DynamicData.Internal;
 using DynamicData.List.Internal;
 
 namespace DynamicData.Cache.Internal;

--- a/src/DynamicData/Internal/ObservableEx.cs
+++ b/src/DynamicData/Internal/ObservableEx.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+
+namespace DynamicData.Internal;
+
+internal static class ObservableEx
+{
+    public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<T> onNext, Action<Exception> onError, Action onComplete) =>
+        observable.SubscribeSafe(Observer.Create(onNext, onError, onComplete));
+}

--- a/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/List/Internal/MergeManyListChangeSets.cs
@@ -4,6 +4,7 @@
 
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using DynamicData.Internal;
 
 namespace DynamicData.List.Internal;
 
@@ -14,34 +15,40 @@ internal sealed class MergeManyListChangeSets<TObject, TDestination>(IObservable
     where TObject : notnull
     where TDestination : notnull
 {
-    public IObservable<IChangeSet<TDestination>> Run() =>
-        Observable.Create<IChangeSet<TDestination>>(
-            observer =>
-            {
-                var locker = new object();
+    public IObservable<IChangeSet<TDestination>> Run() => Observable.Create<IChangeSet<TDestination>>(
+        observer =>
+        {
+            var locker = new object();
+            var parentUpdate = false;
 
-                // This is manages all of the changes
-                var changeTracker = new ChangeSetMergeTracker<TDestination>();
+            // This is manages all of the changes
+            var changeTracker = new ChangeSetMergeTracker<TDestination>();
 
-                // Transform to a list changeset of child lists, synchronize, and publish.
-                var shared = source
-                    .Transform(obj => new ClonedListChangeSet<TDestination>(selector(obj).Synchronize(locker), equalityComparer))
-                    .Synchronize(locker)
-                    .Publish();
+            // Transform to a list changeset of child lists, synchronize, and publish.
+            var shared = source
+                .Transform(obj => new ClonedListChangeSet<TDestination>(selector(obj).Synchronize(locker), equalityComparer))
+                .Synchronize(locker)
+                .Do(_ => parentUpdate = true)
+                .Publish();
 
-                // Merge the child changeset changes together and apply to the tracker
-                var subMergeMany = shared
-                    .MergeMany(clonedList => clonedList.Source.RemoveIndex())
-                    .Subscribe(
-                        changes => changeTracker.ProcessChangeSet(changes, observer),
-                        observer.OnError,
-                        observer.OnCompleted);
+            // Merge the child changeset changes together and apply to the tracker
+            var subMergeMany = shared
+                .MergeMany(clonedList => clonedList.Source.RemoveIndex())
+                .SubscribeSafe(
+                    changes => changeTracker.ProcessChangeSet(changes, !parentUpdate ? observer : null),
+                    observer.OnError,
+                    observer.OnCompleted);
 
-                // When a source item is removed, all of its sub-items need to be removed
-                var subRemove = shared
-                    .OnItemRemoved(clonedList => changeTracker.RemoveItems(clonedList.List, observer), invokeOnUnsubscribe: false)
-                    .Subscribe();
+            // When a source item is removed, all of its sub-items need to be removed
+            var subRemove = shared
+                .OnItemRemoved(clonedList => changeTracker.RemoveItems(clonedList.List), invokeOnUnsubscribe: false)
+                .Do(_ =>
+                {
+                    changeTracker.EmitChanges(observer);
+                    parentUpdate = false;
+                })
+                .Subscribe();
 
-                return new CompositeDisposable(shared.Connect(), subMergeMany, subRemove);
-            });
+            return new CompositeDisposable(shared.Connect(), subMergeMany, subRemove);
+        });
 }


### PR DESCRIPTION
## Description

This PR improves the performance of the various `MergeManyChangeSet` operators by reducing the number of changeset that are emitted.  Instead of one changeset per change in child changesets, the changes are held until they've all been processed, and the result is then emitted as a single changeset.

### Impact

All changes from a parent changeset will result in a single downstream changeset.  If it adds 2 items and removes 3 others, then the downstream will see a single changeset that adds of the child items from the added parent items and removes all of the child items from the 3 removed parent items.

Updates will result in a single changeset with removal of old child items/adding of new child items.

## Logic Overview

By setting a flag before handling any changes to the parent changeset, we can detect if changes to the child changeset are due to parent changes (add/remove) we can avoid emitting them.  At the end of handling a parent changeset, all of the changes can be emitted at once.

When the flag is not set, then the child changeset are not the result of parental changes, and they can be emitted immediately.

## Other Changes

Creates an overload for `SubscribeSafe` extension method that enables it to be invoked with Action objects instead of just `IObserver<T>`.

## Testing

- Updated unit tests to expect fewer changesets as appropriate
- Added a new test to confirm clearing the parent cache results in a single changeset removing all the children