### PR TITLE
Feature:  Group by Dynamic Selector Function

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1367,6 +1367,14 @@ namespace DynamicData
             where TObject :  notnull
             where TKey :  notnull
             where TGroupKey :  notnull { }
+        public static System.IObservable<DynamicData.IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Func<TObject, TGroupKey>> groupSelectorKeyObservable, System.IObservable<System.Reactive.Unit>? regrouper = null)
+            where TObject :  notnull
+            where TKey :  notnull
+            where TGroupKey :  notnull { }
+        public static System.IObservable<DynamicData.IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Func<TObject, TKey, TGroupKey>> groupSelectorKeyObservable, System.IObservable<System.Reactive.Unit>? regrouper = null)
+            where TObject :  notnull
+            where TKey :  notnull
+            where TGroupKey :  notnull { }
         public static System.IObservable<DynamicData.IGroupChangeSet<TObject, TKey, TGroupKey>> GroupOnObservable<TObject, TKey, TGroupKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, System.IObservable<TGroupKey>> groupObservableSelector)
             where TObject :  notnull
             where TKey :  notnull

--- a/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
@@ -45,7 +45,7 @@ public class GroupOnDynamicFixture : IDisposable
         _faker = Fakers.Person.Clone().WithSeed(_randomizer);
         _results = _cache.Connect().AsAggregator();
         _groupResults = _cache.Connect().Group(_keySelectionSubject, _regroupSubject).AsAggregator();
