### PR TITLE
Expose read only collections for source cache

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -540,9 +540,9 @@ namespace DynamicData.Cache.Internal
         public LockFreeObservableCache(System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source) { }
         public int Count { get; }
         public System.IObservable<int> CountChanged { get; }
-        public System.Collections.Generic.IEnumerable<TObject> Items { get; }
-        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>> KeyValues { get; }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get; }
+        public System.Collections.Generic.IReadOnlyList<TObject> Items { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<TKey, TObject> KeyValues { get; }
+        public System.Collections.Generic.IReadOnlyList<TKey> Keys { get; }
         public System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Connect(System.Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) { }
         public void Dispose() { }
         public void Edit(System.Action<DynamicData.ICacheUpdater<TObject, TKey>> editAction) { }
@@ -874,9 +874,9 @@ namespace DynamicData
         where TKey :  notnull
     {
         int Count { get; }
-        System.Collections.Generic.IEnumerable<TObject> Items { get; }
-        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>> KeyValues { get; }
-        System.Collections.Generic.IEnumerable<TKey> Keys { get; }
+        System.Collections.Generic.IReadOnlyList<TObject> Items { get; }
+        System.Collections.Generic.IReadOnlyDictionary<TKey, TObject> KeyValues { get; }
+        System.Collections.Generic.IReadOnlyList<TKey> Keys { get; }
         DynamicData.Kernel.Optional<TObject> Lookup(TKey key);
     }
     public interface IObservableList<T> : System.IDisposable
@@ -993,9 +993,9 @@ namespace DynamicData
         public IntermediateCache(System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source) { }
         public int Count { get; }
         public System.IObservable<int> CountChanged { get; }
-        public System.Collections.Generic.IEnumerable<TObject> Items { get; }
-        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>> KeyValues { get; }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get; }
+        public System.Collections.Generic.IReadOnlyList<TObject> Items { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<TKey, TObject> KeyValues { get; }
+        public System.Collections.Generic.IReadOnlyList<TKey> Keys { get; }
         public System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Connect(System.Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) { }
         public void Dispose() { }
         public void Edit(System.Action<DynamicData.ICacheUpdater<TObject, TKey>> updateAction) { }
@@ -2610,10 +2610,10 @@ namespace DynamicData
         public SourceCache(System.Func<TObject, TKey> keySelector) { }
         public int Count { get; }
         public System.IObservable<int> CountChanged { get; }
-        public System.Collections.Generic.IEnumerable<TObject> Items { get; }
+        public System.Collections.Generic.IReadOnlyList<TObject> Items { get; }
         public System.Func<TObject, TKey> KeySelector { get; }
-        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TObject>> KeyValues { get; }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<TKey, TObject> KeyValues { get; }
+        public System.Collections.Generic.IReadOnlyList<TKey> Keys { get; }
         public System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Connect(System.Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) { }
         public void Dispose() { }
         public void Edit(System.Action<DynamicData.ISourceUpdater<TObject, TKey>> updateAction) { }

--- a/src/DynamicData.Tests/Cache/AndFixture.cs
+++ b/src/DynamicData.Tests/Cache/AndFixture.cs
@@ -78,7 +78,7 @@ public abstract class AndFixtureBase : IDisposable
         _source2.AddOrUpdate(person);
         _results.Messages.Count.Should().Be(1, "Should have no updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public abstract class AndFixtureBase : IDisposable
         _source2.AddOrUpdate(personUpdated);
         _results.Messages.Count.Should().Be(2, "Should be 2 updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(personUpdated, "Should be updated person");
+        _results.Data.Items[0].Should().Be(personUpdated, "Should be updated person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/DisposeManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/DisposeManyFixture.cs
@@ -99,14 +99,14 @@ public sealed class DisposeManyFixture : IDisposable
         {
             new Change<DisposableObject, int>(
                 reason: ChangeReason.Refresh,
-                key: _itemsSource.Items.First().Id,
-                current: _itemsSource.Items.First())
+                key: _itemsSource.Items[0].Id,
+                current: _itemsSource.Items[0])
         });
         _changeSetsSource.OnNext(new ChangeSet<DisposableObject, int>() // Move
         {
             new Change<DisposableObject, int>(
-                key: _itemsSource.Items.First().Id,
-                current: _itemsSource.Items.First(),
+                key: _itemsSource.Items[0].Id,
+                current: _itemsSource.Items[0],
                 currentIndex: 1,
                 previousIndex: 0)
         });

--- a/src/DynamicData.Tests/Cache/DistinctFixture.cs
+++ b/src/DynamicData.Tests/Cache/DistinctFixture.cs
@@ -64,7 +64,7 @@ public class DistinctFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 update message");
         _results.Data.Count.Should().Be(1, "Should be 1 items in the cache");
-        _results.Data.Items.First().Should().Be(20, "Should 20");
+        _results.Data.Items[0].Should().Be(20, "Should 20");
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class DistinctFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(20, "Should 20");
+        _results.Data.Items[0].Should().Be(20, "Should 20");
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class DistinctFixture : IDisposable
         _results.Data.Count.Should().Be(3, "Should be 3 items in the cache");
 
         _results.Data.Items.Should().BeEquivalentTo(new[] { 20, 21, 22 });
-        _results.Data.Items.First().Should().Be(20, "Should 20");
+        _results.Data.Items[0].Should().Be(20, "Should 20");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/DynamicAndFixture.cs
+++ b/src/DynamicData.Tests/Cache/DynamicAndFixture.cs
@@ -108,7 +108,7 @@ public class DynamicAndFixture : IDisposable
         _source2.AddOrUpdate(person);
         _results.Messages.Count.Should().Be(1, "Should have no updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class DynamicAndFixture : IDisposable
         _source2.AddOrUpdate(personUpdated);
         _results.Messages.Count.Should().Be(2, "Should be 2 updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(personUpdated, "Should be updated person");
+        _results.Data.Items[0].Should().Be(personUpdated, "Should be updated person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/DynamicOrFixture.cs
+++ b/src/DynamicData.Tests/Cache/DynamicOrFixture.cs
@@ -108,7 +108,7 @@ public class DynamicOrFixture : IDisposable
         _source2.AddOrUpdate(person);
         _results.Messages.Count.Should().Be(1, "Should have no updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class DynamicOrFixture : IDisposable
         _source2.AddOrUpdate(personUpdated);
         _results.Messages.Count.Should().Be(2, "Should be 2 updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(personUpdated, "Should be updated person");
+        _results.Data.Items[0].Should().Be(personUpdated, "Should be updated person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/FilterControllerFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterControllerFixture.cs
@@ -37,7 +37,7 @@ public class FilterControllerFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class FilterControllerFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Current.Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/FilterFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.cs
@@ -30,7 +30,7 @@ public class FilterFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class FilterFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Current.Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/FilterParallelFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterParallelFixture.cs
@@ -30,7 +30,7 @@ public class FilterParallelFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class FilterParallelFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Messages[0].First().Current.Should().Be(matched, "Should be same person");
-        _results.Data.Items.First().Should().Be(matched, "Should be same person");
+        _results.Data.Items[0].Should().Be(matched, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/GroupImmutableFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupImmutableFixture.cs
@@ -102,7 +102,7 @@ public class GroupImmutableFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1);
         _results.Messages.First().Adds.Should().Be(1);
-        _results.Data.Items.First().Count.Should().Be(4);
+        _results.Data.Items[0].Count.Should().Be(4);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class GroupImmutableFixture : IDisposable
         _results.Messages.First().Adds.Should().Be(1);
         _results.Messages.Skip(1).First().Adds.Should().Be(1);
         _results.Messages.Skip(1).First().Removes.Should().Be(1);
-        var group = _results.Data.Items.First();
+        var group = _results.Data.Items[0];
         group.Count.Should().Be(1);
 
         group.Key.Should().Be(21);
@@ -174,7 +174,7 @@ public class GroupImmutableFixture : IDisposable
         _results.Messages.First().Adds.Should().Be(1);
         _results.Messages.Skip(1).First().Updates.Should().Be(1);
 
-        var group = _results.Data.Items.First();
+        var group = _results.Data.Items[0];
         group.Count.Should().Be(2);
     }
 }

--- a/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnObservableFixture.cs
@@ -208,7 +208,7 @@ public class GroupOnObservableFixture : IDisposable
         _cache.Clear();
 
         // Assert
-        _cache.Items.Count().Should().Be(0);
+        _cache.Items.Count.Should().Be(0);
         _results.Messages.Count.Should().Be(2, "1 for Adds and 1 for Removes");
         _groupResults.Summary.Overall.Adds.Should().Be(colorCount);
         _groupResults.Summary.Overall.Removes.Should().Be(colorCount);

--- a/src/DynamicData.Tests/Cache/GroupOnPropertyFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnPropertyFixture.cs
@@ -28,7 +28,7 @@ public class GroupOnPropertyFixture : IDisposable
 
         _results.Data.Count.Should().Be(1);
 
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Cache.Count.Should().Be(1);
         firstGroup.Key.Should().Be(10);
@@ -92,7 +92,7 @@ public class GroupOnPropertyFixture : IDisposable
         person.Age = 20;
 
         _results.Data.Count.Should().Be(1);
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Cache.Count.Should().Be(1);
         firstGroup.Key.Should().Be(20);

--- a/src/DynamicData.Tests/Cache/GroupOnPropertyWithImmutableStateFixture.cs
+++ b/src/DynamicData.Tests/Cache/GroupOnPropertyWithImmutableStateFixture.cs
@@ -29,7 +29,7 @@ public class GroupOnPropertyWithImmutableStateFixture : IDisposable
 
         _results.Data.Count.Should().Be(1);
 
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Count.Should().Be(1);
         firstGroup.Key.Should().Be(10);
@@ -93,7 +93,7 @@ public class GroupOnPropertyWithImmutableStateFixture : IDisposable
         person.Age = 20;
 
         _results.Data.Count.Should().Be(1);
-        var firstGroup = _results.Data.Items.First();
+        var firstGroup = _results.Data.Items[0];
 
         firstGroup.Count.Should().Be(1);
         firstGroup.Key.Should().Be(20);

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheFixture.cs
@@ -806,11 +806,11 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
 
         // These should be subsets of each other
         expectedMarkets.Should().BeSubsetOf(marketResults.Data.Items);
-        marketResults.Data.Items.Count().Should().Be(expectedMarkets.Count);
+        marketResults.Data.Items.Count.Should().Be(expectedMarkets.Count);
 
         // These should be subsets of each other
         expectedPrices.Should().BeSubsetOf(priceResults.Data.Items);
-        priceResults.Data.Items.Count().Should().Be(expectedPrices.Count);
+        priceResults.Data.Items.Count.Should().Be(expectedPrices.Count);
     }
 
     private void DisposeMarkets()

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
@@ -1074,7 +1074,7 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
 
         // These should be subsets of each other
         expectedMarkets.Should().BeSubsetOf(marketResults.Data.Items);
-        marketResults.Data.Items.Count().Should().Be(expectedMarkets.Count);
+        marketResults.Data.Items.Count.Should().Be(expectedMarkets.Count);
 
         // Pair up all the Markets/Prices, Group them by ItemId, and sort each Group by the Market comparer
         // Then pull out the first value from each group, which should be the price from the best market for each ItemId
@@ -1085,7 +1085,7 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
 
         // These should be subsets of each other
         expectedPrices.Should().BeSubsetOf(priceResults.Data.Items);
-        priceResults.Data.Items.Count().Should().Be(expectedPrices.Count);
+        priceResults.Data.Items.Count.Should().Be(expectedPrices.Count);
     }
 
     private void DisposeMarkets()

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsListFixture.cs
@@ -459,7 +459,7 @@ public sealed class MergeManyChangeSetsListFixture : IDisposable
 
         // These should be subsets of each other
         expectedOwners.Should().BeSubsetOf(ownerResults.Data.Items);
-        ownerResults.Data.Items.Count().Should().Be(expectedOwners.Count);
+        ownerResults.Data.Items.Count.Should().Be(expectedOwners.Count);
 
         // All owner animals should be in the results
         foreach (var owner in owners)

--- a/src/DynamicData.Tests/Cache/ObservableToObservableChangeSetFixture.cs
+++ b/src/DynamicData.Tests/Cache/ObservableToObservableChangeSetFixture.cs
@@ -123,7 +123,7 @@ public class ObservableToObservableChangeSetFixture
 
         results.Messages.Count.Should().Be(1, "Should be 1 updates");
         results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(person, "Should be same person");
+        results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class ObservableToObservableChangeSetFixture
         results.Messages.Count.Should().Be(2, "Should be 2 message");
         results.Messages[1].Updates.Should().Be(1, "Should be 1 updates");
         results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(personamend, "Should be same person");
+        results.Data.Items[0].Should().Be(personamend, "Should be same person");
     }
 
     [Fact]
@@ -155,6 +155,6 @@ public class ObservableToObservableChangeSetFixture
 
         results.Messages.Count.Should().Be(1, "Should be 1 updates");
         results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        results.Data.Items.First().Should().Be(person, "Should be same person");
+        results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 }

--- a/src/DynamicData.Tests/Cache/OrFixture.cs
+++ b/src/DynamicData.Tests/Cache/OrFixture.cs
@@ -67,7 +67,7 @@ public abstract class OrFixtureBase : IDisposable
         _source2.AddOrUpdate(person);
         _results.Messages.Count.Should().Be(1, "Should have no updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public abstract class OrFixtureBase : IDisposable
         _source2.AddOrUpdate(personUpdated);
         _results.Messages.Count.Should().Be(2, "Should be 2 updates");
         _results.Data.Count.Should().Be(1, "Cache should have no items");
-        _results.Data.Items.First().Should().Be(personUpdated, "Should be updated person");
+        _results.Data.Items[0].Should().Be(personUpdated, "Should be updated person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/RightJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/RightJoinManyFixture.cs
@@ -51,7 +51,7 @@ public class RightJoinManyFixture : IDisposable
         _people.AddOrUpdate(people);
 
         _result.Data.Count.Should().Be(1);
-        _result.Data.Items.First().Parent.Should().BeNull();
+        _result.Data.Items[0].Parent.Should().BeNull();
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/SizeLimitFixture.cs
+++ b/src/DynamicData.Tests/Cache/SizeLimitFixture.cs
@@ -40,7 +40,7 @@ public class SizeLimitFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class SizeLimitFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(person, "Should be same person");
+        _results.Data.Items[0].Should().Be(person, "Should be same person");
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Cache/SortAndBindFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortAndBindFixture.cs
@@ -13,6 +13,19 @@ using Xunit;
 
 namespace DynamicData.Tests.Cache;
 
+// Bind to a list
+public sealed class SortByAndBindToList : SortAndBindFixture
+
+{
+    protected override (ChangeSetAggregator<Person, string> Aggregrator, IList<Person> List) SetUpTests()
+    {
+        var list = new List<Person>(100);
+        var aggregator = _source.Connect().SortAndBind(list, _comparer).AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
 
 // Bind to a list
 public sealed class SortAndBindToList: SortAndBindFixture

--- a/src/DynamicData.Tests/Cache/SubscribeManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/SubscribeManyFixture.cs
@@ -33,7 +33,7 @@ public class SubscribeManyFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().IsSubscribed.Should().Be(true, "Should be subscribed");
+        _results.Data.Items[0].IsSubscribed.Should().Be(true, "Should be subscribed");
     }
 
     public void Dispose()

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -26,7 +26,7 @@ public class TransformAsyncFixture
 
         var firstPerson = await stub.TransformFactory(person);
 
-        stub.Results.Data.Items.First().Should().Be(firstPerson, "Should be same person");
+        stub.Results.Data.Items[0].Should().Be(firstPerson, "Should be same person");
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public class TransformAsyncFixture
         stub.Results.Data.Count.Should().Be(1, "Should result in 1 record");
 
         var lastTransformed = await stub.TransformFactory(people.Last());
-        var onlyItemInCache = stub.Results.Data.Items.First();
+        var onlyItemInCache = stub.Results.Data.Items[0];
 
         onlyItemInCache.Should().Be(lastTransformed, "Incorrect transform result");
     }

--- a/src/DynamicData.Tests/Cache/TransformFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformFixture.cs
@@ -22,7 +22,7 @@ public class TransformFixture
 
         stub.Results.Messages.Count.Should().Be(1, "Should be 1 updates");
         stub.Results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        stub.Results.Data.Items.First().Should().Be(stub.TransformFactory(person), "Should be same person");
+        stub.Results.Data.Items[0].Should().Be(stub.TransformFactory(person), "Should be same person");
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class TransformFixture
         stub.Results.Data.Count.Should().Be(1, "Should result in 1 record");
 
         var lastTransformed = stub.TransformFactory(people.Last());
-        var onlyItemInCache = stub.Results.Data.Items.First();
+        var onlyItemInCache = stub.Results.Data.Items[0];
 
         onlyItemInCache.Should().Be(lastTransformed, "Incorrect transform result");
     }

--- a/src/DynamicData.Tests/Cache/TransformFixtureParallel.cs
+++ b/src/DynamicData.Tests/Cache/TransformFixtureParallel.cs
@@ -38,7 +38,7 @@ public class TransformFixtureParallel : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(person), "Should be same person");
+        _results.Data.Items[0].Should().Be(_transformFactory(person), "Should be same person");
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class TransformFixtureParallel : IDisposable
         _results.Data.Count.Should().Be(1, "Should result in 1 record");
 
         var lastTransformed = _transformFactory(people.Last());
-        var onlyItemInCache = _results.Data.Items.First();
+        var onlyItemInCache = _results.Data.Items[0];
 
         // TODO: This is not producing consitent results, the lastTransformed item should be equal to the onlyItemInCache
         onlyItemInCache.Should().Be(lastTransformed, "Incorrect transform result");

--- a/src/DynamicData.Tests/Cache/TransformManyAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformManyAsyncFixture.cs
@@ -231,7 +231,7 @@ public sealed class TransformManyAsyncFixture : IDisposable
 
         // These should be subsets of each other
         expectedOwners.Should().BeSubsetOf(ownerResults.Data.Items);
-        ownerResults.Data.Items.Count().Should().Be(expectedOwners.Count);
+        ownerResults.Data.Items.Count.Should().Be(expectedOwners.Count);
 
         var allAnimals = expectedOwners.SelectMany(owner => owner.Animals.Items).ToList();
         var expectedAnimals = allAnimals.GroupBy(keySelector).Select(group => group.OrderBy(a => a, comparer).First()).ToList();
@@ -247,7 +247,7 @@ public sealed class TransformManyAsyncFixture : IDisposable
 
         // These should be subsets of each other
         expectedOwners.Should().BeSubsetOf(ownerResults.Data.Items);
-        ownerResults.Data.Items.Count().Should().Be(expectedOwners.Count);
+        ownerResults.Data.Items.Count.Should().Be(expectedOwners.Count);
 
         // All owner animals should be in the results
         foreach (var owner in owners)

--- a/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
@@ -72,7 +72,7 @@ public class TransformSafeAsyncFixture
 
         var firstPerson = await stub.TransformFactory(person);
 
-        stub.Results.Data.Items.First().Should().Be(firstPerson, "Should be same person");
+        stub.Results.Data.Items[0].Should().Be(firstPerson, "Should be same person");
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class TransformSafeAsyncFixture
         stub.Results.Data.Count.Should().Be(1, "Should result in 1 record");
 
         var lastTransformed = await stub.TransformFactory(people.Last());
-        var onlyItemInCache = stub.Results.Data.Items.First();
+        var onlyItemInCache = stub.Results.Data.Items[0];
 
         onlyItemInCache.Should().Be(lastTransformed, "Incorrect transform result");
     }

--- a/src/DynamicData.Tests/Cache/TransformSafeFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeFixture.cs
@@ -57,7 +57,7 @@ public class TransformSafeFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(person), "Should be same person");
+        _results.Data.Items[0].Should().Be(_transformFactory(person), "Should be same person");
     }
 
     public void Dispose()
