### PR TITLE
New SortAndPage operator

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1175,6 +1175,18 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<bool> pauseIfTrueSelector, bool initialPauseState = false, System.TimeSpan? timeOut = default, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, DynamicData.Binding.IObservableCollection<TObject> destination)
             where TObject :  notnull
             where TKey :  notnull { }
@@ -1191,6 +1203,18 @@ namespace DynamicData
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.ComponentModel.BindingList<TObject> bindingList, int resetThreshold = 25)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, DynamicData.Binding.IObservableCollection<TObject> destination, DynamicData.Binding.BindingOptions options)
@@ -1662,6 +1686,7 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Or<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, params System.IObservable<DynamicData.IChangeSet<TObject, TKey>>[] others)
             where TObject :  notnull
             where TKey :  notnull { }
+        [System.Obsolete("Use SortAndPage as it\'s more efficient")]
         public static System.IObservable<DynamicData.IPagedChangeSet<TObject, TKey>> Page<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, System.IObservable<DynamicData.IPageRequest> pageRequests)
             where TObject :  notnull
             where TKey :  notnull { }
@@ -1755,15 +1780,19 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SkipInitial<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source)
             where TObject :  notnull
             where TKey :  notnull { }
+        [System.Obsolete("Use SortAndBind as it\'s more efficient")]
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, DynamicData.SortOptimisations sortOptimisations = 0, int resetThreshold = 100)
             where TObject :  notnull
             where TKey :  notnull { }
+        [System.Obsolete("Use SortAndBind as it\'s more efficient")]
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerObservable, DynamicData.SortOptimisations sortOptimisations = 0, int resetThreshold = 100)
             where TObject :  notnull
             where TKey :  notnull { }
+        [System.Obsolete("Use SortAndBind as it\'s more efficient")]
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, System.IObservable<System.Reactive.Unit> resorter, DynamicData.SortOptimisations sortOptimisations = 0, int resetThreshold = 100)
             where TObject :  notnull
             where TKey :  notnull { }
+        [System.Obsolete("Use SortAndBind as it\'s more efficient")]
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerObservable, System.IObservable<System.Reactive.Unit> resorter, DynamicData.SortOptimisations sortOptimisations = 0, int resetThreshold = 100)
             where TObject :  notnull
             where TKey :  notnull { }
@@ -1772,12 +1801,6 @@ namespace DynamicData
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
             where TObject :  notnull, System.IComparable<TObject>
-            where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
-            where TObject :  notnull
-            where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
-            where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull, System.IComparable<TObject>
@@ -1797,12 +1820,6 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
-            where TObject :  notnull
-            where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
-            where TObject :  notnull
-            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
@@ -1813,6 +1830,18 @@ namespace DynamicData
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, DynamicData.Binding.SortAndBindOptions options)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> SortAndPage<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, System.IObservable<DynamicData.IPageRequest> pageRequests)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> SortAndPage<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, System.IObservable<DynamicData.IPageRequest> pageRequests)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> SortAndPage<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, System.IObservable<DynamicData.IPageRequest> pageRequests, DynamicData.SortAndPageOptions options)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> SortAndPage<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, System.IObservable<DynamicData.IPageRequest> pageRequests, DynamicData.SortAndPageOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> SortAndVirtualize<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, System.IObservable<DynamicData.IVirtualRequest> virtualRequests)
@@ -1894,10 +1923,11 @@ namespace DynamicData
             where TObject :  notnull
             where TKey :  notnull
             where TSortKey :  notnull { }
+        [System.Obsolete("Use Overload with comparer as it\'s more efficient")]
         public static System.IObservable<DynamicData.IVirtualChangeSet<TObject, TKey>> Top<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, int size)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IVirtualChangeSet<TObject, TKey>> Top<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, int size)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> Top<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, int size)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, TDestination> transformFactory, bool transformOnRefresh)
@@ -2145,6 +2175,7 @@ namespace DynamicData
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> UpdateIndex<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source)
             where TObject : DynamicData.Binding.IIndexAware
             where TKey :  notnull { }
+        [System.Obsolete("Use SortAndVirtualize as it\'s more efficient")]
         public static System.IObservable<DynamicData.IVirtualChangeSet<TObject, TKey>> Virtualise<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, System.IObservable<DynamicData.IVirtualRequest> virtualRequests)
             where TObject :  notnull
             where TKey :  notnull { }
@@ -2510,15 +2541,22 @@ namespace DynamicData
             where T :  notnull { }
     }
     public static class ObsoleteEx { }
