### PR TITLE
Swappable Locking Implementation

### DIFF
--- a/src/DynamicData/Internal/SwappableLock.cs
+++ b/src/DynamicData/Internal/SwappableLock.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace DynamicData;
+
+internal ref struct SwappableLock
+{
+    public static SwappableLock CreateAndEnter(object gate)
+    {
+        var result = new SwappableLock()
+        {
+            _gate = gate
+        };
+
+        Monitor.Enter(gate, ref result._hasLock);
+
+        return result;
+    }
+
+    public void SwapTo(object gate)
+    {
+        if (_gate is null)
+            throw new InvalidOperationException("Lock is not initialized");
+
+        var hasNewLock = false;
+        Monitor.Enter(gate, ref hasNewLock);
+
+        if (_hasLock)
+            Monitor.Exit(_gate);
+
+        _hasLock = hasNewLock;
+        _gate = gate;
+    }
+
+    public void Dispose()
+    {
+        if (_hasLock && (_gate is not null))
+        {
+            Monitor.Exit(_gate);
+            _hasLock = false;
+            _gate = null;
+        }
+    }
+
+    private bool _hasLock;
+    private object? _gate;
+}


### PR DESCRIPTION
Added a shared/reusable implementation for multi-locking within stream operators, I.E. being able to process upstream notifications and downstream notifications at the same time, with different locks, while still preserving notification order.

I've been testing this strategy for locking within the new `.Filter()` operators I'm working on. Usage of this class in that case would look like....

```cs
private void OnNext(IChangeSet<T> changes)
{
    using var @lock = SwappableLock.CreateAndEnter(UpstreamSynchronizationGate);
    
    foreach (var change in changes)
    {
        ...
    }
    
    var downstreamChanges = ChangeSet<T>.Empty;
    if (_downstreamChangesBuffer.Count is not 0)
    {
        downstreamChanges = new ChangeSet<T>(_downstreamChangesBuffer);
        _downstreamChangesBuffer.Clear();
    }
 
    if ((downstreamChanges.Count is not 0) || !_suppressEmptyChangeSets)
    {
        @lock.SwapTo(DownstreamSynchronizationGate);
        
        _downstreamObserver.OnNext(downstreamChanges);
    }
}
```