@@ -86,7 +86,7 @@ public class TransformSafeFixture : IDisposable
         _results.Messages.Count.Should().Be(1, "Should be 1 messages");
 
         _results.Data.Count.Should().Be(1, "Should 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
+        _results.Data.Items[0].Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
     }
 
     [Fact]
@@ -121,6 +121,6 @@ public class TransformSafeFixture : IDisposable
         _results.Messages.Count.Should().Be(3, "Should be 3 messages");
 
         _results.Data.Count.Should().Be(1, "Should 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
+        _results.Data.Items[0].Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
     }
 }

--- a/src/DynamicData.Tests/Cache/TransformSafeParallelFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeParallelFixture.cs
@@ -57,7 +57,7 @@ public class TransformSafeParallelFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(person), "Should be same person");
+        _results.Data.Items[0].Should().Be(_transformFactory(person), "Should be same person");
     }
 
     public void Dispose()
@@ -86,7 +86,7 @@ public class TransformSafeParallelFixture : IDisposable
         _results.Messages.Count.Should().Be(1, "Should be 1 messages");
 
         _results.Data.Count.Should().Be(1, "Should 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
+        _results.Data.Items[0].Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
     }
 
     [Fact]
@@ -121,6 +121,6 @@ public class TransformSafeParallelFixture : IDisposable
         _results.Messages.Count.Should().Be(3, "Should be 3 messages");
 
         _results.Data.Count.Should().Be(1, "Should 1 item in the cache");