+    public class PageContext<TObject> : System.IEquatable<DynamicData.PageContext<TObject>>
+    {
+        public PageContext(DynamicData.Operators.IPageResponse Response, System.Collections.Generic.IComparer<TObject> Comparer, DynamicData.SortAndPageOptions Options) { }
+        public System.Collections.Generic.IComparer<TObject> Comparer { get; init; }
+        public DynamicData.SortAndPageOptions Options { get; init; }
+        public DynamicData.Operators.IPageResponse Response { get; init; }
+    }
     public sealed class PageRequest : DynamicData.IPageRequest, System.IEquatable<DynamicData.IPageRequest>
     {
         public static readonly DynamicData.IPageRequest Default;
         public static readonly DynamicData.IPageRequest Empty;
         public PageRequest() { }
         public PageRequest(int page, int size) { }
-        public System.Collections.Generic.IEqualityComparer<DynamicData.IPageRequest?> DefaultComparer { get; }
         public int Page { get; }
         public int Size { get; }
+        public static System.Collections.Generic.IEqualityComparer<DynamicData.IPageRequest?> DefaultComparer { get; }
         public bool Equals(DynamicData.IPageRequest? other) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
@@ -2535,6 +2573,13 @@ namespace DynamicData
         public void Insert(int index, T item) { }
         public void SetStartingIndex(int index) { }
         public override string ToString() { }
+    }
+    public struct SortAndPageOptions : System.IEquatable<DynamicData.SortAndPageOptions>
+    {
+        public SortAndPageOptions() { }
+        public int InitialCapacity { get; init; }
+        public int ResetThreshold { get; init; }
+        public bool UseBinarySearch { get; init; }
     }
     public struct SortAndVirtualizeOptions : System.IEquatable<DynamicData.SortAndVirtualizeOptions>
     {

--- a/src/DynamicData.Tests/Cache/SortAndPageFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortAndPageFixture.cs
@@ -1,0 +1,401 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData.Binding;
+using DynamicData.Tests.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.Cache;
+
+public sealed class SortAndPageWithComparerChangesFixture : SortAndPageFixtureBase
+{
+    private BehaviorSubject<IComparer<Person>> _comparerSubject;
+
+    private readonly IComparer<Person> _descComparer = SortExpressionComparer<Person>.Descending(p => p.Age).ThenByAscending(p => p.Name);
+
+    protected override ChangeSetAggregator<Person, string, PageContext<Person>> SetUpTests()
+    {
+        _comparerSubject = new BehaviorSubject<IComparer<Person>>(Comparer);
+
+        return Source.Connect()
+            .SortAndPage(_comparerSubject, PageRequests)
+            .AsAggregator();
+    }
+
+    [Fact]
+    public void ChangeComparer()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid());
+        Source.AddOrUpdate(people);
+
+        // for first batch, it should use the results of the _PageRequests subject (if a behaviour subject is used).
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.Should().BeEquivalentTo(expectedResult);
+
+        // change the comparer 
+        _comparerSubject.OnNext(_descComparer);
+
+        expectedResult = people.OrderBy(p => p, _descComparer).Take(25).ToList();
+        actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+}
+
+public sealed class SortAndPageFixture : SortAndPageFixtureBase
+{
+    protected override ChangeSetAggregator<Person, string, PageContext<Person>> SetUpTests() =>
+        Source.Connect()
+            .SortAndPage(Comparer, PageRequests)
+            .AsAggregator();
+}
+
+public abstract class SortAndPageFixtureBase : IDisposable
+{
+
+    protected readonly SourceCache<Person, string> Source = new(p => p.Name);
+    protected readonly IComparer<Person> Comparer = SortExpressionComparer<Person>.Ascending(p => p.Age).ThenByAscending(p => p.Name);
+    protected readonly ISubject<IPageRequest> PageRequests = new BehaviorSubject<IPageRequest>(new PageRequest(1, 25));
+
+    protected readonly ChangeSetAggregator<Person, string, PageContext<Person>> Aggregator;
+
+
+    protected SortAndPageFixtureBase()
+    {
+        // It's ok in this case to call VirtualMemberCallInConstructor
+
+#pragma warning disable CA2214
+        // ReSharper disable once VirtualMemberCallInConstructor
+        Aggregator = SetUpTests();
+#pragma warning restore CA2214
+    }
+
+
+    protected abstract ChangeSetAggregator<Person, string, PageContext<Person>> SetUpTests();
+
+
+    [Fact]
+    public void InitialBatches()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid());
+        Source.AddOrUpdate(people);
+
+        // for first batch, it should use the results of the _PageRequests subject (if a behaviour subject is used).
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.Should().BeEquivalentTo(expectedResult);
+
+
+        PageRequests.OnNext(new PageRequest(3, 25));
+
+        expectedResult = people.OrderBy(p => p, Comparer).Skip(50).Take(25).ToList();
+        actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Fact]
+    public void ThrowsForNegativePage() => Assert.Throws<ArgumentException>(() => PageRequests.OnNext(new PageRequest(-1, 1)));
+
+    [Fact]
+    public void ThrowsForNegativeSizeParameters() => Assert.Throws<ArgumentException>(() => PageRequests.OnNext(new PageRequest(1, -1)));
+
+
+
+    [Fact]
+    public void PageGreaterThanNumberOfPagesAvailable()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid());
+        Source.AddOrUpdate(people);
+
+        // should select the last page
+        PageRequests.OnNext(new PageRequest(10, 25));
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Skip(75).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+
+    [Fact]
+    public void OverlappingShift()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid());
+        Source.AddOrUpdate(people);
+
+        PageRequests.OnNext(new PageRequest(3, 10));
+
+        // for first batch, it should use the results of the _PageRequests subject (if a behaviour subject is used).
+        var expectedResult = people.OrderBy(p => p, Comparer).Skip(20).Take(10).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Fact]
+    public void AddFirstInRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at beginning
+        var person = new Person("_FirstPerson", 1);
+        Source.AddOrUpdate(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(new Person("P025", 25));
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(person);
+
+        // check for correctness of resulting collection
+        people.Add(person);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+    [Fact]
+    public void AddOutsideOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at end
+        var person = new Person("X_Last", 100);
+        Source.AddOrUpdate(person);
+
+        // only the initials message should have been received
+        Aggregator.Messages.Count.Should().Be(1);
+
+
+        people.Add(person);
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    [Fact]
+    public void UpdateMoveOutOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // Change an item so it moves from in range to out of range
+        var person = new Person("P012", 50);
+        Source.AddOrUpdate(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(new Person("P012", 50));
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(new Person("P026", 26));
+
+        // check for correctness of resulting collection
+        people = people.OrderBy(p => p, Comparer).ToList();
+        people[11] = person;
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+    [Fact]
+    public void UpdateStayRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // Update an item, but keep it withing the expected virtual range.
+        var person = new Person("P012", -1);
+        Source.AddOrUpdate(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(1);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Update);
+        firstChange.Current.Should().Be(new Person("P012", -1));
+        firstChange.Previous.Value.Should().Be(new Person("P012", 12));
+
+        // check for correctness of resulting collection
+        people = people.OrderBy(p => p, Comparer).ToList();
+        people[11] = person;
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+
+    [Fact]
+    public void UpdateOutOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at beginning
+        var person = new Person("P050", 100);
+        Source.AddOrUpdate(person);
+
+        // only the initials message should have been received
+        Aggregator.Messages.Count.Should().Be(1);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+    [Fact]
+    public void RemoveRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // remove an element from the active range
+        var person = new Person("P012", 12);
+        Source.Remove(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(person);
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(new Person("P026", 26));
+
+        // check for correctness of resulting collection
+        people.Remove(person);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    [Fact]
+    public void RemoveOutOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at beginning
+        var person = new Person("P050", 50);
+        Source.Remove(person);
+
+        // only the initials message should have been received
+        Aggregator.Messages.Count.Should().Be(1);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+    [Fact]
+    public void RefreshInRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        var person = people.Single(p => p.Name == "P012");
+        Source.Refresh(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(1);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Refresh);
+    }
+
+    [Fact]
+    public void RefreshWithInlineChangeInRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        var person = people.Single(p => p.Name == "P012");
+
+        // The item will move within the virtual range, so be propagated as a refresh
+        person.Age = 5;
+        Source.Refresh(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(1);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Refresh);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    [Fact]
+    public void RefreshWithInlineChangeOutsideRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        var person = people.Single(p => p.Name == "P012");
+
+        // The item will move outside the virtual range, resulting in a remove and index shift
+        person.Age = 50;
+        Source.Refresh(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(new Person("P012", 50));
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(new Person("P026", 26));
+
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        var actualResult = Aggregator.Data.Items.OrderBy(p => p, Comparer);
+        actualResult.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    public void Dispose()
+    {
+        Source.Dispose();
+        Aggregator.Dispose();
+        PageRequests.OnCompleted();
+    }
+}

--- a/src/DynamicData.Tests/Cache/SortAndVirtualizeAndBindFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortAndVirtualizeAndBindFixture.cs
@@ -1,0 +1,395 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+using DynamicData.Binding;
+using DynamicData.Tests.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.Cache;
+
+
+public sealed class SortAndVirtualizeAndBindWithImplicitOptionsFixtureReadOnlyCollection : SortAndVirtualizeAndBindFixtureBase
+{
+    protected override (ChangeSetAggregator<Person, string> aggregator, IList<Person> list) SetUpTests()
+    {
+
+        var aggregator = Source.Connect()
+            .SortAndVirtualize(Comparer, VirtualRequests)
+            // no sort and bind options. These are extracted from the SortAndVirtualize context
+            .Bind(out var list)
+            .AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
+public sealed class SortAndVirtualizeAndBindFixtureReadOnlyCollection : SortAndVirtualizeAndBindFixtureBase
+{
+    protected override (ChangeSetAggregator<Person, string> aggregator, IList<Person> list) SetUpTests()
+    {
+
+        var aggregator = Source.Connect()
+            .SortAndVirtualize(Comparer, VirtualRequests)
+            .Bind(out var list, new SortAndBindOptions())
+            .AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
+public sealed class SortAndVirtualizeAndBindWithImplicitOptionsFixture : SortAndVirtualizeAndBindFixtureBase
+{
+    protected override (ChangeSetAggregator<Person, string> aggregator, IList<Person> list) SetUpTests()
+    {
+        var list = new List<Person>();
+
+        var aggregator = Source.Connect()
+            .SortAndVirtualize(Comparer, VirtualRequests)
+            // no sort and bind options. These are extracted from the SortAndVirtualize context
+            .Bind(list)
+            .AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
+public sealed class SortAndVirtualizeAndBindFixture : SortAndVirtualizeAndBindFixtureBase
+{
+    protected override (ChangeSetAggregator<Person, string> aggregator, IList<Person> list) SetUpTests()
+    {
+        var list = new List<Person>();
+
+        var aggregator = Source.Connect()
+            .SortAndVirtualize(Comparer, VirtualRequests)
+            .SortAndBind(list, new SortAndBindOptions())
+            .AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
+public abstract class SortAndVirtualizeAndBindFixtureBase : IDisposable
+{
+
+    protected readonly SourceCache<Person, string> Source = new(p => p.Name);
+    protected readonly IComparer<Person> Comparer = SortExpressionComparer<Person>.Ascending(p => p.Age).ThenByAscending(p => p.Name);
+    protected readonly ISubject<IVirtualRequest> VirtualRequests = new BehaviorSubject<IVirtualRequest>(new VirtualRequest(0, 25));
+
+    protected readonly ChangeSetAggregator<Person, string> Aggregator;
+    protected readonly IList<Person> List;
+
+    protected SortAndVirtualizeAndBindFixtureBase()
+    {
+        // It's ok in this case to call VirtualMemberCallInConstructor
+
+#pragma warning disable CA2214
+        // ReSharper disable once VirtualMemberCallInConstructor
+        var args = SetUpTests();
+#pragma warning restore CA2214
+
+        Aggregator = args.aggregator;
+        List = args.list;
+    }
+
+
+    protected abstract (ChangeSetAggregator<Person, string> aggregator, IList<Person> list) SetUpTests();
+
+
+    [Fact]
+    public void InitialBatches()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid());
+        Source.AddOrUpdate(people);
+
+        // for first batch, it should use the results of the _virtualRequests subject (if a behaviour subject is used).
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.Should().BeEquivalentTo(expectedResult);
+
+
+        VirtualRequests.OnNext(new VirtualRequest(25, 50));
+        expectedResult = people.OrderBy(p => p, Comparer).Skip(25).Take(50).ToList();
+        List.Should().BeEquivalentTo(expectedResult);
+
+
+        VirtualRequests.OnNext(new VirtualRequest(40, 50));
+        expectedResult = people.OrderBy(p => p, Comparer).Skip(40).Take(50).ToList();
+        List.Should().BeEquivalentTo(expectedResult);
+    }
+
+
+
+
+
+
+    [Fact]
+    public void OverlappingShift()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid());
+        Source.AddOrUpdate(people);
+
+        VirtualRequests.OnNext(new VirtualRequest(10, 30));
+
+        // for first batch, it should use the results of the _virtualRequests subject (if a behaviour subject is used).
+        var expectedResult = people.OrderBy(p => p, Comparer).Skip(10).Take(30).ToList();
+        List.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Fact]
+    public void AddFirstInRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at beginning
+        var person = new Person("_FirstPerson", 1);
+        Source.AddOrUpdate(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(new Person("P025", 25));
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(person);
+
+        // check for correctness of resulting collection
+        people.Add(person);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+    [Fact]
+    public void AddOutsideOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+
+        // insert right at end
+        var person = new Person("X_Last", 100);
+        Source.AddOrUpdate(person);
+
+        // only the initials message should have been received
+        Aggregator.Messages.Count.Should().Be(1);
+
+
+        people.Add(person);
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    [Fact]
+    public void UpdateMoveOutOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // Change an item so it moves from in range to out of range
+        var person = new Person("P012", 50);
+        Source.AddOrUpdate(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(new Person("P012", 50));
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(new Person("P026", 26));
+
+        // check for correctness of resulting collection
+        people = people.OrderBy(p => p, Comparer).ToList();
+        people[11] = person;
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+    [Fact]
+    public void UpdateStayRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // Update an item, but keep it withing the expected virtual range.
+        var person = new Person("P012", -1);
+        Source.AddOrUpdate(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(1);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Update);
+        firstChange.Current.Should().Be(new Person("P012", -1));
+        firstChange.Previous.Value.Should().Be(new Person("P012", 12));
+
+        // check for correctness of resulting collection
+        people = people.OrderBy(p => p, Comparer).ToList();
+        people[11] = person;
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+
+    [Fact]
+    public void UpdateOutOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at beginning
+        var person = new Person("P050", 100);
+        Source.AddOrUpdate(person);
+
+        // only the initials message should have been received
+        Aggregator.Messages.Count.Should().Be(1);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+    [Fact]
+    public void RemoveRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // remove an element from the active range
+        var person = new Person("P012", 12);
+        Source.Remove(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(person);
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(new Person("P026", 26));
+
+        // check for correctness of resulting collection
+        people.Remove(person);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    [Fact]
+    public void RemoveOutOfRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        // insert right at beginning
+        var person = new Person("P050", 50);
+        Source.Remove(person);
+
+        // only the initials message should have been received
+        Aggregator.Messages.Count.Should().Be(1);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+
+    [Fact]
+    public void RefreshInRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        var person = people.Single(p => p.Name == "P012");
+        Source.Refresh(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(1);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Refresh);
+    }
+
+    [Fact]
+    public void RefreshWithInlineChangeInRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        var person = people.Single(p => p.Name == "P012");
+
+        // The item will move within the virtual range, so be propagated as a refresh
+        person.Age = 5;
+        Source.Refresh(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(1);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Refresh);
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    [Fact]
+    public void RefreshWithInlineChangeOutsideRange()
+    {
+        var people = Enumerable.Range(1, 100).Select(i => new Person($"P{i:000}", i)).OrderBy(p => Guid.NewGuid()).ToList();
+        Source.AddOrUpdate(people);
+
+        var person = people.Single(p => p.Name == "P012");
+
+        // The item will move outside the virtual range, resulting in a remove and index shift
+        person.Age = 50;
+        Source.Refresh(person);
+
+        Aggregator.Messages.Count.Should().Be(2);
+
+        var changes = Aggregator.Messages[1];
+        changes.Count.Should().Be(2);
+
+        var firstChange = changes.First();
+        firstChange.Reason.Should().Be(ChangeReason.Remove);
+        firstChange.Current.Should().Be(new Person("P012", 50));
+
+        var secondChange = changes.Skip(1).First();
+        secondChange.Reason.Should().Be(ChangeReason.Add);
+        secondChange.Current.Should().Be(new Person("P026", 26));
+
+
+        var expectedResult = people.OrderBy(p => p, Comparer).Take(25).ToList();
+        List.SequenceEqual(expectedResult).Should().Be(true);
+    }
+
+    public void Dispose()
+    {
+        Source.Dispose();
+        Aggregator.Dispose();
+        VirtualRequests.OnCompleted();
+    }
+}

--- a/src/DynamicData/Binding/BindVirtualized.cs
+++ b/src/DynamicData/Binding/BindVirtualized.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace DynamicData.Binding;
+
+/*
+ * Binding for the result of the SortAndVirtualize operator
+ */
+internal sealed class BindVirtualized<TObject, TKey>(
+    IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
+    IList<TObject> targetList,
+    SortAndBindOptions? options)
+    where TObject : notnull
+    where TKey : notnull
+{
+    public IObservable<IChangeSet<TObject, TKey>> Run() => options is null
+        ? UseVirtualSortOptions()
+        : UseProvidedOptions(options.Value);
+
+    private IObservable<IChangeSet<TObject, TKey>> UseProvidedOptions(SortAndBindOptions sortAndBindOptions) =>
+        source.Publish(changes =>
+        {
+            var comparedChanged = changes
+                .Select(changesWithContext => changesWithContext.Context.Comparer)
+                .DistinctUntilChanged();
+
+            return changes.SortAndBind(targetList, comparedChanged, sortAndBindOptions);
+        });
+
+    private IObservable<IChangeSet<TObject, TKey>> UseVirtualSortOptions() =>
+        Observable.Create<IChangeSet<TObject, TKey>>(observer =>
+        {
+            var shared = source.Publish();
+
+            var subscriber = new SingleAssignmentDisposable();
+
+            // I tried to make this work without subjects but had issues
+            // making the comparedChanged observable to fire. Probably a deadlock
+            var changesSubject = new Subject<IChangeSet<TObject, TKey>>();
+            var comparerSubject = new ReplaySubject<IComparer<TObject>>(1);
+
+            // once we have the initial values, publish as normal.
+            var subsequent = shared
+                .Skip(1)
+                .Subscribe(changesWithContext =>
+                {
+                    comparerSubject.OnNext(changesWithContext.Context.Comparer);
+                    changesSubject.OnNext(changesWithContext);
+                });
+
+            // extract binding options from the virtual context
+            var initial = shared
+                .Take(1)
+                .Subscribe(changesWithContext =>
+                {
+                    var virtualOptions = changesWithContext.Context.Options;
+                    var extractedOptions = DynamicDataOptions.SortAndBind with
+                    {
+                        UseBinarySearch = virtualOptions.UseBinarySearch,
+                        ResetThreshold = virtualOptions.ResetThreshold
+                    };
+
+                    subscriber.Disposable = changesSubject
+                            .SortAndBind(targetList, comparerSubject.DistinctUntilChanged(), extractedOptions)
+                            .SubscribeSafe(observer);
+
+                    comparerSubject.OnNext(changesWithContext.Context.Comparer);
+                    changesSubject.OnNext(changesWithContext);
+                });
+
+            return new CompositeDisposable(initial, subscriber, subsequent, shared.Connect());
+        });
+}

--- a/src/DynamicData/Cache/Internal/SortAndPage.cs
+++ b/src/DynamicData/Cache/Internal/SortAndPage.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using DynamicData.Binding;
+
+namespace DynamicData.Cache.Internal;
+
+internal sealed class SortAndPage<TObject, TKey>
+    where TObject : notnull
+    where TKey : notnull
+{
+    private static readonly KeyComparer<TObject, TKey> _keyComparer = new();
+
+    private readonly IObservable<IChangeSet<TObject, TKey>> _source;
+    private readonly IObservable<IComparer<TObject>> _comparerChanged;
+    private readonly IObservable<IPageRequest> _pageRequests;
+    private readonly SortAndPageOptions _options;
+
+    public SortAndPage(IObservable<IChangeSet<TObject, TKey>> source,
+        IComparer<TObject> comparer,
+        IObservable<IPageRequest> virtualRequests,
+        SortAndPageOptions options)
+        : this(source, Observable.Return(comparer), virtualRequests, options)
+    {
+    }
+
+    public SortAndPage(IObservable<IChangeSet<TObject, TKey>> source,
+        IObservable<IComparer<TObject>> comparerChanged,
+        IObservable<IPageRequest> virtualRequests,
+        SortAndPageOptions options)
+    {
+        _options = options;
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _comparerChanged = comparerChanged;
+        _pageRequests = virtualRequests ?? throw new ArgumentNullException(nameof(virtualRequests));
+    }
+
+    private static readonly ChangeSet<TObject, TKey, PageContext<TObject>> Empty = new(0, PageContext<TObject>.Empty);
+
+    public IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> Run() =>
+        Observable.Create<IChangeSet<TObject, TKey, PageContext<TObject>>>(
+            observer =>
+            {
+                var locker = new object();
+
+                var sortOptions = new SortAndBindOptions
+                {
+                    UseBinarySearch = _options.UseBinarySearch,
+                    ResetThreshold = _options.ResetThreshold
+                };
+
+                var pageRequest = PageRequest.Default;
+
+                // a sorted list of key value pairs
+                var sortedList = new List<KeyValuePair<TKey, TObject>>(_options.InitialCapacity);
+                var pagedItems = new List<KeyValuePair<TKey, TObject>>(pageRequest.Size);
+
+                IComparer<TObject>? comparer = null;
+                KeyValueComparer<TObject, TKey>? keyValueComparer = null;
+                SortedKeyValueApplicator<TObject, TKey>? applicator = null;
+
+                // used to maintain a sorted list of key value pairs
+                var comparerChanged = _comparerChanged.Synchronize(locker)
+                    .Select(c =>
+                    {
+                        comparer = c;
+                        keyValueComparer = new KeyValueComparer<TObject, TKey>(c);
+
+                        if (applicator is null)
+                        {
+                            applicator = new SortedKeyValueApplicator<TObject, TKey>(sortedList, keyValueComparer, sortOptions);
+                        }
+                        else
+                        {
+                            applicator.ChangeComparer(keyValueComparer);
+                        }
+                        return ApplyPagedChanges();
+                    });
+
+                var paramsChanged = _pageRequests.Synchronize(locker)
+                    .DistinctUntilChanged()
+                    // exclude dodgy params
+                    .Where(parameters => parameters is { Page: > 0, Size: > 0 })
+                    .Select(request =>
+                    {
+                        pageRequest = request;
+
+                        // have not received the comparer yet
+                        if (applicator is null) return Empty;
+
+                        // re-apply virtual changes
+                        return ApplyPagedChanges();
+                    });
+
+                var dataChange = _source.Synchronize(locker)
+                    // we need to ensure each change batch has unique keys only.
+                    // Otherwise, calculation of virtualized changes is super complex
+                    .EnsureUniqueKeys()
+                    .Select(changes =>
+                    {
+                        // have not received the comparer yet
+                        if (applicator is null) return Empty;
+
+                        // apply changes to the sorted list
+                        applicator.ProcessChanges(changes);
+
+                        // re-apply virtual changes
+                        return ApplyPagedChanges(changes);
+                    });
+
+                return
+                    comparerChanged
+                        .Merge(paramsChanged)
+                        .Merge(dataChange)
+                        .Where(changes => changes.Count is not 0)
+                        .SubscribeSafe(observer);
+
+                ChangeSet<TObject, TKey, PageContext<TObject>> ApplyPagedChanges(IChangeSet<TObject, TKey>? changeSet = null)
+                {
+                    var previousVirtualList = pagedItems;
+
+                    var listSize = sortedList.Count;
+                    var pages = CalculatePages(pageRequest, listSize);
+                    var page = pageRequest.Page > pages ? pages : pageRequest.Page;
+                    var skip = pageRequest.Size * (page - 1);
+
+                    // re-calculate virtual changes
+                    var currentPagesItems = new List<KeyValuePair<TKey, TObject>>(pageRequest.Size);
+                    currentPagesItems.AddRange(sortedList.Skip(skip).Take(pageRequest.Size));
+
+                    var responseParams = new PageResponse(pageRequest.Size, listSize, page, pages);
+                    var context = new PageContext<TObject>(responseParams, comparer!, _options);
+
+                    // calculate notifications
+                    var virtualChanges = CalculatePageChanges(context, currentPagesItems, previousVirtualList, changeSet);
+
+                    pagedItems = currentPagesItems;
+
+                    return virtualChanges;
+                }
+
+                static int CalculatePages(IPageRequest request, int totalCount)
+                {
+                    if (request.Size >= totalCount)
+                    {
+                        return 1;
+                    }
+
+                    var pages = totalCount / request.Size;
+                    var overlap = totalCount % request.Size;
+
+                    if (overlap == 0)
+                    {
+                        return pages;
+                    }
+
+                    return pages + 1;
+                }
+            });
+
+    // Calculates any changes within the paged range.
+    private static ChangeSet<TObject, TKey, PageContext<TObject>> CalculatePageChanges(PageContext<TObject> context,
+        List<KeyValuePair<TKey, TObject>> currentItems,
+        List<KeyValuePair<TKey, TObject>> previousItems,
+        IChangeSet<TObject, TKey>? changes = null)
+    {
+        var result = new ChangeSet<TObject, TKey, PageContext<TObject>>(currentItems.Count * 2, context);
+
+        var removes = previousItems.Except(currentItems, _keyComparer).Select(kvp => new Change<TObject, TKey>(ChangeReason.Remove, kvp.Key, kvp.Value));
+        var adds = currentItems.Except(previousItems, _keyComparer).Select(kvp => new Change<TObject, TKey>(ChangeReason.Add, kvp.Key, kvp.Value));
+
+        result.AddRange(removes);
+        result.AddRange(adds);
+
+        if (changes is null) return result;
+
+        var keyInPreviousAndCurrent = new HashSet<TKey>(previousItems.Intersect(currentItems, _keyComparer).Select(x => x.Key));
+
+        foreach (var change in changes)
+        {
+            // An update (or refresh) can only occur if it was in the previous or current result set.
+            // If it was in only one or the other, it would be an add or remove accordingly.
+            if (!keyInPreviousAndCurrent.Contains(change.Key)) continue;
+
+            if (change.Reason is ChangeReason.Update or ChangeReason.Refresh)
+            {
+                result.Add(change);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using DynamicData.Binding;
 
 namespace DynamicData;
@@ -14,6 +13,80 @@ namespace DynamicData;
 public static partial class ObservableCacheEx
 {
     /// <summary>
+    /// Bind paged data to the specified readonly observable collection.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
+        out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        var targetList = new ObservableCollectionExtended<TObject>();
+        readOnlyObservableCollection = new ReadOnlyObservableCollection<TObject>(targetList);
+
+        return source.Bind(targetList);
+    }
+
+    /// <summary>
+    /// Bind paged data to the specified collection.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
+    /// <param name="options">Bind and sort default options.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
+        out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
+        SortAndBindOptions options)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        var targetList = new ObservableCollectionExtended<TObject>();
+        readOnlyObservableCollection = new ReadOnlyObservableCollection<TObject>(targetList);
+
+        return source.Bind(targetList, options);
+    }
+
+    /// <summary>
+    /// Bind paged data to the specified collection.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="targetList">The list to bind to.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
+        IList<TObject> targetList)
+        where TObject : notnull
+        where TKey : notnull =>
+        new BindPaged<TObject, TKey>(source, targetList, null).Run();
+
+    /// <summary>
+    /// Bind paged data to the specified collection.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="targetList">The list to bind to.</param>
+    /// <param name="options">Bind and sort default options.</param>
+    /// <returns>An observable which will emit change sets.</returns>
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+        this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
+        IList<TObject> targetList,
+        SortAndBindOptions options)
+        where TObject : notnull
+        where TKey : notnull =>
+        new BindPaged<TObject, TKey>(source, targetList, options).Run();
+
+    /// <summary>
     /// Bind virtualized and sorted data to the specified readonly observable collection.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
@@ -21,7 +94,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
         where TObject : notnull
@@ -30,7 +103,7 @@ public static partial class ObservableCacheEx
         var targetList = new ObservableCollectionExtended<TObject>();
         readOnlyObservableCollection = new ReadOnlyObservableCollection<TObject>(targetList);
 
-        return source.SortAndBind(targetList);
+        return source.Bind(targetList);
     }
 
     /// <summary>
@@ -42,7 +115,7 @@ public static partial class ObservableCacheEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         SortAndBindOptions options)
@@ -52,7 +125,7 @@ public static partial class ObservableCacheEx
         var targetList = new ObservableCollectionExtended<TObject>();
         readOnlyObservableCollection = new ReadOnlyObservableCollection<TObject>(targetList);
 
-        return source.SortAndBind(targetList, options);
+        return source.Bind(targetList, options);
     }
 
     /// <summary>
@@ -63,12 +136,12 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="targetList">The list to bind to.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         IList<TObject> targetList)
         where TObject : notnull
         where TKey : notnull =>
-        new SortAndBindVirtualized<TObject, TKey>(source, targetList, null).Run();
+        new BindVirtualized<TObject, TKey>(source, targetList, null).Run();
 
     /// <summary>
     /// Bind virtualized data to the specified collection.
@@ -79,13 +152,13 @@ public static partial class ObservableCacheEx
     /// <param name="targetList">The list to bind to.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         IList<TObject> targetList,
         SortAndBindOptions options)
         where TObject : notnull
         where TKey : notnull =>
-        new SortAndBindVirtualized<TObject, TKey>(source, targetList, options).Run();
+        new BindVirtualized<TObject, TKey>(source, targetList, options).Run();
 
     /// <summary>
     /// Bind sorted data to the specified collection, for an object which implements IComparable<typeparamref name="TObject"></typeparamref>>.

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -4091,6 +4091,7 @@ public static partial class ObservableCacheEx
     /// or
     /// comparer.
     /// </exception>
+    [Obsolete(Constants.SortIsObsolete)]
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IComparer<TObject> comparer, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
         where TObject : notnull
         where TKey : notnull
@@ -4111,6 +4112,7 @@ public static partial class ObservableCacheEx
     /// <param name="sortOptimisations">The sort optimisations.</param>
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>An observable which emits change sets.</returns>
+    [Obsolete(Constants.SortIsObsolete)]
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<IComparer<TObject>> comparerObservable, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
         where TObject : notnull
         where TKey : notnull
@@ -4132,6 +4134,7 @@ public static partial class ObservableCacheEx
     /// <param name="sortOptimisations">The sort optimisations.</param>
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>An observable which emits change sets.</returns>
+    [Obsolete(Constants.SortIsObsolete)]
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<IComparer<TObject>> comparerObservable, IObservable<Unit> resorter, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
         where TObject : notnull
         where TKey : notnull
@@ -4153,6 +4156,7 @@ public static partial class ObservableCacheEx
     /// <param name="sortOptimisations">The sort optimisations.</param>
     /// <param name="resetThreshold">The reset threshold.</param>
     /// <returns>An observable which emits change sets.</returns>
+    [Obsolete(Constants.SortIsObsolete)]
     public static IObservable<ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IComparer<TObject> comparer, IObservable<Unit> resorter, SortOptimisations sortOptimisations = SortOptimisations.None, int resetThreshold = DefaultSortResetThreshold)
         where TObject : notnull
         where TKey : notnull

--- a/src/DynamicData/Cache/PageContext.cs
+++ b/src/DynamicData/Cache/PageContext.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using DynamicData.Operators;
+
+namespace DynamicData;
+
+/// <summary>
+/// Parameters associated with the page operation.
+/// </summary>
+/// <typeparam name="TObject"> The type of object.</typeparam>
+/// <param name="Response"> Response parameters.</param>
+/// <param name="Comparer"> The comparer used to order the items.</param>
+/// <param name="Options"> The options used to perform virtualization.</param>
+public record PageContext<TObject>(
+    IPageResponse Response,
+    IComparer<TObject> Comparer,
+    SortAndPageOptions Options)
+{
+    internal static readonly PageContext<TObject> Empty = new
+    (
+        new PageResponse(0, 0, 0, 0),
+        Comparer<TObject>.Default,
+        new SortAndPageOptions()
+    );
+}

--- a/src/DynamicData/Cache/PageRequest.cs
+++ b/src/DynamicData/Cache/PageRequest.cs
@@ -22,8 +22,6 @@ public sealed class PageRequest : IPageRequest, IEquatable<IPageRequest>
     /// </summary>
     public static readonly IPageRequest Empty = new PageRequest(0, 0);
 
-    private static readonly IEqualityComparer<IPageRequest?> _pageSizeComparerInstance = new PageSizeEqualityComparer();
-
     /// <summary>
     /// Initializes a new instance of the <see cref="PageRequest"/> class.
     /// </summary>
@@ -58,8 +56,7 @@ public sealed class PageRequest : IPageRequest, IEquatable<IPageRequest>
     /// <value>
     /// The default comparer.
     /// </value>
-    [SuppressMessage("Design", "CA1822: Member can be static", Justification = "Backwards compatibilty")]
-    public IEqualityComparer<IPageRequest?> DefaultComparer => _pageSizeComparerInstance;
+    public static IEqualityComparer<IPageRequest?> DefaultComparer { get; } = new PageSizeEqualityComparer();
 
     /// <summary>
     /// Gets the page to move to.

--- a/src/DynamicData/Cache/SortAndPageOptions.cs
+++ b/src/DynamicData/Cache/SortAndPageOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using DynamicData.Binding;
+
+namespace DynamicData;
+
+/// <summary>
+/// Options for the sort and virtualize operator.
+/// </summary>
+public record struct SortAndPageOptions()
+{
+    /// <summary>
+    /// The sort reset threshold ie the number of changes before a reset is fired.
+    /// </summary>
+    public int ResetThreshold { get; init; } = BindingOptions.DefaultResetThreshold;
+
+    /// <summary>
+    /// Use binary search when the result of the comparer is a pure function.
+    /// </summary>
+    public bool UseBinarySearch { get; init; }
+
+    /// <summary>
+    /// Set the initial capacity of internal sorted list.
+    /// </summary>
+    public int InitialCapacity { get; init; }
+}

--- a/src/DynamicData/Constants.cs
+++ b/src/DynamicData/Constants.cs
@@ -7,4 +7,7 @@ namespace DynamicData;
 internal static class Constants
 {
     public const string EvaluateIsDead = "Use Refresh: Same thing but better semantics";
+    public const string VirtualizeIsObsolete = "Use SortAndVirtualize as it's more efficient";
+    public const string PageIsObsolete = "Use SortAndPage as it's more efficient";
+    public const string TopIsObsolete = "Use Overload with comparer as it's more efficient";
 }

--- a/src/DynamicData/Constants.cs
+++ b/src/DynamicData/Constants.cs
@@ -10,4 +10,5 @@ internal static class Constants
     public const string VirtualizeIsObsolete = "Use SortAndVirtualize as it's more efficient";
     public const string PageIsObsolete = "Use SortAndPage as it's more efficient";
     public const string TopIsObsolete = "Use Overload with comparer as it's more efficient";
+    public const string SortIsObsolete = "Use SortAndBind as it's more efficient";
 }


### PR DESCRIPTION
This is the following up to the SortAndVirtualize - see https://github.com/reactivemarbles/DynamicData/pull/888

If is an almost a direct lift of the code but using page based calculations.   This is part of the drive to eliminate the Sort operator altogether, and subsequently the need to propagate the index on `Change<TObject,TKey>`.  

**Old**

```cs
var pageRequests=new BehaviorSubject<IPageRequest>(new PageRequest(1, 25))

myCache 
  .Sort(myComparer)
  .Page(pageRequests)
```
**New**

```cs
var pageRequests=new BehaviorSubject<IPageRequest>(new PageRequest(1, 25))

myCache 
  .SortAndPage(myComparer, pageRequests)
```

There is a also a  new `Bind()` overload to bind the results of the page response.

Additionally I have renamed SortAndBind which acts on a a virtual response to `Bind()` .

I just need and replace `SortBy` with `SortByAndBind` operator and I am happy to make the big version release.