### PR TITLE
IObservableList items as IReadOnlyList

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -890,7 +890,7 @@ namespace DynamicData
     {
         int Count { get; }
         System.IObservable<int> CountChanged { get; }
-        System.Collections.Generic.IEnumerable<T> Items { get; }
+        System.Collections.Generic.IReadOnlyList<T> Items { get; }
         System.IObservable<DynamicData.IChangeSet<T>> Connect(System.Func<T, bool>? predicate = null);
         System.IObservable<DynamicData.IChangeSet<T>> Preview(System.Func<T, bool>? predicate = null);
     }
@@ -2650,7 +2650,7 @@ namespace DynamicData
         public SourceList(System.IObservable<DynamicData.IChangeSet<T>>? source = null) { }
         public int Count { get; }
         public System.IObservable<int> CountChanged { get; }
-        public System.Collections.Generic.IEnumerable<T> Items { get; }
+        public System.Collections.Generic.IReadOnlyList<T> Items { get; }
         public System.IObservable<DynamicData.IChangeSet<T>> Connect(System.Func<T, bool>? predicate = null) { }
         public void Dispose() { }
         public void Edit(System.Action<DynamicData.IExtendedList<T>> updateAction) { }

--- a/src/DynamicData.Tests/Binding/AvaloniaDictionaryFixture.cs
+++ b/src/DynamicData.Tests/Binding/AvaloniaDictionaryFixture.cs
@@ -35,7 +35,7 @@ public class AvaloniaDictionaryFixture
 
         _results.Messages.Count.Should().Be(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(person);
+        _results.Data.Items[0].Should().Be(person);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class AvaloniaDictionaryFixture
         _collection["Someone"] = person2;
 
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(person2);
+        _results.Data.Items[0].Should().Be(person2);
     }
 
 

--- a/src/DynamicData.Tests/Binding/BindingListToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/BindingListToChangeSetFixture.cs
@@ -29,7 +29,7 @@ public class BindingListToChangeSetFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     public void Dispose() => _results.Dispose();

--- a/src/DynamicData.Tests/Binding/IObservableListBindCacheFixture.cs
+++ b/src/DynamicData.Tests/Binding/IObservableListBindCacheFixture.cs
@@ -37,7 +37,7 @@ public class IObservableListBindCacheFixture : IDisposable
         _source.AddOrUpdate(person);
 
         _list.Count.Should().Be(1, "Should be 1 item in the collection");
-        _list.Items.First().Should().Be(person, "Should be same person");
+        _list.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -97,6 +97,6 @@ public class IObservableListBindCacheFixture : IDisposable
         _source.AddOrUpdate(personUpdated);
 
         _list.Count.Should().Be(1, "Should be 1 item in the collection");
-        _list.Items.First().Should().Be(personUpdated, "Should be updated person");
+        _list.Items[0].Should().Be(personUpdated, "Should be updated person");
     }
 }

--- a/src/DynamicData.Tests/Binding/IObservableListBindCacheSortedFixture.cs
+++ b/src/DynamicData.Tests/Binding/IObservableListBindCacheSortedFixture.cs
@@ -45,7 +45,7 @@ public class IObservableListBindCacheSortedFixture : IDisposable
         _source.AddOrUpdate(person);
 
         _list.Count.Should().Be(1, "Should be 1 item in the collection");
-        _list.Items.First().Should().Be(person, "Should be same person");
+        _list.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Binding/IObservableListBindListFixture.cs
+++ b/src/DynamicData.Tests/Binding/IObservableListBindListFixture.cs
@@ -141,7 +141,7 @@ public class IObservableListBindListFixture : IDisposable
         _source.Add(person);
 
         _list.Count.Should().Be(1, "Should be 1 item in the collection");
-        _list.Items.First().Should().Be(person, "Should be same person");
+        _list.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -191,6 +191,6 @@ public class IObservableListBindListFixture : IDisposable
         _source.Replace(person, personUpdated);
 
         _list.Count.Should().Be(1, "Should be 1 item in the collection");