-        _cleanup = _keySelectionSubject.Do(func => _groupKeySelector = func).Subscribe();
+        _cleanup = _keySelectionSubject.Subscribe(func => _groupKeySelector = func, static _ => { });
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+using Bogus;
+using DynamicData.Tests.Domain;
+using DynamicData.Binding;
+using DynamicData.Kernel;
+using FluentAssertions;
+using Xunit;
+
+using Person = DynamicData.Tests.Domain.Person;
+using System.Reactive.Subjects;
+using System.Reactive;
+
+namespace DynamicData.Tests.Cache;
+
+public class GroupOnDynamicFixture : IDisposable
+{
+#if DEBUG
+    private const int InitialCount = 7;
+    private const int AddCount = 5;
+    private const int RemoveCount = 3;
+    private const int UpdateCount = 2;
+#else
+    private const int InitialCount = 103;
+    private const int AddCount = 53;
+    private const int RemoveCount = 37;
+    private const int UpdateCount = 101;
+#endif
+    private readonly SourceCache<Person, string> _personCache = new(p => p.UniqueKey);
+    private readonly ChangeSetAggregator<Person, string> _personResults;
+    private readonly GroupChangeSetAggregator<Person, string, string> _groupResults;
+    private readonly Faker<Person> _personFaker;
+    private readonly Randomizer _randomizer;
+    private readonly Subject<Func<Person, string, string>> _keySelectionSubject = new ();
+    private readonly Subject<Unit> _regroupSubject = new ();
+    private readonly IDisposable _cleanup;
+    private Func<Person, string, string>? _groupKeySelector;
+
+    public GroupOnDynamicFixture()
+    {
+        unchecked { _randomizer = new((int)0xc001_d00d); }
+        _personFaker = Fakers.Person.Clone().WithSeed(_randomizer);
+        _personResults = _personCache.Connect().AsAggregator();
+        _groupResults = _personCache.Connect().Group(_keySelectionSubject, _regroupSubject).AsAggregator();
+        _cleanup = _keySelectionSubject.Do(func => _groupKeySelector = func).Subscribe();
+    }
+
+    [Fact]
+    public void ResultEmptyIfSelectionKeyDoesNotFire()
+    {
+        // Arrange
+
+        // Act
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount);
+        _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultContainsAllInitialChildren()
+    {
+        // Arrange
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+
+        // Act
+        GroupByFavColor();
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount);
+        _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultContainsAllAddedChildren()
+    {
+        // Arrange
+        GroupByFavColor();
+
+        // Act
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount);
+        _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultContainsAddedValues()
+    {
+        // Arrange
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        GroupByPetType();
+
+        // Act
+        _personCache.AddOrUpdate(_personFaker.Generate(AddCount));
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount + AddCount);
+        _personResults.Messages.Count.Should().Be(2, "Initial Adds and then the subsequent Additions should each be a single message");
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultDoesNotContainRemovedValues()
+    {
+        // Arrange
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        GroupByPetType();
+
+        // Act
+        _personCache.RemoveKeys(_randomizer.ListItems(_personCache.Items.ToList(), RemoveCount).Select(p => p.UniqueKey));
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount - RemoveCount);
+        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultContainsUpdatedValues()
+    {
+        // Arrange
+        GroupByPetType();
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        var replacements = _randomizer.ListItems(_personCache.Items.ToList(), UpdateCount)
+            .Select(replacePerson => Person.CloneUniqueId(_personFaker.Generate(), replacePerson));
+
+        // Act
+        _personCache.AddOrUpdate(replacements);
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount, "Only replacements were made");
+        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Updates");
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultIsCorrectWhenGroupSelectorChanges()
+    {
+        // Arrange
+        GroupByFavColor();
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        var usedColorList = _personCache.Items.Select(p => p.FavoriteColor).Distinct().Select(x => x.ToString()).ToList();
+        var usedPetTypeList = _personCache.Items.Select(p => p.PetType).Distinct().Select(x => x.ToString()).ToList();
+
+        // Act
+        GroupByPetType();
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount);
+        _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        _groupResults.Summary.Overall.Adds.Should().Be(usedColorList.Count + usedPetTypeList.Count);
+        _groupResults.Summary.Overall.Removes.Should().Be(usedColorList.Count);
+        VerifyGroupingResults();
+    }
+
+    [Fact]
+    public void ResultIsCorrectAfterForcedRegroup()
+    {
+        // Arrange
+        GroupByFavColor();
+        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _personCache.Items.ForEach(person => person.FavoriteColor = _randomizer.RandomColor(person.FavoriteColor));
+
+        // Act
+        ForceRegroup();
+
+        // Assert
+        _personResults.Data.Count.Should().Be(InitialCount);
+        _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        VerifyGroupingResults();
+    }
+
+    public void Dispose()
+    {
+        _groupResults.Dispose();
+        _personResults.Dispose();
+        _personCache.Dispose();
+        _cleanup.Dispose();
+        _keySelectionSubject.Dispose();
+        _regroupSubject.Dispose();
+    }
+
+    private void VerifyGroupingResults() =>
+        VerifyGroupingResults(_personCache, _personResults, _groupResults, _groupKeySelector);
+
+    private static void VerifyGroupingResults(ISourceCache<Person, string> personCache, ChangeSetAggregator<Person, string> personResults, GroupChangeSetAggregator<Person, string, string> groupResults, Func<Person, string, string>? groupKeySelector)
+    {
+        if (groupKeySelector is null)
+        {
+            groupResults.Data.Count.Should().Be(0);
+            groupResults.Groups.Count.Should().Be(0);
+            return;
+        }
+
+        var expectedPersons = personCache.Items.ToList();
+        var expectedGroupings = personCache.Items.GroupBy(p => groupKeySelector(p, string.Empty)).ToList();
+
+        // These should be subsets of each other
+        expectedPersons.Should().BeEquivalentTo(personResults.Data.Items);
+        groupResults.Groups.Count.Should().Be(expectedGroupings.Count);
+
+        // Check each group
+        foreach (var grouping in expectedGroupings)
+        {
+            var key = grouping.Key;
+            var expectedGroup = grouping.ToList();
+            var optionalGroup = groupResults.Groups.Lookup(key);
+
+            optionalGroup.HasValue.Should().BeTrue();
+            var actualGroup = optionalGroup.Value.Data.Items.ToList();
+
+            expectedGroup.Should().BeEquivalentTo(actualGroup);
+        }
+    }
+
+    private void ForceRegroup() => _regroupSubject.OnNext(Unit.Default);
+
+    private void GroupByFavColor() => _keySelectionSubject.OnNext(FavColor);
+
+    private void GroupByParentName() => _keySelectionSubject.OnNext(ParentName);
+
+    private void GroupByPetType() => _keySelectionSubject.OnNext(PetType);
+
+    private static string FavColor(Person person, string _) => person.FavoriteColor.ToString();
+
+    private static string ParentName(Person person, string _) => person.ParentName ?? string.Empty;
+
+    private static string PetType(Person person, string _) => person.PetType.ToString();
+}

--- a/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
@@ -74,6 +74,7 @@ public class GroupOnDynamicFixture : IDisposable
         // Assert
         _personResults.Data.Count.Should().Be(InitialCount);
         _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().Be(1));
         VerifyGroupingResults();
     }
 