-        _results.Data.Items.First().Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
+        _results.Data.Items[0].Should().Be(_transformFactory(update2), "Change 2 shoud be the only item cached");
     }
 }

--- a/src/DynamicData.Tests/Cache/TransformTreeFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformTreeFixture.cs
@@ -36,10 +36,10 @@ public class TransformTreeFixture : IDisposable
 
         _result.Count.Should().Be(1);
 
-        var firstNode = _result.Items.First();
+        var firstNode = _result.Items[0];
         firstNode.Item.Should().Be(boss);
 
-        var childNode = firstNode.Children.Items.First();
+        var childNode = firstNode.Children.Items[0];
         childNode.Item.Should().Be(minion);
     }
 
@@ -81,7 +81,7 @@ public class TransformTreeFixture : IDisposable
         _sourceCache.AddOrUpdate(TransformTreeFixture.CreateEmployees());
         _result.Count.Should().Be(2);
 
-        var firstNode = _result.Items.First();
+        var firstNode = _result.Items[0];
         firstNode.Children.Count.Should().Be(3);
 
         var secondNode = _result.Items.Skip(1).First();
@@ -157,7 +157,7 @@ public class TransformTreeFixture : IDisposable
         _sourceCache.AddOrUpdate(changed);
         _result.Count.Should().Be(2);
 
