### PR TITLE
ToChangeSet now emits empty sets

### DIFF
--- a/src/DynamicData.Tests/Binding/AvaloniaDictionaryFixture.cs
+++ b/src/DynamicData.Tests/Binding/AvaloniaDictionaryFixture.cs
@@ -33,7 +33,7 @@ public class AvaloniaDictionaryFixture
 
         _collection.Add("Someone", person);
 
-        _results.Messages.Count.Should().Be(1);
+        _results.Messages.Count.Should().Be(2);
         _results.Data.Count.Should().Be(1);
         _results.Data.Items[0].Should().Be(person);
     }
@@ -86,7 +86,7 @@ public interface IAvaloniaReadOnlyDictionary<TKey, TValue>
 /*
   Copied from Avalionia because an issue was raised due to compatibility issues with ToObservableChangeSet().
 
-There's not other way of testing it.  
+There's not other way of testing it.
 
 See https://github.com/AvaloniaUI/Avalonia/blob/d7c82a1a6f7eb95b2214f20a281fa0581fb7b792/src/Avalonia.Base/Collections/AvaloniaDictionary.cs#L17
  */

--- a/src/DynamicData.Tests/Binding/ObservableCollectionExtendedToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionExtendedToChangeSetFixture.cs
@@ -30,7 +30,7 @@ public class ObservableCollectionExtendedToChangeSetFixture : IDisposable
     {
         _collection.Add(1);
 
-        _results.Messages.Count.Should().Be(1);
+        _results.Messages.Count.Should().Be(2);
         _results.Data.Count.Should().Be(1);
         _results.Data.Items[0].Should().Be(1);
     }

--- a/src/DynamicData.Tests/Binding/ObservableCollectionToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ObservableCollectionToChangeSetFixture.cs
@@ -28,7 +28,7 @@ public class ObservableCollectionToChangeSetFixture : IDisposable
     {
         _collection.Add(1);
 
-        _results.Messages.Count.Should().Be(1);
+        _results.Messages.Count.Should().BeGreaterOrEqualTo(1);
         _results.Data.Count.Should().Be(1);
         _results.Data.Items[0].Should().Be(1);
     }

--- a/src/DynamicData.Tests/Binding/ReadOnlyObservableCollectionToChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Binding/ReadOnlyObservableCollectionToChangeSetFixture.cs
@@ -31,7 +31,7 @@ public class ReadOnlyObservableCollectionToChangeSetFixture : IDisposable
     {
         _collection.Add(1);
 
-        _results.Messages.Count.Should().Be(1);
+        _results.Messages.Count.Should().Be(2);
         _results.Data.Count.Should().Be(1);
         _results.Data.Items[0].Should().Be(1);
     }

--- a/src/DynamicData.Tests/Issues/EmptyToChangeSetIssue.cs
+++ b/src/DynamicData.Tests/Issues/EmptyToChangeSetIssue.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.ObjectModel;
+using System.Reactive;
+using DynamicData.Binding;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.Issues
+{
+    public class EmptyToChangeSetIssue
+    {
+        [Fact]
+        public void EmptyCollectionToChangeSetBehaviour()
+        {
+            var collection = new ObservableCollection<Unit>();
+
+            var results = collection.ToObservableChangeSet().AsAggregator();
+            results.Messages.Count.Should()
+                .BeGreaterThan(0, "An empty collection should still have an update, even if empty.");
+        }
+    }
+}

--- a/src/DynamicData/Binding/ObservableCollectionEx.cs
+++ b/src/DynamicData/Binding/ObservableCollectionEx.cs
@@ -119,10 +119,7 @@ public static class ObservableCollectionEx
             {
                 var data = new ChangeAwareList<T>(source);
 
-                if (data.Count > 0)
-                {
-                    observer.OnNext(data.CaptureChanges());
-                }
+                observer.OnNext(data.CaptureChanges());
 
                 return source.ObserveCollectionChanges().Scan(
                     data,


### PR DESCRIPTION
Created a PR for removing the empty check in ToChangeSet as talked in #903 