### PR TITLE
Fix for #966

### DIFF
--- a/src/DynamicData.Tests/Cache/SwitchFixture.cs
+++ b/src/DynamicData.Tests/Cache/SwitchFixture.cs
@@ -10,54 +10,83 @@ using Xunit;
 
 namespace DynamicData.Tests.Cache;
 
-public class SwitchFixture : IDisposable
+public class SwitchFixture
 {
-    private readonly ChangeSetAggregator<Person, string> _results;
-
-    private readonly ISourceCache<Person, string> _source;
-
-    private readonly ISubject<ISourceCache<Person, string>> _switchable;
-
-    public SwitchFixture()
-    {
-        _source = new SourceCache<Person, string>(p => p.Name);
-        _switchable = new BehaviorSubject<ISourceCache<Person, string>>(_source);
-        _results = _switchable.Switch().AsAggregator();
-    }
-
     [Fact]
     public void ClearsForNewSource()
     {
-        var inital = Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray();
-        _source.AddOrUpdate(inital);
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<ISourceCache<Person, string>>(source);
+        var results = switchable.Switch().AsAggregator();
 
-        _results.Data.Count.Should().Be(100);
+
+        var inital = Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray();
+        source.AddOrUpdate(inital);
+
+        results.Data.Count.Should().Be(100);
 
         var newSource = new SourceCache<Person, string>(p => p.Name);
-        _switchable.OnNext(newSource);
+        switchable.OnNext(newSource);
 
-        _results.Data.Count.Should().Be(0);
+        results.Data.Count.Should().Be(0);
 
         newSource.AddOrUpdate(inital);
-        _results.Data.Count.Should().Be(100);
+        results.Data.Count.Should().Be(100);
 
         var nextUpdates = Enumerable.Range(101, 100).Select(i => new Person("Person" + i, i)).ToArray();
         newSource.AddOrUpdate(nextUpdates);
-        _results.Data.Count.Should().Be(200);
-    }
-
-    public void Dispose()
-    {
-        _source.Dispose();
-        _results.Dispose();
+        results.Data.Count.Should().Be(200);
     }
 
     [Fact]
     public void PoulatesFirstSource()
     {
-        var inital = Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray();
-        _source.AddOrUpdate(inital);
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<ISourceCache<Person, string>>(source);
+        var results = switchable.Switch().AsAggregator();
 
-        _results.Data.Count.Should().Be(100);
+
+        var inital = Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray();
+        source.AddOrUpdate(inital);
+
+        results.Data.Count.Should().Be(100);
+    }
+
+    [Fact]
+    public void PropagatesOuterErrors()
+    {
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<ISourceCache<Person, string>>(source);
+        var results = switchable.Switch().AsAggregator();
+
+
+        var inital = Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray();
+        source.AddOrUpdate(inital);
+
+        var error = new Exception("Test");
+        switchable.OnError(error);
+
+        results.Error.Should().Be(error);
+    }
+
+    [Fact]
+    public void PropagatesInnerErrors()
+    {
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<Person, string>>>(source.Connect());
+        var results = switchable.Switch().AsAggregator();
+
+
+        var inital = Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray();
+        source.AddOrUpdate(inital);
+
+        using var source2 = new BehaviorSubject<IChangeSet<Person, string>>(ChangeSet<Person, string>.Empty);
+
+        switchable.OnNext(source2);
+
+        var error = new Exception("Test");
+        source2.OnError(error);
+
+        results.Error.Should().Be(error);
     }
 }


### PR DESCRIPTION
Fixed that .Switch() did not propagate errors downstream.