-        var firstNode = _result.Items.First();
+        var firstNode = _result.Items[0];
         firstNode.Children.Count.Should().Be(3);
         firstNode.Item.Name.Should().Be(changed.Name);
     }
@@ -176,7 +176,7 @@ public class TransformTreeFixture : IDisposable
         _sourceCache.AddOrUpdate(changed);
         _result.Count.Should().Be(2);
 
-        var changedNode = _result.Items.First().Children.Items.First();
+        var changedNode = _result.Items[0].Children.Items[0];
 
         changedNode.Parent.Value.Item.Id.Should().Be(1);
         changedNode.Children.Count.Should().Be(1);

--- a/src/DynamicData.Tests/Cache/TransformWithInlineUpdateFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformWithInlineUpdateFixture.cs
@@ -17,17 +17,17 @@ public class TransformWithInlineUpdateFixture
         var person = new Person("Adult1", 50);
         stub.Source.AddOrUpdate(person);
 
-        var transformedPerson = stub.Results.Data.Items.First();
+        var transformedPerson = stub.Results.Data.Items[0];
 
         var personUpdate = new Person("Adult1", 51);
         stub.Source.AddOrUpdate(personUpdate);
 
-        var updatedTransform = stub.Results.Data.Items.First();
+        var updatedTransform = stub.Results.Data.Items[0];
 
         updatedTransform.Age.Should().Be(personUpdate.Age, "Age should be updated from 50 to 51.");
         stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
         stub.Results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        transformedPerson.Should().Be(stub.Results.Data.Items.First(), "Should be same transformed person instance.");
