### PR TITLE
SortAndBind fixes and improvements

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -473,7 +473,9 @@ namespace DynamicData.Binding
     {
         public SortAndBindOptions() { }
         public int InitialCapacity { get; init; }
+        public bool ResetOnFirstTimeLoad { get; init; }
         public int ResetThreshold { get; init; }
+        public System.Reactive.Concurrency.IScheduler? Scheduler { get; init; }
         public bool UseBinarySearch { get; init; }
         public bool UseReplaceForUpdates { get; init; }
     }

--- a/src/DynamicData/Binding/BindingListEventsSuspender.cs
+++ b/src/DynamicData/Binding/BindingListEventsSuspender.cs
@@ -2,30 +2,26 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if SUPPORTS_BINDINGLIST
 using System.ComponentModel;
 using System.Reactive.Disposables;
 
-namespace DynamicData.Binding
+namespace DynamicData.Binding;
+
+internal sealed class BindingListEventsSuspender<T> : IDisposable
 {
-    internal sealed class BindingListEventsSuspender<T> : IDisposable
+    private readonly IDisposable _cleanUp;
+
+    public BindingListEventsSuspender(BindingList<T> list)
     {
-        private readonly IDisposable _cleanUp;
+        list.RaiseListChangedEvents = false;
 
-        public BindingListEventsSuspender(BindingList<T> list)
-        {
-            list.RaiseListChangedEvents = false;
-
-            _cleanUp = Disposable.Create(
-                () =>
-                    {
-                        list.RaiseListChangedEvents = true;
-                        list.ResetBindings();
-                    });
-        }
-
-        public void Dispose() => _cleanUp.Dispose();
+        _cleanUp = Disposable.Create(
+            () =>
+            {
+                list.RaiseListChangedEvents = true;
+                list.ResetBindings();
+            });
     }
-}
 
-#endif
+    public void Dispose() => _cleanUp.Dispose();
+}

--- a/src/DynamicData/Binding/SortAndBind.cs
+++ b/src/DynamicData/Binding/SortAndBind.cs
@@ -2,6 +2,7 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Cache;
@@ -33,12 +34,17 @@ internal sealed class SortAndBind<TObject, TKey>
         // static one time comparer
         var applicator = new SortApplicator(_cache, target, comparer, options);
 
-        _sorted = source.Do(changes =>
+        if (options.Scheduler is not null)
+            source = source.ObserveOn(options.Scheduler);
+
+        _sorted = source.Select((changes, index) =>
         {
             // clone to local cache so that we can sort the entire set when threshold is over a certain size.
             _cache.Clone(changes);
 
-            applicator.ProcessChanges(changes);
+            applicator.ProcessChanges(changes, index == 0);
+
+            return changes;
         });
     }
 
@@ -48,6 +54,9 @@ internal sealed class SortAndBind<TObject, TKey>
         IList<TObject> target)
         => _sorted = Observable.Create<IChangeSet<TObject, TKey>>(observer =>
         {
+            if (options.Scheduler is not null)
+                source = source.ObserveOn(options.Scheduler);
+
             var locker = new object();
             SortApplicator? sortApplicator = null;
 
@@ -61,14 +70,17 @@ internal sealed class SortAndBind<TObject, TKey>
 
             // Listen to changes and apply the sorting
             var subscriber = source.Synchronize(locker)
-                .Do(changes =>
+                .Select((changes, index) =>
                 {
                     _cache.Clone(changes);
 
                     // the sort applicator will be null until the comparer change observable fires.
                     if (sortApplicator is not null)
-                        sortApplicator.ProcessChanges(changes);
-                }).SubscribeSafe(observer);
+                        sortApplicator.ProcessChanges(changes, index == 0);
+
+                    return changes;
+                })
+                .SubscribeSafe(observer);
 
             return new CompositeDisposable(latestComparer, subscriber);
         });
@@ -92,10 +104,12 @@ internal sealed class SortAndBind<TObject, TKey>
         }
 
         // apply sorting as a side effect of the observable stream.
-        public void ProcessChanges(IChangeSet<TObject, TKey> changeSet)
+        public void ProcessChanges(IChangeSet<TObject, TKey> changeSet, bool isFirstTimeLoad)
         {
+            var forceReset = isFirstTimeLoad && options.ResetOnFirstTimeLoad;
+
             // apply sorted changes to the target collection
-            if (options.ResetThreshold > 0 && options.ResetThreshold < changeSet.Count)
+            if (forceReset || (options.ResetThreshold > 0 && options.ResetThreshold < changeSet.Count))
             {
                 Reset(cache.Items.OrderBy(t => t, comparer), true);
             }
@@ -120,6 +134,15 @@ internal sealed class SortAndBind<TObject, TKey>
                 using (observableCollectionExtended.SuspendNotifications())
                 {
                     observableCollectionExtended.Load(sorted);
+                }
+            }
+            else if (fireReset && target is BindingList<TObject> bindingList)
+            {
+                // suspend count as it can result in a flood of binding updates.
+                using (new BindingListEventsSuspender<TObject>(bindingList))
+                {
+                    target.Clear();
+                    target.AddRange(sorted);
                 }
             }
             else

--- a/src/DynamicData/Binding/SortAndBindOptions.cs
+++ b/src/DynamicData/Binding/SortAndBindOptions.cs
@@ -2,6 +2,8 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reactive.Concurrency;
+
 namespace DynamicData.Binding;
 
 /// <summary>
@@ -28,4 +30,18 @@ public record struct SortAndBindOptions()
     /// Set the initial capacity of the readonly observable collection.
     /// </summary>
     public int InitialCapacity { get; init; } = -1;
+
+    /// <summary>
+    /// Reset on first time load.
+    ///
+    /// This is opt-in only and is only required for consumers who need to maintain
+    /// backwards compatibility will the former  BindingOptions.ResetOnFirstTimeLoad.
+    /// </summary>
+    public bool ResetOnFirstTimeLoad { get; init; }
+
+    /// <summary>
+    /// The default main thread scheduler.  If left null, it is the responsibility of the consumer
+    /// to ensure binding takes place on the main thread.
+    /// </summary>
+    public IScheduler? Scheduler { get; init; }
 }

--- a/src/DynamicData/List/ListEx.cs
+++ b/src/DynamicData/List/ListEx.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;
-
+using System.ComponentModel;
 using DynamicData.Kernel;
 
 // ReSharper disable once CheckNamespace
@@ -101,7 +101,8 @@ public static class ListEx
                 extendedList.AddRange(items);
                 break;
             default:
-                items.ForEach(source.Add);
+                foreach (var t in items)
+                    source.Add(t);
                 break;
         }
     }


### PR DESCRIPTION
- Enable opt-in to ResetOnFirstTimeLoad to ensure backwards compatibility with the old `Sort(...).Bind(...)` behaviour.

To opt-in system-wide after upgrading from v8 to v9 (and migrating to SortAndBind) like this:

```cs
DynamicDataOptions.SortAndBind = DynamicDataOptions.SortAndBind with { ResetOnFirstTimeLoad = true };
```

- Specialised handing for BindingList<T> when used with `SortAndBind`, to ensure reset is respected.

- Specify SortAndBind scheduler at a system with level.

```cs
DynamicDataOptions.SortAndBind = DynamicDataOptions.SortAndBindwith { Scheduler= myMainThreadScheduler };
```

With this ObserveOn(myMainThreadScheduler) will be a thing of the past.