### PR TITLE
Fix for #929

### DIFF
--- a/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
+++ b/src/DynamicData/Binding/SortedObservableCollectionAdaptor.cs
@@ -68,7 +68,7 @@ public class SortedObservableCollectionAdaptor<TObject, TKey>(int refreshThresho
                 break;
 
             case SortReason.InitialLoad:
-                if (resetOnFirstTimeLoad && (changes.Count - changes.Refreshes > refreshThreshold))
+                if (resetOnFirstTimeLoad || (changes.Count - changes.Refreshes > refreshThreshold))
                 {
                     using (collection.SuspendNotifications())
                     {


### PR DESCRIPTION
Fixed that `.Bind()` operators for `ISortedChangeSet<TObject, TKey>` streams were not properly recognizing the `ResetOnFirstTimeLoad` option. The option was only being used if the initial changeset also exceeded the `ResetThreshold` setting.

Resolves #929.