+        transformedPerson.Should().Be(stub.Results.Data.Items[0], "Should be same transformed person instance.");
     }
 
     [Fact]
@@ -84,17 +84,17 @@ public class TransformWithInlineUpdateFixture
         var person = new Person("Adult1", 50);
         stub.Source.AddOrUpdate(person);
 
-        var transformedPerson = stub.Results.Data.Items.First();
+        var transformedPerson = stub.Results.Data.Items[0];
 
         person.Age = 51;
         stub.Source.Refresh(person);
 
-        var updatedTransform = stub.Results.Data.Items.First();
+        var updatedTransform = stub.Results.Data.Items[0];
 
         updatedTransform.Age.Should().Be(51, "Age should be updated from 50 to 51.");
         stub.Results.Messages.Count.Should().Be(2, "Should be 2 updates");
         stub.Results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        transformedPerson.Should().Be(stub.Results.Data.Items.First(), "Should be same transformed person instance.");
+        transformedPerson.Should().Be(stub.Results.Data.Items[0], "Should be same transformed person instance.");
     }
 
     private class TransformWithInlineUpdateFixtureStub : IDisposable

--- a/src/DynamicData.Tests/Cache/WatchFixture.cs
+++ b/src/DynamicData.Tests/Cache/WatchFixture.cs
@@ -26,7 +26,7 @@ public class WatchFixture : IDisposable
 
         _results.Messages.Count.Should().Be(1, "Should be 1 updates");
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
-        _results.Data.Items.First().IsDisposed.Should().Be(false, "Should not be disposed");
+        _results.Data.Items[0].IsDisposed.Should().Be(false, "Should not be disposed");
     }
 
     public void Dispose()