@@ -146,8 +147,8 @@ public class GroupOnDynamicFixture : IDisposable
     public void ResultIsCorrectWhenGroupSelectorChanges()
     {
         // Arrange
-        GroupByFavColor();
         _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        GroupByFavColor();
         var usedColorList = _personCache.Items.Select(p => p.FavoriteColor).Distinct().Select(x => x.ToString()).ToList();
         var usedPetTypeList = _personCache.Items.Select(p => p.PetType).Distinct().Select(x => x.ToString()).ToList();
 
@@ -159,6 +160,7 @@ public class GroupOnDynamicFixture : IDisposable
         _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
         _groupResults.Summary.Overall.Adds.Should().Be(usedColorList.Count + usedPetTypeList.Count);
         _groupResults.Summary.Overall.Removes.Should().Be(usedColorList.Count);
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -166,8 +168,8 @@ public class GroupOnDynamicFixture : IDisposable
     public void ResultIsCorrectAfterForcedRegroup()
     {
         // Arrange
-        GroupByFavColor();
         _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        GroupByFavColor();
         _personCache.Items.ForEach(person => person.FavoriteColor = _randomizer.RandomColor(person.FavoriteColor));
 
         // Act
@@ -176,6 +178,7 @@ public class GroupOnDynamicFixture : IDisposable
         // Assert
         _personResults.Data.Count.Should().Be(InitialCount);
         _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 

--- a/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
@@ -26,17 +26,17 @@ public class GroupOnObservableFixture : IDisposable
     private const int RemoveCount = 37;
     private const int UpdateCount = 101;
 #endif
-    private readonly SourceCache<Person, string> _personCache = new (p => p.UniqueKey);
-    private readonly ChangeSetAggregator<Person, string> _personResults;
-    private readonly GroupChangeSetAggregator<Person, string, Color> _favoriteColorResults;
-    private readonly Faker<Person> _personFaker;
+    private readonly SourceCache<Person, string> _cache = new (p => p.UniqueKey);
+    private readonly ChangeSetAggregator<Person, string> _results;
+    private readonly GroupChangeSetAggregator<Person, string, Color> _groupResults;
+    private readonly Faker<Person> _faker;
     private readonly Randomizer _randomizer = new(0x3141_5926);
 
     public GroupOnObservableFixture()
     {
-        _personFaker = Fakers.Person.Clone().WithSeed(_randomizer);
-        _personResults = _personCache.Connect().AsAggregator();
-        _favoriteColorResults = _personCache.Connect().GroupOnObservable(CreateFavoriteColorObservable).AsAggregator();
+        _faker = Fakers.Person.Clone().WithSeed(_randomizer);
+        _results = _cache.Connect().AsAggregator();
+        _groupResults = _cache.Connect().GroupOnObservable(CreateFavoriteColorObservable).AsAggregator();
     }
 
     [Fact]
@@ -45,11 +45,11 @@ public class GroupOnObservableFixture : IDisposable
         // Arrange
 
         // Act
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
         // Assert
-        _personResults.Data.Count.Should().Be(InitialCount);
-        _personResults.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        _results.Data.Count.Should().Be(InitialCount);
+        _results.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
         VerifyGroupingResults();
     }
 
@@ -57,14 +57,14 @@ public class GroupOnObservableFixture : IDisposable
     public void ResultContainsAddedValues()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
         // Act
-        _personCache.AddOrUpdate(_personFaker.Generate(AddCount));
+        _cache.AddOrUpdate(_faker.Generate(AddCount));
 
         // Assert
-        _personResults.Data.Count.Should().Be(InitialCount + AddCount);
-        _personResults.Messages.Count.Should().Be(2, "Initial Adds and then the subsequent Additions should each be a single message");
+        _results.Data.Count.Should().Be(InitialCount + AddCount);
+        _results.Messages.Count.Should().Be(2, "Initial Adds and then the subsequent Additions should each be a single message");
         VerifyGroupingResults();
     }
 
@@ -72,14 +72,14 @@ public class GroupOnObservableFixture : IDisposable
     public void ResultDoesNotContainRemovedValues()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
         // Act
-        _personCache.RemoveKeys(_randomizer.ListItems(_personCache.Items.ToList(), RemoveCount).Select(p => p.UniqueKey));
+        _cache.RemoveKeys(_randomizer.ListItems(_cache.Items.ToList(), RemoveCount).Select(p => p.UniqueKey));
 
         // Assert
-        _personResults.Data.Count.Should().Be(InitialCount - RemoveCount);
-        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _results.Data.Count.Should().Be(InitialCount - RemoveCount);
+        _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
         VerifyGroupingResults();
     }
 
@@ -87,16 +87,16 @@ public class GroupOnObservableFixture : IDisposable
     public void ResultContainsUpdatedValues()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
-        var replacements = _randomizer.ListItems(_personCache.Items.ToList(), UpdateCount)
-            .Select(replacePerson => Person.CloneUniqueId(_personFaker.Generate(), replacePerson));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
+        var replacements = _randomizer.ListItems(_cache.Items.ToList(), UpdateCount)
+            .Select(replacePerson => Person.CloneUniqueId(_faker.Generate(), replacePerson));
 
         // Act
-        _personCache.AddOrUpdate(replacements);
+        _cache.AddOrUpdate(replacements);
 
         // Assert
-        _personResults.Data.Count.Should().Be(InitialCount, "Only replacements were made");
-        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Updates");
+        _results.Data.Count.Should().Be(InitialCount, "Only replacements were made");
+        _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Updates");
         VerifyGroupingResults();
     }
 
@@ -104,20 +104,20 @@ public class GroupOnObservableFixture : IDisposable
     public void GroupRemovedWhenEmpty()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