-        _list.Items.First().Should().Be(personUpdated, "Should be updated person");
+        _list.Items[0].Should().Be(personUpdated, "Should be updated person");
     }
 }

--- a/src/DynamicData.Tests/Binding/ObservableCollectionExtendedToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionExtendedToChangeSetFixture.cs
@@ -32,7 +32,7 @@ public class ObservableCollectionExtendedToChangeSetFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     public void Dispose() => _results.Dispose();

--- a/src/DynamicData.Tests/Binding/ObservableCollectionToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionToChangeSetFixture.cs
@@ -30,7 +30,7 @@ public class ObservableCollectionToChangeSetFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     public void Dispose() => _results.Dispose();

--- a/src/DynamicData.Tests/Binding/ReadOnlyObservableCollectionToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ReadOnlyObservableCollectionToChangeSetFixture.cs
@@ -33,7 +33,7 @@ public class ReadOnlyObservableCollectionToChangeSetFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     public void Dispose() => _results.Dispose();

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
@@ -270,7 +270,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
     {
         // Arrange
         var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
-        var insertIndex = _randomizer.Number(randomOwner.Animals.Items.Count());
+        var insertIndex = _randomizer.Number(randomOwner.Animals.Items.Count);
         var insertThis = _animalFaker.Generate();
         var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
 

--- a/src/DynamicData.Tests/Cache/TransformManyAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformManyAsyncFixture.cs
@@ -273,7 +273,7 @@ public sealed class TransformManyAsyncFixture : IDisposable
         CreateSelector(static owner => owner.ObservableCache, delayFactory);
 
     private static Func<AnimalOwner, Guid, Task<IEnumerable<Animal>>> SelectEnumerable(Func<Task>? delayFactory = null) =>
-        CreateSelector(static owner => owner.Animals.Items, delayFactory);
+        CreateSelector(static owner => owner.Animals.Items.AsEnumerable(), delayFactory);
 
     private static Func<AnimalOwner, Guid, Task<T>> CreateSelector<T>(Func<AnimalOwner, T> selector, Func<Task>? delayFactory = null) =>
         (delayFactory != null)

--- a/src/DynamicData.Tests/EnumerableIListFixture.cs
+++ b/src/DynamicData.Tests/EnumerableIListFixture.cs
@@ -19,7 +19,7 @@ namespace DynamicData.Tests
             rng.NextBytes(data);
 
             var inputData = new byte[39];
-            var lastItem = data[data.Length - 1];
+            var lastItem = data[^1];
             var firstItem = data[0];
             Array.Copy(data, 1, inputData, 0, 38);
             var listOfRandomFloats = new List<byte>(inputData);

--- a/src/DynamicData.Tests/List/AutoRefreshFixture.cs
+++ b/src/DynamicData.Tests/List/AutoRefreshFixture.cs
@@ -176,9 +176,9 @@ public class AutoRefreshFixture
         //change the value and move to a grouping which does not yet exist
         items[1].Age = -1;
         results.Data.Count.Should().Be(11);
-        results.Data.Items.Last().GroupKey.Should().Be(-1);
-        results.Data.Items.Last().List.Count.Should().Be(1);
-        results.Data.Items.First().List.Count.Should().Be(9);
+        results.Data.Items[^1].GroupKey.Should().Be(-1);
+        results.Data.Items[^1].List.Count.Should().Be(1);
+        results.Data.Items[0].List.Count.Should().Be(9);
         CheckContent();
 
         //put the value back where it was and check the group was removed
@@ -230,9 +230,9 @@ public class AutoRefreshFixture
         //change the value and move to a grouping which does not yet exist
         items[1].Age = -1;
         results.Data.Count.Should().Be(11);
-        results.Data.Items.Last().Key.Should().Be(-1);
-        results.Data.Items.Last().Count.Should().Be(1);
-        results.Data.Items.First().Count.Should().Be(9);
+        results.Data.Items[^1].Key.Should().Be(-1);
+        results.Data.Items[^1].Count.Should().Be(1);
+        results.Data.Items[0].Count.Should().Be(9);
         CheckContent();
 
         //put the value back where it was and check the group was removed
@@ -354,7 +354,7 @@ public class AutoRefreshFixture
         var obj = new Example { Value = 0 };
         list.Add(obj);
         obj.Value = 1;
-        valueList.Items.First().Should().Be(1);
+        valueList.Items[0].Should().Be(1);
     }
 
     private class Example : AbstractNotifyPropertyChanged