--- a/src/DynamicData.Tests/Cache/WatcherFixture.cs
+++ b/src/DynamicData.Tests/Cache/WatcherFixture.cs
@@ -57,7 +57,7 @@ public class WatcherFixture : IDisposable
         _results.Data.Count.Should().Be(1, "Should be 1 item in the cache");
 
         _scheduler.AdvanceBy(TimeSpan.FromMilliseconds(50).Ticks);
-        var result = _results.Data.Items.First();
+        var result = _results.Data.Items[0];
         result.UpdateCount.Should().Be(1, "Person should have received 1 update");
         result.Completed.Should().Be(false, "Person should have received 1 update");
     }

--- a/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
+++ b/src/DynamicData.Tests/List/MergeManyChangeSetsCacheFixture.cs
@@ -835,7 +835,7 @@ public sealed class MergeManyChangeSetsCacheFixture : IDisposable
 
         // These should be subsets of each other
         expectedPrices.Should().BeSubsetOf(priceResults.Data.Items);
-        priceResults.Data.Items.Count().Should().Be(expectedPrices.Count);
+        priceResults.Data.Items.Count.Should().Be(expectedPrices.Count);
     }
 
     private void DisposeMarkets()

--- a/src/DynamicData.Tests/Utilities/TestSourceCache.cs
+++ b/src/DynamicData.Tests/Utilities/TestSourceCache.cs
@@ -32,17 +32,17 @@ public sealed class TestSourceCache<TObject, TKey>
     public IObservable<int> CountChanged
         => _countChanged;
 
