### PR TITLE
Enable the use of default comparer for SortAndBind

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1760,8 +1760,20 @@ namespace DynamicData
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerObservable, System.IObservable<System.Reactive.Unit> resorter, DynamicData.SortOptimisations sortOptimisations = 0, int resetThreshold = 100)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+            where TObject :  notnull, System.IComparable<TObject>
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
+            where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1761,13 +1761,13 @@ namespace DynamicData
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList)
-            where TObject :  notnull
+            where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
             where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
-            where TObject :  notnull
+            where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull

--- a/src/DynamicData.Tests/Cache/SortAndBindFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortAndBindFixture.cs
@@ -9,7 +9,6 @@ using System.Reactive.Disposables;
 using DynamicData.Binding;
 using DynamicData.Tests.Domain;
 using FluentAssertions;
-using Mono.Cecil;
 using Xunit;
 
 namespace DynamicData.Tests.Cache;
@@ -28,6 +27,19 @@ public sealed class SortAndBindToList: SortAndBindFixture
     }
 }
 
+// Bind to a list using default comparer
+public sealed class SortAndBindToListDefaultComparer : SortAndBindFixture
+
+{
+    protected override (ChangeSetAggregator<Person, string> Aggregrator, IList<Person> List) SetUpTests()
+    {
+        var list = new List<Person>(100);
+        var aggregator = _source.Connect().SortAndBind(list).AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
 // Bind to an observable collection
 public sealed class SortAndBindToObservableCollection : SortAndBindFixture
 
@@ -36,10 +48,10 @@ public sealed class SortAndBindToObservableCollection : SortAndBindFixture
     {
         var list = new ObservableCollection<Person>(new List<Person>(100));
         var aggregator = _source.Connect().SortAndBind(list, _comparer).AsAggregator();
-
         return (aggregator, list);
     }
 }
+
 
 // Bind to a readonly observable collection
 public sealed class SortAndBindToReadOnlyObservableCollection: SortAndBindFixture
@@ -59,6 +71,17 @@ public sealed class SortAndBindWithBinarySearch : SortAndBindFixture
     {
         var options = new SortAndBindOptions { UseBinarySearch = true };
         var aggregator = _source.Connect().SortAndBind(out var list, _comparer, options).AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
+// Bind to a readonly observable collection - using default comparer
+public sealed class SortAndBindToReadOnlyObservableCollectionDefaultComparer : SortAndBindFixture
+{
+    protected override (ChangeSetAggregator<Person, string> Aggregrator, IList<Person> List) SetUpTests()
+    {
+        var aggregator = _source.Connect().SortAndBind(out var list).AsAggregator();
 
         return (aggregator, list);
     }
@@ -144,7 +167,7 @@ public abstract class SortAndBindFixture : IDisposable
     private readonly ChangeSetAggregator<Person, string> _results;
     private readonly IList<Person> _boundList;
 
-    protected readonly IComparer<Person> _comparer = SortExpressionComparer<Person>.Ascending(p => p.Age).ThenByAscending(p => p.Name);
+    protected readonly IComparer<Person> _comparer = Person.DefaultComparer;
     protected readonly ISourceCache<Person, string> _source = new SourceCache<Person, string>(p => p.Key);
 
 
@@ -531,3 +554,4 @@ public abstract class SortAndBindFixture : IDisposable
         _results.Dispose();
     }
 }
+

--- a/src/DynamicData.Tests/Domain/Person.cs
+++ b/src/DynamicData.Tests/Domain/Person.cs
@@ -17,7 +17,7 @@ public enum Color
     Violet,
 }
 
-public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>
+public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>, IComparable<Person>
 {
     private int _age;
     private int? _ageNullable;
@@ -215,4 +215,11 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>
             }
         }
     }
+
+    // Implemented for SortAndBindFixture.
+    public static IComparer<Person> DefaultComparer { get; } = SortExpressionComparer<Person>
+        .Ascending(p => p.Age)
+        .ThenByAscending(p => p.Name);
+
+    public int CompareTo(Person? other) => DefaultComparer.Compare(this, other);
 }