-        var usedColorList = _personCache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
+        var usedColorList = _cache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
         var removeColor = _randomizer.ListItem(usedColorList);
         var colorCount = usedColorList.Count;
 
         // Act
-        _personCache.Edit(updater => updater.Remove(updater.Items.Where(p => p.FavoriteColor == removeColor).Select(p => p.UniqueKey)));
+        _cache.Edit(updater => updater.Remove(updater.Items.Where(p => p.FavoriteColor == removeColor).Select(p => p.UniqueKey)));
 
         // Assert
-        _personCache.Items.Select(p => p.FavoriteColor).Distinct().Count().Should().Be(colorCount - 1);
-        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
-        _favoriteColorResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
-        _favoriteColorResults.Summary.Overall.Adds.Should().Be(colorCount);
-        _favoriteColorResults.Summary.Overall.Removes.Should().Be(1);
+        _cache.Items.Select(p => p.FavoriteColor).Distinct().Count().Should().Be(colorCount - 1);
+        _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _groupResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _groupResults.Summary.Overall.Adds.Should().Be(colorCount);
+        _groupResults.Summary.Overall.Removes.Should().Be(1);
         VerifyGroupingResults();
     }
 
@@ -125,26 +125,26 @@ public class GroupOnObservableFixture : IDisposable
     public void GroupNotRemovedIfAddedBackImmediately()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
-        var usedColorList = _personCache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
+        var usedColorList = _cache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
         var removeColor = _randomizer.ListItem(usedColorList);
         var colorCount = usedColorList.Count;
 
         // Act
-        _personCache.Edit(updater =>
+        _cache.Edit(updater =>
         {
             updater.Remove(updater.Items.Where(p => p.FavoriteColor == removeColor).Select(p => p.UniqueKey));
-            var newPerson = _personFaker.Generate();
+            var newPerson = _faker.Generate();
             newPerson.FavoriteColor = removeColor;
             updater.AddOrUpdate(newPerson);
         });
 
         // Assert
-        _personCache.Items.Select(p => p.FavoriteColor).Distinct().Count().Should().Be(colorCount);
-        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Other Added Value");
-        _favoriteColorResults.Messages.Count.Should().Be(1, "Shouldn't be removed/re-added");
-        _favoriteColorResults.Summary.Overall.Adds.Should().Be(colorCount);
-        _favoriteColorResults.Summary.Overall.Removes.Should().Be(0);
+        _cache.Items.Select(p => p.FavoriteColor).Distinct().Count().Should().Be(colorCount);
+        _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Other Added Value");
+        _groupResults.Messages.Count.Should().Be(1, "Shouldn't be removed/re-added");
+        _groupResults.Summary.Overall.Adds.Should().Be(colorCount);
+        _groupResults.Summary.Overall.Removes.Should().Be(0);
         VerifyGroupingResults();
     }
 
@@ -152,18 +152,18 @@ public class GroupOnObservableFixture : IDisposable
     public void GroupingSequenceCompletesWhenEmpty()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
-        var usedColorList = _personCache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
+        var usedColorList = _cache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
         var removeColor = _randomizer.ListItem(usedColorList);
 
-        var results = _personCache.Connect().GroupOnObservable(CreateFavoriteColorObservable)
+        var results = _cache.Connect().GroupOnObservable(CreateFavoriteColorObservable)
             .Filter(grp => grp.Key == removeColor)
             .Take(1)
             .MergeMany(grp => grp.Cache.Connect())
             .AsAggregator();
 
         // Act
-        _personCache.Edit(updater => updater.Remove(updater.Items.Where(p => p.FavoriteColor == removeColor).Select(p => p.UniqueKey)));
+        _cache.Edit(updater => updater.Remove(updater.Items.Where(p => p.FavoriteColor == removeColor).Select(p => p.UniqueKey)));
 
         // Assert
         results.IsCompleted.Should().BeTrue();
@@ -174,14 +174,14 @@ public class GroupOnObservableFixture : IDisposable
     public void AllSequencesCompleteWhenSourceIsDisposed()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
-        var results = _personCache.Connect().GroupOnObservable(CreateFavoriteColorObservable)
+        var results = _cache.Connect().GroupOnObservable(CreateFavoriteColorObservable)
             .MergeMany(grp => grp.Cache.Connect())
             .AsAggregator();
 
         // Act
-        _personCache.Dispose();
+        _cache.Dispose();
 
         // Assert
         results.IsCompleted.Should().BeTrue();
@@ -192,18 +192,18 @@ public class GroupOnObservableFixture : IDisposable
     public void AllGroupsRemovedWhenCleared()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
-        var usedColorList = _personCache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
+        var usedColorList = _cache.Items.Select(p => p.FavoriteColor).Distinct().ToList();
         var colorCount = usedColorList.Count;
 
         // Act