-    public IEnumerable<TObject> Items
+    public IReadOnlyList<TObject> Items
         => _source.Items;
     
-    public IEnumerable<TKey> Keys
+    public IReadOnlyList<TKey> Keys
         => _source.Keys;
 
     public Func<TObject, TKey> KeySelector
         => _source.KeySelector;
 
-    public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues
-        => KeyValues;
+    public IReadOnlyDictionary<TKey, TObject> KeyValues
+        => _source.KeyValues;
 
     public void Complete()
     {

--- a/src/DynamicData/Cache/ChangeAwareCache.cs
+++ b/src/DynamicData/Cache/ChangeAwareCache.cs
@@ -63,6 +63,8 @@ public sealed class ChangeAwareCache<TObject, TKey> : ICache<TObject, TKey>
     /// <inheritdoc />
     public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _data;
 
+    internal Dictionary<TKey, TObject> GetDictionary() => _data;
+
     /// <summary>
     /// Adds the item to the cache without checking whether there is an existing value in the cache.
     /// </summary>

--- a/src/DynamicData/Cache/IObservableCache.cs
+++ b/src/DynamicData/Cache/IObservableCache.cs
@@ -24,17 +24,17 @@ public interface IObservableCache<TObject, TKey> : IConnectableCache<TObject, TK
     /// <summary>
     /// Gets the Items.
     /// </summary>
-    IEnumerable<TObject> Items { get; }
+    IReadOnlyList<TObject> Items { get; }
 
     /// <summary>
     /// Gets the keys.
     /// </summary>
-    IEnumerable<TKey> Keys { get; }
+    IReadOnlyList<TKey> Keys { get; }
 
     /// <summary>
     /// Gets the key value pairs.
     /// </summary>
-    IEnumerable<KeyValuePair<TKey, TObject>> KeyValues { get; }
+    IReadOnlyDictionary<TKey, TObject> KeyValues { get; }
 
     /// <summary>
     /// Lookup a single item using the specified key.

--- a/src/DynamicData/Cache/IntermediateCache.cs
+++ b/src/DynamicData/Cache/IntermediateCache.cs
@@ -46,13 +46,13 @@ public sealed class IntermediateCache<TObject, TKey> : IIntermediateCache<TObjec
     public IObservable<int> CountChanged => _innerCache.CountChanged;
 
     /// <inheritdoc />
-    public IEnumerable<TObject> Items => _innerCache.Items;
+    public IReadOnlyList<TObject> Items => _innerCache.Items;
 
     /// <inheritdoc />
-    public IEnumerable<TKey> Keys => _innerCache.Keys;
+    public IReadOnlyList<TKey> Keys => _innerCache.Keys;
 
     /// <inheritdoc />
-    public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _innerCache.KeyValues;
+    public IReadOnlyDictionary<TKey, TObject> KeyValues => _innerCache.KeyValues;
 
     /// <inheritdoc />
     public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true)

--- a/src/DynamicData/Cache/Internal/AnonymousObservableCache.cs
+++ b/src/DynamicData/Cache/Internal/AnonymousObservableCache.cs
@@ -37,11 +37,11 @@ internal sealed class AnonymousObservableCache<TObject, TKey> : IObservableCache
 
     public IObservable<int> CountChanged => _cache.CountChanged;
 
