### PR TITLE
Bug Fix:  Consolidate changes made to Group Caches into a single ChangeSet

### DIFF
--- a/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnDynamicFixture.cs
@@ -34,16 +34,15 @@ public class GroupOnDynamicFixture : IDisposable
     private readonly GroupChangeSetAggregator<Person, string, string> _groupResults;
     private readonly Faker<Person> _faker;
     private readonly Randomizer _randomizer;
-    private readonly Subject<Func<Person, string, string>> _keySelectionSubject = new ();
+    private readonly BehaviorSubject<Func<Person, string, string>> _keySelectionSubject = new (ParentName);
     private readonly Subject<Unit> _regroupSubject = new ();
-    private Func<Person, string, string>? _groupKeySelector;
 
     public GroupOnDynamicFixture()
     {
         unchecked { _randomizer = new((int)0xc001_d00d); }
         _faker = Fakers.Person.Clone().WithSeed(_randomizer);
         _results = _cache.Connect().AsAggregator();
-        _groupResults = _cache.Connect().Group(_keySelectionSubject.Do(func => _groupKeySelector = func), _regroupSubject).AsAggregator();
+        _groupResults = _cache.Connect().Group(_keySelectionSubject, _regroupSubject).AsAggregator();
     }
 
     [Theory]
@@ -151,6 +150,7 @@ public class GroupOnDynamicFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount);
         _results.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().Be(1));
         VerifyGroupingResults();
     }
 
@@ -167,6 +167,7 @@ public class GroupOnDynamicFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount + AddCount);
         _results.Messages.Count.Should().Be(2, "Initial Adds and then the subsequent Additions should each be a single message");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -183,6 +184,7 @@ public class GroupOnDynamicFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount - RemoveCount);
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -201,6 +203,7 @@ public class GroupOnDynamicFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount, "Only replacements were made");
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Updates");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -352,7 +355,7 @@ public class GroupOnDynamicFixture : IDisposable
     private void InitialPopulate() => _cache.AddOrUpdate(_faker.Generate(InitialCount));
 
     private void VerifyGroupingResults() =>
-        VerifyGroupingResults(_cache, _results, _groupResults, _groupKeySelector);
+        VerifyGroupingResults(_cache, _results, _groupResults, _keySelectionSubject.Value);
 
     private static void VerifyGroupingResults(ISourceCache<Person, string> cache, ChangeSetAggregator<Person, string> cacheResults, GroupChangeSetAggregator<Person, string, string> groupResults, Func<Person, string, string>? groupKeySelector)
     {
@@ -374,7 +377,7 @@ public class GroupOnDynamicFixture : IDisposable
         expectedGroupings.ForEach(grouping => grouping.Should().BeEquivalentTo(groupResults.Groups.Lookup(grouping.Key).Value.Data.Items));
 
         // No groups should be empty
-        groupResults.Groups.Items.ForEach(group => group.Data.Count.Should().BeGreaterThan(0));
+        groupResults.Groups.Items.ForEach(group => group.Data.Count.Should().BeGreaterThan(0, "Empty groups should be removed"));
     }
 
     private void ForceRegroup() => _regroupSubject.OnNext(Unit.Default);

--- a/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.Linq;
-using Bogus;
-using DynamicData.Tests.Domain;
-using DynamicData.Binding;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+using Bogus;
+using DynamicData.Binding;
+using DynamicData.Kernel;
+using DynamicData.Tests.Domain;
 using FluentAssertions;
 using Xunit;
 
 using Person = DynamicData.Tests.Domain.Person;
-using System.Threading.Tasks;
-using DynamicData.Kernel;
 
 namespace DynamicData.Tests.Cache;
 
@@ -50,6 +51,7 @@ public class GroupOnObservableFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount);
         _results.Messages.Count.Should().Be(1, "The child observables fire on subscription so everything should appear as a single changeset");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().Be(1));
         VerifyGroupingResults();
     }
 
@@ -65,6 +67,7 @@ public class GroupOnObservableFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount + AddCount);
         _results.Messages.Count.Should().Be(2, "Initial Adds and then the subsequent Additions should each be a single message");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -80,6 +83,7 @@ public class GroupOnObservableFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount - RemoveCount);
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -97,6 +101,7 @@ public class GroupOnObservableFixture : IDisposable
         // Assert
         _results.Data.Count.Should().Be(InitialCount, "Only replacements were made");
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Updates");
+        _groupResults.Groups.Items.ForEach(group => group.Messages.Count.Should().BeLessThanOrEqualTo(2));
         VerifyGroupingResults();
     }
 