--- a/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
@@ -13,7 +13,39 @@ namespace DynamicData;
 public static partial class ObservableCacheEx
 {
     /// <summary>
-    /// Bind sorted data to the specified readonly observable collection.
+    /// Bind sorted data to the specified collection IList  for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="targetList">The list to bind to.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey>> source,
+        IList<TObject> targetList)
+        where TObject : notnull
+        where TKey : notnull =>
+        source.SortAndBind(targetList, DynamicDataOptions.SortAndBind);
+
+    /// <summary>
+    /// Bind sorted data to the specified collection IList  for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="targetList">The list to bind to.</param>
+    /// <param name="options">Bind and sort default options.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey>> source,
+        IList<TObject> targetList,
+        SortAndBindOptions options)
+        where TObject : notnull
+        where TKey : notnull =>
+        source.SortAndBind(targetList, Comparer<TObject>.Default, options);
+
+    /// <summary>
+    /// Bind sorted data to the specified collection IList.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -27,10 +59,10 @@ public static partial class ObservableCacheEx
         IComparer<TObject> comparer)
         where TObject : notnull
         where TKey : notnull =>
-        new SortAndBind<TObject, TKey>(source, comparer, DynamicDataOptions.SortAndBind, targetList).Run();
+        source.SortAndBind(targetList, comparer, DynamicDataOptions.SortAndBind);
 
     /// <summary>
-    ///  Bind sorted data to the specified readonly observable collection.
+    /// Bind sorted data to the specified collection IList.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -47,6 +79,38 @@ public static partial class ObservableCacheEx
         where TObject : notnull
         where TKey : notnull =>
         new SortAndBind<TObject, TKey>(source, comparer, options, targetList).Run();
+
+    /// <summary>
+    ///  Bind sorted data to the specified readonly observable collection for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey>> source,
+        out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+        where TObject : notnull, IComparable<TObject>
+        where TKey : notnull =>
+        source.SortAndBind(out readOnlyObservableCollection, Comparer<TObject>.Default, DynamicDataOptions.SortAndBind);
+
+    /// <summary>
+    ///  Bind sorted data to the specified readonly observable collection for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
+    /// <param name="options">Bind and sort default options.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey>> source,
+        out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
+        SortAndBindOptions options)
+        where TObject : notnull, IComparable<TObject>
+        where TKey : notnull =>
+        source.SortAndBind(out readOnlyObservableCollection, Comparer<TObject>.Default, options);
 
     /// <summary>
     ///  Bind sorted data to the specified readonly observable collection.

--- a/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
@@ -13,7 +13,7 @@ namespace DynamicData;
 public static partial class ObservableCacheEx
 {
     /// <summary>
-    /// Bind sorted data to the specified collection IList  for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
+    /// Bind sorted data to the specified collection, for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -28,7 +28,7 @@ public static partial class ObservableCacheEx
         source.SortAndBind(targetList, DynamicDataOptions.SortAndBind);
 
     /// <summary>
-    /// Bind sorted data to the specified collection IList  for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
+    /// Bind sorted data to the specified collection, for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -45,7 +45,7 @@ public static partial class ObservableCacheEx
         source.SortAndBind(targetList, Comparer<TObject>.Default, options);
 
     /// <summary>
-    /// Bind sorted data to the specified collection IList.
+    /// Bind sorted data to the specified collection.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -62,7 +62,7 @@ public static partial class ObservableCacheEx
         source.SortAndBind(targetList, comparer, DynamicDataOptions.SortAndBind);
 
     /// <summary>
-    /// Bind sorted data to the specified collection IList.
+    /// Bind sorted data to the specified collection.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>

--- a/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
@@ -23,7 +23,7 @@ public static partial class ObservableCacheEx
     public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList)
-        where TObject : notnull
+        where TObject : notnull, IComparable<TObject>
         where TKey : notnull =>
         source.SortAndBind(targetList, DynamicDataOptions.SortAndBind);
 
@@ -40,7 +40,7 @@ public static partial class ObservableCacheEx
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList,
         SortAndBindOptions options)
-        where TObject : notnull
+        where TObject : notnull, IComparable<TObject>
         where TKey : notnull =>
         source.SortAndBind(targetList, Comparer<TObject>.Default, options);
 


### PR DESCRIPTION
This is a follow up to #878, and thanks to a great suggestion by @JakenVeina overloads have been added  to enable the use of default comparers.

If an object implements `IComparable<T>` we can apply sorting without the need to specify the `Comparer<T>.Default`.

```
      var sorted = _source.Connect()
            .SortAndBind(out var myItems)
            .Subscribe();
```