--- a/src/DynamicData.Tests/List/DisposeManyFixture.cs
+++ b/src/DynamicData.Tests/List/DisposeManyFixture.cs
@@ -96,7 +96,7 @@ public sealed class DisposeManyFixture : IDisposable
         _itemsSource.AddRange(items[7..10]);
         _changeSetsSource.OnNext(new ChangeSet<DisposableObject>() // Refresh
         {
-            new(ListChangeReason.Refresh, current: _itemsSource.Items.First(), index: 0)
+            new(ListChangeReason.Refresh, current: _itemsSource.Items[0], index: 0)
         });
 
         _results.Exception.Should().BeNull();

--- a/src/DynamicData.Tests/List/DistinctValuesFixture.cs
+++ b/src/DynamicData.Tests/List/DistinctValuesFixture.cs
@@ -58,7 +58,7 @@ public class DistinctValuesFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 update message");
         _results.Data.Count.Should().Be(1, "Should be 1 items in the cache");
-        _results.Data.Items.First().Should().Be(20, "Should 20");
+        _results.Data.Items[0].Should().Be(20, "Should 20");
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class DistinctValuesFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(20, "Should 20");
+        _results.Data.Items[0].Should().Be(20, "Should 20");
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class DistinctValuesFixture : IDisposable
         _results.Data.Count.Should().Be(3, "Should be 3 items in the cache");
 
         _results.Data.Items.Should().BeEquivalentTo(new[] { 20, 21, 22 });
-        _results.Data.Items.First().Should().Be(20, "Should 20");
+        _results.Data.Items[0].Should().Be(20, "Should 20");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/DynamicOrFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicOrFixture.cs
@@ -26,7 +26,7 @@ public class DynamicOrRefreshFixture
         results.Data.Count.Should().Be(2);
         results.Messages.Count.Should().Be(3);
         results.Messages[2].Refreshes.Should().Be(1);
-        results.Messages[2].First().Item.Current.Should().Be(source1.Items.First());
+        results.Messages[2].First().Item.Current.Should().Be(source1.Items[0]);
     }
 }
 
@@ -126,7 +126,7 @@ public class DynamicOrFixture : IDisposable
         _source1.Add(1);
 
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class DynamicOrFixture : IDisposable
         _source1.Add(1);
         _source2.Add(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/DynamicXOrFixture.cs
+++ b/src/DynamicData.Tests/List/DynamicXOrFixture.cs
@@ -94,7 +94,7 @@ public class DynamicXOrFixture : IDisposable
         _source1.Add(1);
 
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/FilterControllerFixtureWithClearAndReplace.cs
+++ b/src/DynamicData.Tests/List/FilterControllerFixtureWithClearAndReplace.cs
@@ -35,7 +35,7 @@ public class FilterControllerFixtureWithClearAndReplace : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class FilterControllerFixtureWithClearAndReplace : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Range.First().Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/FilterControllerFixtureWithDiffSet.cs
+++ b/src/DynamicData.Tests/List/FilterControllerFixtureWithDiffSet.cs
@@ -35,7 +35,7 @@ public class FilterControllerFixtureWithDiffSet : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class FilterControllerFixtureWithDiffSet : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Range.First().Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/FilterFixture.cs
+++ b/src/DynamicData.Tests/List/FilterFixture.cs
@@ -29,7 +29,7 @@ public class FilterFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class FilterFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Range.First().Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/FilterWithObservable.cs
+++ b/src/DynamicData.Tests/List/FilterWithObservable.cs
@@ -37,7 +37,7 @@ public class FilterWithObservable : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class FilterWithObservable : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Range.First().Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/GroupImmutableFixture.cs
+++ b/src/DynamicData.Tests/List/GroupImmutableFixture.cs
@@ -104,7 +104,7 @@ public class GroupImmutableFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1);
         _results.Messages.First().Adds.Should().Be(1);