-    public IEnumerable<TObject> Items => _cache.Items;
+    public IReadOnlyList<TObject> Items => _cache.Items;
 
-    public IEnumerable<TKey> Keys => _cache.Keys;
+    public IReadOnlyList<TKey> Keys => _cache.Keys;
 
-    public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _cache.KeyValues;
+    public IReadOnlyDictionary<TKey, TObject> KeyValues => _cache.KeyValues;
 
     public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true)
         => _cache.Connect(predicate, suppressEmptyChangeSets);

--- a/src/DynamicData/Cache/Internal/LockFreeObservableCache.cs
+++ b/src/DynamicData/Cache/Internal/LockFreeObservableCache.cs
@@ -84,13 +84,13 @@ public sealed class LockFreeObservableCache<TObject, TKey> : IObservableCache<TO
     public IObservable<int> CountChanged => _countChanged.StartWith(_innerCache.Count).DistinctUntilChanged();
 
     /// <inheritdoc />
-    public IEnumerable<TObject> Items => _innerCache.Items;
+    public IReadOnlyList<TObject> Items => _innerCache.Items.ToArray();
 
     /// <inheritdoc />
-    public IEnumerable<TKey> Keys => _innerCache.Keys;
+    public IReadOnlyList<TKey> Keys => _innerCache.Keys.ToArray();
 
     /// <inheritdoc />
-    public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _innerCache.KeyValues;
+    public IReadOnlyDictionary<TKey, TObject> KeyValues => new Dictionary<TKey, TObject>(_innerCache.GetDictionary());
 
     /// <inheritdoc />
     public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) => Observable.Defer(

--- a/src/DynamicData/Cache/Internal/ReaderWriter.cs
+++ b/src/DynamicData/Cache/Internal/ReaderWriter.cs
@@ -49,13 +49,13 @@ internal sealed class ReaderWriter<TObject, TKey>(Func<TObject, TKey>? keySelect
         }
     }
 
-    public KeyValuePair<TKey, TObject>[] KeyValues
+    public IReadOnlyDictionary<TKey, TObject> KeyValues
     {
         get
         {
             lock (_locker)
             {
-                return [.. _data];
+                return new Dictionary<TKey, TObject>(_data);
             }
         }
     }

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -115,11 +115,11 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 }
             });
 
-    public IEnumerable<TObject> Items => _readerWriter.Items;
+    public IReadOnlyList<TObject> Items => _readerWriter.Items;
 
-    public IEnumerable<TKey> Keys => _readerWriter.Keys;
+    public IReadOnlyList<TKey> Keys => _readerWriter.Keys;
 
-    public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _readerWriter.KeyValues;
+    public IReadOnlyDictionary<TKey, TObject> KeyValues => _readerWriter.KeyValues;
 
     public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) =>
         Observable.Create<IChangeSet<TObject, TKey>>(observer =>

--- a/src/DynamicData/Cache/SourceCache.cs
+++ b/src/DynamicData/Cache/SourceCache.cs
@@ -34,16 +34,16 @@ public sealed class SourceCache<TObject, TKey>(Func<TObject, TKey> keySelector) 
     public IObservable<int> CountChanged => _innerCache.CountChanged;
 
     /// <inheritdoc />
-    public IEnumerable<TObject> Items => _innerCache.Items;
+    public IReadOnlyList<TObject> Items => _innerCache.Items;
 
     /// <inheritdoc />
-    public IEnumerable<TKey> Keys => _innerCache.Keys;
+    public IReadOnlyList<TKey> Keys => _innerCache.Keys;
 
     /// <inheritdoc/>
     public Func<TObject, TKey> KeySelector { get; } = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
 
     /// <inheritdoc />
-    public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _innerCache.KeyValues;
+    public IReadOnlyDictionary<TKey, TObject> KeyValues => _innerCache.KeyValues;
 
     /// <inheritdoc />
     public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) => _innerCache.Connect(predicate, suppressEmptyChangeSets);


### PR DESCRIPTION
Similar to the recent PR to expose list items as a read only list, this PR changes the observable cache to use readonly collections.

We now have theses exposed 

```cs
IReadOnlyList<TObject> Items { get; }
IReadOnlyList<TKey> Keys { get; }
IReadOnlyDictionary<TKey, TObject> KeyValues { get; }
```

instead of raw IEnumerables