### PR TITLE
Fix for #925

### DIFF
--- a/src/DynamicData.Tests/Cache/TransformImmutableFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformImmutableFixture.cs
@@ -267,6 +267,26 @@ public sealed class TransformImmutableFixture
         results.IsCompleted.Should().BeFalse();
     }
 
+    // https://github.com/reactivemarbles/DynamicData/issues/925
+    [Fact]
+    public void TDestinationIsValueType_DoesNotThrowException()
+    {
+        using var source = new Subject<IChangeSet<string, string>>();
+
+        using var results = source
+            .TransformImmutable(transformFactory: static value => value.Length)
+            .AsAggregator();
+
+
+        source.OnNext(new ChangeSet<string, string>()
+        {
+            new(reason: ChangeReason.Add, key: "Item #1", current: "Item #1", index: 0)
+        });
+
+        results.Error.Should().BeNull();
+        results.Messages.Count.Should().Be(1, "1 source operation was performed");
+    }
+
     private class Item
     {
         public static readonly Func<Item, int> IdSelector

--- a/src/DynamicData/Cache/Internal/TransformImmutable.cs
+++ b/src/DynamicData/Cache/Internal/TransformImmutable.cs
@@ -5,6 +5,8 @@
 using System.Reactive;
 using System.Reactive.Linq;
 
+using DynamicData.Kernel;
+
 namespace DynamicData.Cache.Internal;
 
 internal sealed class TransformImmutable<TDestination, TSource, TKey>
@@ -40,7 +42,7 @@ internal sealed class TransformImmutable<TDestination, TSource, TKey>
                                 current: _transformFactory.Invoke(change.Current),
                                 previous: change.Previous.HasValue
                                     ? _transformFactory.Invoke(change.Previous.Value)
-                                    : default,
+                                    : Optional.None<TDestination>(),
                                 currentIndex: change.CurrentIndex,
                                 previousIndex: change.PreviousIndex));
                         }


### PR DESCRIPTION
Fixed a bogus use of the `default` keyword, within a ternary expression where implicit casting of a generic is in play. The expression compiles differently depending on whether the generic type in question is a value type, versus a reference type, and generates an exception in the case of a value type.