-        _results.Data.Items.First().Count.Should().Be(4);
+        _results.Data.Items[0].Count.Should().Be(4);
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class GroupImmutableFixture : IDisposable
         _results.Messages.First().Adds.Should().Be(1);
         _results.Messages.Skip(1).First().Adds.Should().Be(1);
         _results.Messages.Skip(1).First().Removes.Should().Be(1);
-        var group = _results.Data.Items.First();
+        var group = _results.Data.Items[0];
         group.Count.Should().Be(1);
 
         group.Key.Should().Be(21);
@@ -178,7 +178,7 @@ public class GroupImmutableFixture : IDisposable
         _results.Messages.First().Adds.Should().Be(1);
         _results.Messages.Skip(1).First().Replaced.Should().Be(1);
 
-        var group = _results.Data.Items.First();
+        var group = _results.Data.Items[0];
         group.Count.Should().Be(2);
     }
 }

--- a/src/DynamicData.Tests/List/GroupOnFixture.cs
+++ b/src/DynamicData.Tests/List/GroupOnFixture.cs
@@ -30,7 +30,7 @@ public class GroupOnFixture : IDisposable
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
 
-        var firstGroup = _results.Data.Items.First().List.Items.ToArray();
+        var firstGroup = _results.Data.Items[0].List.Items.ToArray();
         firstGroup[0].Should().Be(person, "Should be same person");
     }
 
@@ -71,7 +71,7 @@ public class GroupOnFixture : IDisposable
         _results.Messages.Count.Should().Be(2, "Should be 2 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
 
-        var firstGroup = _results.Data.Items.First().List.Items.ToArray();
+        var firstGroup = _results.Data.Items[0].List.Items.ToArray();
         firstGroup[0].Should().Be(amended, "Should be same person");
     }
 }

--- a/src/DynamicData.Tests/List/GroupOnPropertyFixture.cs
+++ b/src/DynamicData.Tests/List/GroupOnPropertyFixture.cs
@@ -29,7 +29,7 @@ public class GroupOnPropertyFixture : IDisposable
 
         _results.Data.Count.Should().Be(1);
 
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Count.Should().Be(1);
         firstGroup.Key.Should().Be(10);
@@ -93,7 +93,7 @@ public class GroupOnPropertyFixture : IDisposable
         person.Age = 20;
 
         _results.Data.Count.Should().Be(1);
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Count.Should().Be(1);
         firstGroup.Key.Should().Be(20);

--- a/src/DynamicData.Tests/List/GroupOnPropertyWithImmutableStateFixture.cs
+++ b/src/DynamicData.Tests/List/GroupOnPropertyWithImmutableStateFixture.cs
@@ -29,7 +29,7 @@ public class GroupOnPropertyWithImmutableStateFixture : IDisposable
 
         _results.Data.Count.Should().Be(1);
 
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Count.Should().Be(1);
         firstGroup.Key.Should().Be(10);
@@ -93,7 +93,7 @@ public class GroupOnPropertyWithImmutableStateFixture : IDisposable
         person.Age = 20;
 
         _results.Data.Count.Should().Be(1);
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Count.Should().Be(1);
         firstGroup.Key.Should().Be(20);

--- a/src/DynamicData.Tests/List/MergeChangeSetsFixture.cs
+++ b/src/DynamicData.Tests/List/MergeChangeSetsFixture.cs
@@ -409,7 +409,7 @@ public sealed class MergeChangeSetsFixture : IDisposable
 
         // These should be subsets of each other, so check one subset and the size
         expectedAnimals.Should().BeSubsetOf(animalResults.Data.Items);
-        animalResults.Data.Items.Count().Should().Be(expectedAnimals.Count);
+        animalResults.Data.Items.Count.Should().Be(expectedAnimals.Count);
     }
 
     Task ForOwnersAsync(Action<AnimalOwner> action) => Task.WhenAll(_animalOwners.Select(owner => Task.Run(() => action(owner))));

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
@@ -831,7 +831,7 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
 
         // These should be subsets of each other
         expectedMarkets.Should().BeSubsetOf(marketResults.Data.Items);