@@ -329,6 +334,9 @@ public class GroupOnObservableFixture : IDisposable
 
         // Check each group
         expectedGroupings.ForEach(grouping => grouping.Should().BeEquivalentTo(groupResults.Groups.Lookup(grouping.Key).Value.Data.Items));
+
+        // No groups should be empty
+        groupResults.Groups.Items.ForEach(group => group.Data.Count.Should().BeGreaterThan(0, "Empty groups should be removed"));
     }
 
     private static IObservable<Color> CreateFavoriteColorObservable(Person person, string key) =>

--- a/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
@@ -120,6 +120,7 @@ public class GroupOnObservableFixture : IDisposable
         // Assert
         _cache.Items.Select(p => p.FavoriteColor).Distinct().Count().Should().Be(colorCount - 1);
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
+        _groupResults.Data.Count.Should().Be(colorCount - 1, "{0} colors were used and then all of the {1} were removed", colorCount, removeColor);
         _groupResults.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
         _groupResults.Summary.Overall.Adds.Should().Be(colorCount);
         _groupResults.Summary.Overall.Removes.Should().Be(1);
@@ -147,9 +148,11 @@ public class GroupOnObservableFixture : IDisposable
         // Assert
         _cache.Items.Select(p => p.FavoriteColor).Distinct().Count().Should().Be(colorCount);
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Other Added Value");
+        _groupResults.Data.Count.Should().Be(colorCount);
         _groupResults.Messages.Count.Should().Be(1, "Shouldn't be removed/re-added");
         _groupResults.Summary.Overall.Adds.Should().Be(colorCount);
         _groupResults.Summary.Overall.Removes.Should().Be(0);
+        _groupResults.Groups.Lookup(removeColor).Value.Data.Count.Should().Be(1, "All the {0} were removed and then 1 was added back", removeColor);
         VerifyGroupingResults();
     }
 

--- a/src/DynamicData/Cache/Internal/GroupOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnObservable.cs
@@ -23,8 +23,8 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
             selectGroup(item, key)
                 .DistinctUntilChanged()
                 .Synchronize(locker!)
-                .Do(// Only suspend updates if inside of a parentUpdate.  Otherwise, it will only generate at most one change per group, so there's no value in suspending.
-                    onNext: groupKey => grouper!.AddOrUpdate(key, groupKey, item, !parentUpdate ? observer : null, suspendUpdates: parentUpdate),
+                .Do(
+                    onNext: groupKey => grouper!.AddOrUpdate(key, groupKey, item, !parentUpdate ? observer : null),
                     onError: observer.OnError);
 
         // Create a shared connection to the source

--- a/src/DynamicData/Cache/Internal/GroupOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnObservable.cs
@@ -23,8 +23,8 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
             selectGroup(item, key)
                 .DistinctUntilChanged()
                 .Synchronize(locker!)
-                .Do(
-                    onNext: groupKey => grouper!.AddOrUpdate(key, groupKey, item, !parentUpdate ? observer : null),
+                .Do(// Only suspend updates if inside of a parentUpdate.  Otherwise, it will only generate at most one change per group, so there's no value in suspending.
+                    onNext: groupKey => grouper!.AddOrUpdate(key, groupKey, item, !parentUpdate ? observer : null, suspendUpdates: parentUpdate),
                     onError: observer.OnError);
 
         // Create a shared connection to the source

--- a/src/DynamicData/Cache/Internal/ManagedGroup.cs
+++ b/src/DynamicData/Cache/Internal/ManagedGroup.cs
@@ -18,6 +18,8 @@ internal sealed class ManagedGroup<TObject, TKey, TGroupKey>(TGroupKey groupKey)
 
     public void Dispose() => _cache.Dispose();
 
+    public IDisposable SuspendNotifications() => _cache.SuspendNotifications();
+
     /// <summary>
     /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="object"/>.
     /// </summary>


### PR DESCRIPTION
## Description

Fixes #851 by leveraging the code from #852 to suspend the notifications about changes to the group contents until all of the groups have been updated.

- Changes grouping helper class `DynamicGrouper` so that it manages the notification suspensions using a new helper class
- Simplifies regrouping logic by removing multiple `GroupBy` LINQ operations that batched changes to so they could all be made at once (suspended notifications makes this unnecessary)

### Operators Affected
- `GroupOnObservable` Operator
- `Group` Operator including the overload with IObservable Group Key Selector (`GroupOnDynamic`)

### Testing
Added unit tests to verify the number of change sets is what it should be