-        _personCache.Clear();
+        _cache.Clear();
 
         // Assert
-        _personCache.Items.Count().Should().Be(0);
-        _personResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
-        _favoriteColorResults.Summary.Overall.Adds.Should().Be(colorCount);
-        _favoriteColorResults.Summary.Overall.Removes.Should().Be(colorCount);
+        _cache.Items.Count().Should().Be(0);
+        _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _groupResults.Summary.Overall.Adds.Should().Be(colorCount);
+        _groupResults.Summary.Overall.Removes.Should().Be(colorCount);
         VerifyGroupingResults();
     }
 
@@ -211,7 +211,7 @@ public class GroupOnObservableFixture : IDisposable
     public void ResultsContainsCorrectRegroupedValues()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
         // Act
         Enumerable.Range(0, UpdateCount).ForEach(_ => RandomFavoriteColorChange());
@@ -224,7 +224,7 @@ public class GroupOnObservableFixture : IDisposable
     public async Task ResultsContainsCorrectRegroupedValuesAsync()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
         var tasks = Enumerable.Range(0, UpdateCount).Select(_ => Task.Run(RandomFavoriteColorChange));
 
         // Act
@@ -240,29 +240,30 @@ public class GroupOnObservableFixture : IDisposable
     public void ResultCompletesOnlyWhenSourceCompletes(bool completeSource)
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
         // Act
         if (completeSource)
         {
-            _personCache.Dispose();
+            _cache.Dispose();
         }
 
         // Assert
-        _personResults.IsCompleted.Should().Be(completeSource);
+        _results.IsCompleted.Should().Be(completeSource);
+        _groupResults.IsCompleted.Should().Be(completeSource);
     }
 
     [Fact]
     public void ResultFailsIfSourceFails()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
         var expectedError = new Exception("Expected");
         var throwObservable = Observable.Throw<IChangeSet<Person, string>>(expectedError);
-        using var results = _personCache.Connect().Concat(throwObservable).GroupOnObservable(CreateFavoriteColorObservable).AsAggregator();
+        using var results = _cache.Connect().Concat(throwObservable).GroupOnObservable(CreateFavoriteColorObservable).AsAggregator();
 
         // Act
-        _personCache.Dispose();
+        _cache.Dispose();
 
         // Assert
         results.Error.Should().Be(expectedError);
@@ -272,12 +273,12 @@ public class GroupOnObservableFixture : IDisposable
     public void ResultFailsIfGroupObservableFails()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
         var expectedError = new Exception("Expected");
         var throwObservable = Observable.Throw<Color>(expectedError);
 
         // Act
-        using var results = _personCache.Connect().GroupOnObservable((person, key) => CreateFavoriteColorObservable(person, key).Take(1).Concat(throwObservable)).AsAggregator();
+        using var results = _cache.Connect().GroupOnObservable((person, key) => CreateFavoriteColorObservable(person, key).Take(1).Concat(throwObservable)).AsAggregator();
 
         // Assert
         results.Error.Should().Be(expectedError);
