### PR TITLE
Fix sort exception when using binary search

### DIFF
--- a/src/DynamicData.Tests/Cache/SortAndBindFixture.cs
+++ b/src/DynamicData.Tests/Cache/SortAndBindFixture.cs
@@ -91,11 +91,22 @@ public sealed class SortAndBindToReadOnlyObservableCollection: SortAndBindFixtur
 }
 
 // Bind to a readonly observable collection using binary search
-public sealed class SortAndBindWithBinarySearch : SortAndBindFixture
+public sealed class SortAndBindWithBinarySearch1 : SortAndBindFixture
 {
     protected override (ChangeSetAggregator<Person, string> Aggregrator, IList<Person> List) SetUpTests()
     {
         var options = new SortAndBindOptions { UseBinarySearch = true, UseReplaceForUpdates = false};
+        var aggregator = _source.Connect().SortAndBind(out var list, _comparer, options).AsAggregator();
+
+        return (aggregator, list);
+    }
+}
+
+public sealed class SortAndBindWithBinarySearch2 : SortAndBindFixture
+{
+    protected override (ChangeSetAggregator<Person, string> Aggregrator, IList<Person> List) SetUpTests()
+    {
+        var options = new SortAndBindOptions { UseBinarySearch = true, UseReplaceForUpdates = true };
         var aggregator = _source.Connect().SortAndBind(out var list, _comparer, options).AsAggregator();
 
         return (aggregator, list);
@@ -609,32 +620,6 @@ public abstract class SortAndBindFixture : IDisposable
         int IndexFromKey(string key) => people.FindIndex(p => p.Key == key);
 
         people.OrderBy(p => p, _comparer).SequenceEqual(_boundList).Should().BeTrue();
-    }
-
-    [Fact]
-    public void SmallDataSet_UpdateLast()
-    {
-        List<Person> people = 
-            [
-                new Person("A", 11),
-                new Person("B", 10),
-                new Person("C", 9),
-            ];
-        _source.AddOrUpdate(people);
-
-       // var toUpdate = _boundList[^1];
-
-        _source.AddOrUpdate(new Person("C", 4));
-        _source.AddOrUpdate(new Person("C", 3));
-        _source.AddOrUpdate(new Person("C", 2));
-
-        var xxx = _boundList;
-
-        //eople[IndexFromKey(toUpdate.Key)] = new Person(toUpdate.Name, toUpdate.Age + 5);
-
-        //int IndexFromKey(string key) => people.FindIndex(p => p.Key == key);
-
-        //people.OrderBy(p => p, _comparer).SequenceEqual(_boundList).Should().BeTrue();
     }
 
 

--- a/src/DynamicData/Cache/Internal/SortExtensions.cs
+++ b/src/DynamicData/Cache/Internal/SortExtensions.cs
@@ -35,6 +35,17 @@ internal static class SortExtensions
         // sort is not returning uniqueness
         if (insertIndex < 0)
         {
+            /*
+             * Binary search should not strictly already contain the item (or an item with the same value) when
+             * attempting to find the insert position (it does for updates).  This can result in the insert position not being found.
+             * In this case revert to linear search.
+             */
+            index = list.GetInsertPositionLinear(t, c);
+            if (index >= 0)
+            {
+                return index;
+            }
+
             throw new SortException("Binary search has been specified, yet the sort does not yield uniqueness");
         }
 


### PR DESCRIPTION
Fix for a SortException being thrown bug in SortAndBind when using binary search.  This occurred when  trying to find an update position where the value of an object is the same before and after an update.  

The test mimics this scenario in the most simplistic scenario.  However,  in practise  this scenario was hit where the equality, hash code and comparer are the same value.

EDIT: The issue is easily replicated by sorting on key.  In this case an update causes the issue due to an ambiguous insert position