-        marketResults.Data.Items.Count().Should().Be(expectedMarkets.Count);
+        marketResults.Data.Items.Count.Should().Be(expectedMarkets.Count);
 
         // These should be subsets of each other
         expectedPrices.Should().BeSubsetOf(priceResults.Data.Items);

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsListFixture.cs
@@ -353,7 +353,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
     {
         // Arrange
         var randomOwner = _randomizer.ListItem(_animalOwners.Items.ToList());
-        var insertIndex = _randomizer.Number(randomOwner.Animals.Items.Count());
+        var insertIndex = _randomizer.Number(randomOwner.Animals.Items.Count);
         var insertThis = _animalFaker.Generate();
         var initialCount = _animalOwners.Items.Sum(owner => owner.Animals.Count);
 
@@ -526,7 +526,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // These should be subsets of each other
         expectedOwners.Should().BeSubsetOf(ownerResults.Data.Items);
-        ownerResults.Data.Items.Count().Should().Be(expectedOwners.Count);
+        ownerResults.Data.Items.Count.Should().Be(expectedOwners.Count);
 
         // All owner animals should be in the results
         foreach (var owner in owners)

--- a/src/DynamicData.Tests/List/OrFixture.cs
+++ b/src/DynamicData.Tests/List/OrFixture.cs
@@ -39,7 +39,7 @@ public class OrRefreshFixture
         results.Data.Count.Should().Be(2);
         results.Messages.Count.Should().Be(3);
         results.Messages[2].Refreshes.Should().Be(1);
-        results.Messages[2].First().Item.Current.Should().Be(source1.Items.First());
+        results.Messages[2].First().Item.Current.Should().Be(source1.Items[0]);
     }
 }
 
@@ -115,7 +115,7 @@ public abstract class OrFixtureBase : IDisposable
         _source1.Add(1);
 
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public abstract class OrFixtureBase : IDisposable
         _source1.Add(1);
         _source2.Add(1);
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/SelectFixture.cs
+++ b/src/DynamicData.Tests/List/SelectFixture.cs
@@ -36,7 +36,7 @@ public class SelectFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(person), "Should be same person");
+        _results.Data.Items[0].Should().Be(_transformFactory(person), "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/SizeLimitFixture.cs
+++ b/src/DynamicData.Tests/List/SizeLimitFixture.cs
@@ -39,7 +39,7 @@ public class SizeLimitFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class SizeLimitFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/SortFixture.cs
+++ b/src/DynamicData.Tests/List/SortFixture.cs
@@ -83,7 +83,7 @@ public class SortFixture : IDisposable
 
         _results.Data.Count.Should().Be(101, "Should be 100 people in the cache");
 
-        _results.Data.Items.First().Should().Be(shouldbefirst);
+        _results.Data.Items[0].Should().Be(shouldbefirst);
     }
 
     [Fact]
@@ -166,7 +166,7 @@ public class SortFixture : IDisposable
 
         _results.Data.Count.Should().Be(100, "Should be 100 people in the cache");
 
-        _results.Data.Items.First().Should().Be(shouldbefirst);
+        _results.Data.Items[0].Should().Be(shouldbefirst);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/SortMutableFixture.cs
+++ b/src/DynamicData.Tests/List/SortMutableFixture.cs
@@ -72,7 +72,8 @@ public class SortMutableFixture : IDisposable
 
         _results.Data.Count.Should().Be(101);
 
-        _results.Data.Items.Last().Should().Be(shouldbeLast);
+        _results.Data.Items[
+        ^1].Should().Be(shouldbeLast);
     }
 
     [Fact]
@@ -155,7 +156,8 @@ public class SortMutableFixture : IDisposable
 
         _results.Data.Count.Should().Be(100, "Should be 100 people in the cache");
 