@@ -287,11 +288,11 @@ public class GroupOnObservableFixture : IDisposable
     public void OnErrorFiresIfSelectorThrows()
     {
         // Arrange
-        _personCache.AddOrUpdate(_personFaker.Generate(InitialCount));
+        _cache.AddOrUpdate(_faker.Generate(InitialCount));
         var expectedError = new Exception("Expected");
 
         // Act
-        using var results = _personCache.Connect().GroupOnObservable<Person, string, Color>(_ => throw expectedError).AsAggregator();
+        using var results = _cache.Connect().GroupOnObservable<Person, string, Color>(_ => throw expectedError).AsAggregator();
 
         // Assert
         results.Error.Should().Be(expectedError);
@@ -299,14 +300,14 @@ public class GroupOnObservableFixture : IDisposable
 
     public void Dispose()
     {
-        _favoriteColorResults.Dispose();
-        _personResults.Dispose();
-        _personCache.Dispose();
+        _groupResults.Dispose();
+        _results.Dispose();
+        _cache.Dispose();
     }
 
     private void RandomFavoriteColorChange()
     {
-        var person = _randomizer.ListItem(_personCache.Items.ToList());
+        var person = _randomizer.ListItem(_cache.Items.ToList());
         lock (person)
         {
             // Pick a new favorite color
@@ -315,29 +316,19 @@ public class GroupOnObservableFixture : IDisposable
     }
 
     private void VerifyGroupingResults() =>
-        VerifyGroupingResults(_personCache, _personResults, _favoriteColorResults);
+        VerifyGroupingResults(_cache, _results, _groupResults);
 
-    private static void VerifyGroupingResults(ISourceCache<Person, string> personCache, ChangeSetAggregator<Person, string> personResults, GroupChangeSetAggregator<Person, string, Color> favoriteColorResults)
+    private static void VerifyGroupingResults(ISourceCache<Person, string> cache, ChangeSetAggregator<Person, string> cacheResults, GroupChangeSetAggregator<Person, string, Color> groupResults)
     {
-        var expectedPersons = personCache.Items.ToList();
-        var expectedGroupings = personCache.Items.GroupBy(p => p.FavoriteColor).ToList();
+        var expectedPersons = cache.Items.ToList();
+        var expectedGroupings = cache.Items.GroupBy(p => p.FavoriteColor).ToList();
 
-        // These should be subsets of each other
-        expectedPersons.Should().BeEquivalentTo(personResults.Data.Items);
-        favoriteColorResults.Groups.Count.Should().Be(expectedGroupings.Count);
+        // These datasets should be equivalent
+        expectedPersons.Should().BeEquivalentTo(cacheResults.Data.Items);
+        groupResults.Groups.Keys.Should().BeEquivalentTo(expectedGroupings.Select(g => g.Key));
 
         // Check each group
-        foreach (var grouping in expectedGroupings)
-        {
-            var color = grouping.Key;
-            var expectedGroup = grouping.ToList();
-            var optionalGroup = favoriteColorResults.Groups.Lookup(color);
-
-            optionalGroup.HasValue.Should().BeTrue();
-            var actualGroup = optionalGroup.Value.Data.Items.ToList();
-
-            expectedGroup.Should().BeEquivalentTo(actualGroup);
-        }
+        expectedGroupings.ForEach(grouping => grouping.Should().BeEquivalentTo(groupResults.Groups.Lookup(grouping.Key).Value.Data.Items));
     }
 
     private static IObservable<Color> CreateFavoriteColorObservable(Person person, string key) =>

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
@@ -52,7 +52,7 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
     [Theory]
     [InlineData(5, 7)]
     [InlineData(10, 50)]
-#if !DEBUG
+#if false || !DEBUG
     [InlineData(100, 100)]
     [InlineData(10, 1_000)]
     [InlineData(1_000, 10)]

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
@@ -52,7 +52,7 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
     [Theory]
     [InlineData(5, 7)]
     [InlineData(10, 50)]
-#if false || !DEBUG
+#if false && !DEBUG
     [InlineData(100, 100)]
     [InlineData(10, 1_000)]
     [InlineData(1_000, 10)]

--- a/src/DynamicData.Tests/Domain/Fakers.cs
+++ b/src/DynamicData.Tests/Domain/Fakers.cs
@@ -52,9 +52,10 @@ internal static class Fakers
     public static Faker<Market> Market { get; } = new Faker<Market>().CustomInstantiator(faker => new Market($"{faker.Commerce.ProductName()} Id#{faker.Random.AlphaNumeric(5)}"));
 
     public static Faker<Person> Person { get; } = new Faker<Person>().CustomInstantiator(faker =>
-        new Person(faker.Person.FullName, faker.Random.Int(1, 100), faker.PickRandom(PersonGenders))
+        new Person(faker.Person.FullName, faker.Random.Int(1, 100), faker.PickRandom(PersonGenders), faker.Person.FirstName)
         {
-            FavoriteColor = faker.Random.RandomColor()
+            FavoriteColor = faker.Random.RandomColor(),
+            PetType = faker.PickRandom<AnimalFamily>(),
         });
 
     public static Faker<AnimalOwner> WithInitialAnimals(this Faker<AnimalOwner> existing, Faker<Animal> animalFaker, int minCount, int maxCount) =>

--- a/src/DynamicData.Tests/Domain/Person.cs
+++ b/src/DynamicData.Tests/Domain/Person.cs
@@ -22,6 +22,7 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>
     private int _age;
     private int? _ageNullable;
     private Color _favoriteColor;
+    private AnimalFamily _petType;
 
     public Person()
         : this("unknown", 0, "none")
@@ -80,6 +81,12 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>
         set => SetAndRaise(ref _favoriteColor, value);
     }
 
+    public AnimalFamily PetType
+    {
+        get => _petType;
+        set => SetAndRaise(ref _petType, value);
+    }
+
     public string Gender { get; }
 
     public string Key => Name;
@@ -97,7 +104,8 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>
     public static Person CloneUniqueId(Person sourceData, Person sourceId) =>
         new((sourceData ?? throw new ArgumentNullException(nameof(sourceData))).Name, sourceData.Age, sourceData.Gender, sourceId)
         {
-            FavoriteColor = sourceData.FavoriteColor
+            FavoriteColor = sourceData.FavoriteColor,
+            PetType = sourceData.PetType,
         };
 
     public bool Equals(Person? other)

--- a/src/DynamicData/Cache/Internal/GroupOnDynamic.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnDynamic.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using DynamicData.Internal;
+
+namespace DynamicData.Cache.Internal;
+
+internal sealed class GroupOnDynamic<TObject, TKey, TGroupKey>(IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, TKey, TGroupKey>> selectGroupObservable, IObservable<Unit>? regrouper = null)
+    where TObject : notnull
+    where TKey : notnull
+    where TGroupKey : notnull
+{
+    public IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Run() => Observable.Create<IGroupChangeSet<TObject, TKey, TGroupKey>>(observer =>
+    {
+        var dynamicGrouper = new DynamicGrouper<TObject, TKey, TGroupKey>();
+        var locker = new object();
+        var parentUpdate = false;
+
+        // Create a shared connection to the source
+        var shared = source
+            .Synchronize(locker)
+            .Do(_ => parentUpdate = true)
+            .Publish();
+
+        var subGroupSelector = selectGroupObservable
+            .Synchronize(locker)
+            .SubscribeSafe(
+                onNext: groupSelector => dynamicGrouper.SetGroupSelector(groupSelector, observer),
+                onError: observer.OnError);
+
+        var subRegrouper = (regrouper == null)
+            ? Disposable.Empty
+            : regrouper
+                .Synchronize(locker)
+                .SubscribeSafe(
+                    onNext: _ => dynamicGrouper.RegroupAll(observer),
+                    onError: observer.OnError);
+
+        var subChanges = shared
+            .SubscribeSafe(
+                onNext: changeSet => dynamicGrouper.ProcessChangeSet(changeSet),
+                onError: observer.OnError);
+
+        // Next process the Grouping observables created for each item
+        var subMergeMany = shared
+            .MergeMany(CreateGroupObservable)
+            .SubscribeSafe(onError: observer.OnError);
+
+        // Finally, emit the results
+        var subResults = shared
+            .SubscribeSafe(
+                onNext: _ =>
+                {
+                    dynamicGrouper.EmitChanges(observer);
+                    parentUpdate = false;
+                },
+                onError: observer.OnError,
+                onComplete: observer.OnCompleted);
+
+        return new CompositeDisposable(shared.Connect(), subMergeMany, subChanges, subGroupSelector, subRegrouper, dynamicGrouper);
+    });
+}

--- a/src/DynamicData/Cache/Internal/GroupOnDynamic.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnDynamic.cs
@@ -19,13 +19,12 @@ internal sealed class GroupOnDynamic<TObject, TKey, TGroupKey>(IObservable<IChan
     {
         var dynamicGrouper = new DynamicGrouper<TObject, TKey, TGroupKey>();
         var notGrouped = new Cache<TObject, TKey>();
-        var locker = new object();
         var hasSelector = false;
 
         // Create shared observables for the 3 inputs
-        var sharedSource = source.Synchronize(locker).Publish();
-        var sharedGroupSelector = selectGroupObservable.DistinctUntilChanged().Synchronize(locker).Publish();
-        var sharedRegrouper = (regrouper ?? Observable.Empty<Unit>()).Synchronize(locker).Publish();
+        var sharedSource = source.Synchronize(dynamicGrouper).Publish();
+        var sharedGroupSelector = selectGroupObservable.DistinctUntilChanged().Synchronize(dynamicGrouper).Publish();
+        var sharedRegrouper = (regrouper ?? Observable.Empty<Unit>()).Synchronize(dynamicGrouper).Publish();
 
         // The first value from the Group Selector should update the Grouper with all the values seen so far
         // Then indicate a selector has been found.  Subsequent values should just update the group selector.

--- a/src/DynamicData/Cache/Internal/GroupOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnObservable.cs
@@ -53,7 +53,7 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
                     parentUpdate = false;
                 },
                 onError: observer.OnError,
-                onComplete: observer.OnCompleted);
+                onCompleted: observer.OnCompleted);
 
         return new CompositeDisposable(shared.Connect(), subMergeMany, subChanges, grouper);
     });

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -6513,6 +6513,7 @@ public static class ObservableCacheEx
         });
     }
 
+    // TODO: Apply the Adapter to more places
     private static Func<TObject, TKey, TResult> AdaptSelector<TObject, TKey, TResult>(Func<TObject, TResult> other)
         where TObject : notnull
         where TKey : notnull

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -1974,6 +1974,62 @@ public static class ObservableCacheEx
     }
 
     /// <summary>
+    /// Groups the source on the value returned by the latest value from the group selector factory observable.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TGroupKey">The type of the group key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="groupSelectorKeyObservable">The group selector key observable.</param>
+    /// <param name="regrouper">Fires when the current Grouping Selector needs to re-evaluate all the items in the cache.</param>
+    /// <returns>An observable which will emit group change sets.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// source
+    /// or
+    /// groupSelectorKey
+    /// or
+    /// groupController.
+    /// </exception>
+    public static IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, TKey, TGroupKey>> groupSelectorKeyObservable, IObservable<Unit>? regrouper = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TGroupKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        groupSelectorKeyObservable.ThrowArgumentNullExceptionIfNull(nameof(groupSelectorKeyObservable));
+        regrouper.ThrowArgumentNullExceptionIfNull(nameof(regrouper));
+
+        return new GroupOnDynamic<TObject, TKey, TGroupKey>(source, groupSelectorKeyObservable, regrouper).Run();
+    }
+
+    /// <summary>
+    /// Groups the source on the value returned by the latest value from the group selector factory observable.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TGroupKey">The type of the group key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="groupSelectorKeyObservable">The group selector key observable.</param>
+    /// <param name="regrouper">Fires when the current Grouping Selector needs to re-evaluate all the items in the cache.</param>
+    /// <returns>An observable which will emit group change sets.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// source
+    /// or
+    /// groupSelectorKey
+    /// or
+    /// groupController.
+    /// </exception>
+    public static IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Group<TObject, TKey, TGroupKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Func<TObject, TGroupKey>> groupSelectorKeyObservable, IObservable<Unit>? regrouper = null)
+        where TObject : notnull
+        where TKey : notnull
+        where TGroupKey : notnull
+    {
+        groupSelectorKeyObservable.ThrowArgumentNullExceptionIfNull(nameof(groupSelectorKeyObservable));
+
+        return source.Group(groupSelectorKeyObservable.Select(AdaptSelector<TObject, TKey, TGroupKey>), regrouper);
+    }
+
+    /// <summary>
     /// Groups the source by the latest value from their observable created by the given factory.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