-        _results.Data.Items.Last().Should().Be(shouldbeLast);
+        _results.Data.Items[
+        ^1].Should().Be(shouldbeLast);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/SubscribeManyFixture.cs
+++ b/src/DynamicData.Tests/List/SubscribeManyFixture.cs
@@ -33,7 +33,7 @@ public class SubscribeManyFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().IsSubscribed.Should().Be(true, "Should be subscribed");
+        _results.Data.Items[0].IsSubscribed.Should().Be(true, "Should be subscribed");
     }
 
     public void Dispose()

--- a/src/DynamicData.Tests/List/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/List/TransformAsyncFixture.cs
@@ -48,7 +48,7 @@ public class TransformAsyncFixture : IDisposable
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
 
         var transformed = await _transformFactory(person);
-        _results.Data.Items.First().Should().Be(transformed, "Should be same person");
+        _results.Data.Items[0].Should().Be(transformed, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/List/TransformFixture.cs
+++ b/src/DynamicData.Tests/List/TransformFixture.cs
@@ -34,7 +34,7 @@ public class TransformFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(person), "Should be same person");
+        _results.Data.Items[0].Should().Be(_transformFactory(person), "Should be same person");
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class TransformFixture : IDisposable
         // Assert
         _results.Messages.Count.Should().Be(2, "Should be 2 messages");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(person2), "Should be same person");
+        _results.Data.Items[0].Should().Be(_transformFactory(person2), "Should be same person");
     }
 
     [Fact]
@@ -219,6 +219,6 @@ public class TransformFixture : IDisposable
         // Assert
         results.Messages.Count.Should().Be(2, "Should be 2 messages");
         results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(_transformFactory(person2), "Should be same person");
+        results.Data.Items[0].Should().Be(_transformFactory(person2), "Should be same person");
     }
 }

--- a/src/DynamicData.Tests/List/XOrFixture.cs
+++ b/src/DynamicData.Tests/List/XOrFixture.cs
@@ -70,7 +70,7 @@ public abstract class XOrFixtureBase : IDisposable
         _source1.Add(1);
 
         _results.Data.Count.Should().Be(1);
-        _results.Data.Items.First().Should().Be(1);
+        _results.Data.Items[0].Should().Be(1);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Utilities/TestSourceList.cs
+++ b/src/DynamicData.Tests/Utilities/TestSourceList.cs
@@ -29,7 +29,7 @@ public sealed class TestSourceList<T>
     public IObservable<int> CountChanged
         => _countChanged;
 
-    public IEnumerable<T> Items
+    public IReadOnlyList<T> Items
         => _source.Items;
 
     public IObservable<IChangeSet<T>> Connect(Func<T, bool>? predicate = null)

--- a/src/DynamicData/List/IObservableList.cs
+++ b/src/DynamicData/List/IObservableList.cs
@@ -26,7 +26,7 @@ public interface IObservableList<T> : IDisposable
     /// <summary>
     /// Gets items enumerable.
     /// </summary>
-    IEnumerable<T> Items { get; }
+    IReadOnlyList<T> Items { get; }
 
     /// <summary>
     /// Connect to the observable list and observe any changes

--- a/src/DynamicData/List/Internal/AnonymousObservableList.cs
+++ b/src/DynamicData/List/Internal/AnonymousObservableList.cs
@@ -33,7 +33,7 @@ internal sealed class AnonymousObservableList<T> : IObservableList<T>
 
     public IObservable<int> CountChanged => _sourceList.CountChanged;
 
-    public IEnumerable<T> Items => _sourceList.Items;
+    public IReadOnlyList<T> Items => _sourceList.Items;
 
     public IObservable<IChangeSet<T>> Connect(Func<T, bool>? predicate = null) => _sourceList.Connect(predicate);
 

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -70,7 +70,7 @@ public sealed class SourceList<T> : ISourceList<T>
             });
 
     /// <inheritdoc />
-    public IEnumerable<T> Items => _readerWriter.Items;
+    public IReadOnlyList<T> Items => _readerWriter.Items;
 
     /// <inheritdoc />
     public IObservable<IChangeSet<T>> Connect(Func<T, bool>? predicate = null)


### PR DESCRIPTION
Changes the `Items` property in `IObservableList<T>` from `IEnumerable<T>` to `IReadOnlyList<T>`.