@@ -2009,7 +2065,7 @@ public static class ObservableCacheEx
     {
         groupObservableSelector.ThrowArgumentNullExceptionIfNull(nameof(groupObservableSelector));
 
-        return source.GroupOnObservable((obj, _) => groupObservableSelector(obj));
+        return source.GroupOnObservable(AdaptSelector<TObject, TKey, IObservable<TGroupKey>>(groupObservableSelector));
     }
 
     /// <summary>
@@ -6456,6 +6512,11 @@ public static class ObservableCacheEx
             }
         });
     }
+
+    private static Func<TObject, TKey, TResult> AdaptSelector<TObject, TKey, TResult>(Func<TObject, TResult> other)
+        where TObject : notnull
+        where TKey : notnull
+        where TResult : notnull => (obj, _) => other(obj);
 
     private static IObservable<IChangeSet<TObject, TKey>> OnChangeAction<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, ChangeReason reason, Action<TObject, TKey> action)
         where TObject : notnull

--- a/src/DynamicData/Cache/Tests/GroupChangeSetAggregator.cs
+++ b/src/DynamicData/Cache/Tests/GroupChangeSetAggregator.cs
@@ -99,7 +99,6 @@ public class GroupChangeSetAggregator<TObject, TKey, TGroupKey> : IDisposable
             _ = disposing;
             _compositeDisposable.Dispose();
             _disposedValue = true;
-            using var cleanup = Groups.Connect().DisposeMany().Subscribe();
         }
     }
 }

--- a/src/DynamicData/Internal/ObservableEx.cs
+++ b/src/DynamicData/Internal/ObservableEx.cs
@@ -8,14 +8,14 @@ namespace DynamicData.Internal;
 
 internal static class ObservableEx
 {
-    public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<T> onNext, Action<Exception> onError, Action onComplete) =>
-        observable.SubscribeSafe(Observer.Create(onNext, onError, onComplete));
+    public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<T> onNext, Action<Exception> onError, Action onCompleted) =>
+        observable.SubscribeSafe(Observer.Create(onNext, onError, onCompleted));
 
     public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<T> onNext, Action<Exception> onError) =>
         observable.SubscribeSafe(Observer.Create(onNext, onError));
 
-    public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<Exception> onError, Action onComplete) =>
-        observable.SubscribeSafe(Observer.Create(Stub<T>.Ignore, onError, onComplete));
+    public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<Exception> onError, Action onCompleted) =>
+        observable.SubscribeSafe(Observer.Create(Stub<T>.Ignore, onError, onCompleted));
 
     public static IDisposable SubscribeSafe<T>(this IObservable<T> observable, Action<Exception> onError) =>
         observable.SubscribeSafe(Observer.Create(Stub<T>.Ignore, onError));


### PR DESCRIPTION
## Description

Addresses #848 by providing new overloads for the `Group` operator that allow the user to supply a `IObservable<Func<TObject, TKey, TGroupKey>>` so that the function that is used to obtain the GroupKey can change dynamically.  When a new value is supplied, a new GroupKey will be obtained for each item, and if the GroupKey has changed, the item will be moved to the new Group.

Also allows for an optional `IObservable<Unit>` parameter that will force the current GroupKey selector to be re-applied to all the items.

## Issues
This operator also suffers from #851.  I will submit another PR that fixes both operators at the same time.
