### PR TITLE
Add AOT Friendly Attributes for BindingList<T> Compatibility

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -312,13 +312,13 @@ namespace DynamicData.Binding
         [System.Obsolete("This never worked properly in the first place")]
         public System.IDisposable SuspendNotifications(bool invokePropertyChangeEventWhenDisposed = true) { }
     }
-    public class BindingListAdaptor<T> : DynamicData.IChangeSetAdaptor<T>
+    public class BindingListAdaptor<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  T> : DynamicData.IChangeSetAdaptor<T>
         where T :  notnull
     {
         public BindingListAdaptor(System.ComponentModel.BindingList<T> list, int refreshThreshold = 25) { }
         public void Adapt(DynamicData.IChangeSet<T> changes) { }
     }
-    public class BindingListAdaptor<TObject, TKey> : DynamicData.IChangeSetAdaptor<TObject, TKey>
+    public class BindingListAdaptor<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey> : DynamicData.IChangeSetAdaptor<TObject, TKey>
         where TObject :  notnull
         where TKey :  notnull
     {
@@ -499,7 +499,7 @@ namespace DynamicData.Binding
         public DynamicData.Binding.SortDirection Direction { get; }
         public System.Func<T, System.IComparable> Expression { get; }
     }
-    public class SortedBindingListAdaptor<TObject, TKey> : DynamicData.ISortedChangeSetAdaptor<TObject, TKey>
+    public class SortedBindingListAdaptor<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey> : DynamicData.ISortedChangeSetAdaptor<TObject, TKey>
         where TObject :  notnull
         where TKey :  notnull
     {
@@ -1167,16 +1167,16 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> BatchIf<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<bool> pauseIfTrueSelector, bool initialPauseState = false, System.TimeSpan? timeOut = default, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, DynamicData.Binding.IObservableCollection<TObject> destination)
@@ -1194,19 +1194,19 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.BindingOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.ComponentModel.BindingList<TObject> bindingList, int resetThreshold = 25)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.ComponentModel.BindingList<TObject> bindingList, int resetThreshold = 25)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, DynamicData.Binding.IObservableCollection<TObject> destination, DynamicData.Binding.BindingOptions options)
@@ -1218,7 +1218,7 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.BindingOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, System.ComponentModel.BindingList<TObject> bindingList, int resetThreshold = 25)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> source, System.ComponentModel.BindingList<TObject> bindingList, int resetThreshold = 25)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, int resetThreshold = 25, bool useReplaceForUpdates = true, DynamicData.Binding.IObservableCollectionAdaptor<TObject, TKey>? adaptor = null)
@@ -1779,40 +1779,40 @@ namespace DynamicData
         public static System.IObservable<DynamicData.ISortedChangeSet<TObject, TKey>> Sort<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerObservable, System.IObservable<System.Reactive.Unit> resorter, DynamicData.SortOptimisations sortOptimisations = 0, int resetThreshold = 100)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList)
             where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
             where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull, System.IComparable<TObject>
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.Collections.Generic.IComparer<TObject> comparer)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.Collections.Generic.IComparer<TObject> comparer)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.Collections.Generic.IComparer<TObject> comparer, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IList<TObject> targetList, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.Collections.Generic.IComparer<TObject> comparer, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.Collections.Generic.IComparer<TObject> comparer, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, DynamicData.Binding.SortAndBindOptions options)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> SortAndBind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<TObject> readOnlyObservableCollection, System.IObservable<System.Collections.Generic.IComparer<TObject>> comparerChanged, DynamicData.Binding.SortAndBindOptions options)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.PageContext<TObject>>> SortAndPage<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Collections.Generic.IComparer<TObject> comparer, System.IObservable<DynamicData.IPageRequest> pageRequests)
@@ -2280,7 +2280,7 @@ namespace DynamicData
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<T>> Bind<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, out System.Collections.ObjectModel.ReadOnlyObservableCollection<T> readOnlyObservableCollection, int resetThreshold = 25)
             where T :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<T>> Bind<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.ComponentModel.BindingList<T> bindingList, int resetThreshold = 25)
+        public static System.IObservable<DynamicData.IChangeSet<T>> Bind<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.ComponentModel.BindingList<T> bindingList, int resetThreshold = 25)
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<T>> BufferIf<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.IObservable<bool> pauseIfTrueSelector, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where T :  notnull { }

--- a/src/DynamicData/Binding/BindPaged.cs
+++ b/src/DynamicData/Binding/BindPaged.cs
@@ -2,7 +2,7 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Concurrency;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -14,7 +14,7 @@ namespace DynamicData.Binding;
  *
  * (Direct lift from BindVirtualized).
  */
-internal sealed class BindPaged<TObject, TKey>(
+internal sealed class BindPaged<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
     IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
     IList<TObject> targetList,
     SortAndBindOptions? options)

--- a/src/DynamicData/Binding/BindVirtualized.cs
+++ b/src/DynamicData/Binding/BindVirtualized.cs
@@ -2,7 +2,7 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Concurrency;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -12,7 +12,7 @@ namespace DynamicData.Binding;
 /*
  * Binding for the result of the SortAndVirtualize operator
  */
-internal sealed class BindVirtualized<TObject, TKey>(
+internal sealed class BindVirtualized<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
     IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
     IList<TObject> targetList,
     SortAndBindOptions? options)

--- a/src/DynamicData/Binding/BindingListAdaptor.cs
+++ b/src/DynamicData/Binding/BindingListAdaptor.cs
@@ -8,120 +8,119 @@ using System.Diagnostics.CodeAnalysis;
 using DynamicData.Cache;
 using DynamicData.Cache.Internal;
 
-namespace DynamicData.Binding
+namespace DynamicData.Binding;
+
+/// <summary>
+/// Adaptor to reflect a change set into a binding list.
+/// </summary>
+/// <typeparam name="T">The type of items.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="BindingListAdaptor{T}"/> class.
+/// </remarks>
+/// <param name="list">The list of items to add to the adapter.</param>
+/// <param name="refreshThreshold">The threshold before a reset is issued.</param>
+public class BindingListAdaptor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(BindingList<T> list, int refreshThreshold = BindingOptions.DefaultResetThreshold) : IChangeSetAdaptor<T>
+    where T : notnull
 {
-    /// <summary>
-    /// Adaptor to reflect a change set into a binding list.
-    /// </summary>
-    /// <typeparam name="T">The type of items.</typeparam>
-    /// <remarks>
-    /// Initializes a new instance of the <see cref="BindingListAdaptor{T}"/> class.
-    /// </remarks>
-    /// <param name="list">The list of items to add to the adapter.</param>
-    /// <param name="refreshThreshold">The threshold before a reset is issued.</param>
-    public class BindingListAdaptor<T>(BindingList<T> list, int refreshThreshold = BindingOptions.DefaultResetThreshold) : IChangeSetAdaptor<T>
-        where T : notnull
+    private readonly BindingList<T> _list = list ?? throw new ArgumentNullException(nameof(list));
+    private bool _loaded;
+
+    /// <inheritdoc />
+    public void Adapt(IChangeSet<T> changes)
     {
-        private readonly BindingList<T> _list = list ?? throw new ArgumentNullException(nameof(list));
-        private bool _loaded;
+        changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
 
-        /// <inheritdoc />
-        public void Adapt(IChangeSet<T> changes)
+        if (changes.TotalChanges - changes.Refreshes > refreshThreshold || !_loaded)
         {
-            changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
-
-            if (changes.TotalChanges - changes.Refreshes > refreshThreshold || !_loaded)
-            {
-                using (new BindingListEventsSuspender<T>(_list))
-                {
-                    _list.Clone(changes);
-                    _loaded = true;
-                }
-            }
-            else
+            using (new BindingListEventsSuspender<T>(_list))
             {
                 _list.Clone(changes);
+                _loaded = true;
             }
+        }
+        else
+        {
+            _list.Clone(changes);
+        }
+    }
+}
+
+/// <summary>
+/// Adaptor to reflect a change set into a binding list.
+/// </summary>
+/// <typeparam name="TObject">The type of the object.</typeparam>
+/// <typeparam name="TKey">The type of the key.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="BindingListAdaptor{TObject, TKey}"/> class.
+/// </remarks>
+/// <param name="list">The list of items to adapt.</param>
+/// <param name="refreshThreshold">The threshold before the refresh is triggered.</param>
+[SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Same class name, different generics")]
+public class BindingListAdaptor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(BindingList<TObject> list, int refreshThreshold = BindingOptions.DefaultResetThreshold) : IChangeSetAdaptor<TObject, TKey>
+    where TObject : notnull
+    where TKey : notnull
+{
+    private readonly Cache<TObject, TKey> _cache = new();
+
+    private readonly BindingList<TObject> _list = list ?? throw new ArgumentNullException(nameof(list));
+    private bool _loaded;
+
+    /// <inheritdoc />
+    public void Adapt(IChangeSet<TObject, TKey> changes)
+    {
+        changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
+        _cache.Clone(changes);
+
+        if (changes.Count - changes.Refreshes > refreshThreshold || !_loaded)
+        {
+            using (new BindingListEventsSuspender<TObject>(_list))
+            {
+                _list.Clear();
+                _list.AddRange(_cache.Items);
+                _loaded = true;
+            }
+        }
+        else
+        {
+            DoUpdate(changes, _list);
         }
     }
 
-    /// <summary>
-    /// Adaptor to reflect a change set into a binding list.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <remarks>
-    /// Initializes a new instance of the <see cref="BindingListAdaptor{TObject, TKey}"/> class.
-    /// </remarks>
-    /// <param name="list">The list of items to adapt.</param>
-    /// <param name="refreshThreshold">The threshold before the refresh is triggered.</param>
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Same class name, different generics")]
-    public class BindingListAdaptor<TObject, TKey>(BindingList<TObject> list, int refreshThreshold = BindingOptions.DefaultResetThreshold) : IChangeSetAdaptor<TObject, TKey>
-        where TObject : notnull
-        where TKey : notnull
+    private static void DoUpdate(IChangeSet<TObject, TKey> changes, BindingList<TObject> list)
     {
-        private readonly Cache<TObject, TKey> _cache = new();
-
-        private readonly BindingList<TObject> _list = list ?? throw new ArgumentNullException(nameof(list));
-        private bool _loaded;
-
-        /// <inheritdoc />
-        public void Adapt(IChangeSet<TObject, TKey> changes)
+        foreach (var update in changes.ToConcreteType())
         {
-            changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
-            _cache.Clone(changes);
+            switch (update.Reason)
+            {
+                case ChangeReason.Add:
+                    list.Add(update.Current);
+                    break;
 
-            if (changes.Count - changes.Refreshes > refreshThreshold || !_loaded)
-            {
-                using (new BindingListEventsSuspender<TObject>(_list))
-                {
-                    _list.Clear();
-                    _list.AddRange(_cache.Items);
-                    _loaded = true;
-                }
-            }
-            else
-            {
-                DoUpdate(changes, _list);
-            }
-        }
+                case ChangeReason.Remove:
+                    list.Remove(update.Current);
+                    break;
 
-        private static void DoUpdate(IChangeSet<TObject, TKey> changes, BindingList<TObject> list)
-        {
-            foreach (var update in changes.ToConcreteType())
-            {
-                switch (update.Reason)
-                {
-                    case ChangeReason.Add:
+                case ChangeReason.Update:
+                    var previousIndex = list.IndexOf(update.Previous.Value);
+                    if (previousIndex >= 0)
+                    {
+                        list[previousIndex] = update.Current;
+                    }
+                    else
+                    {
                         list.Add(update.Current);
-                        break;
+                    }
 
-                    case ChangeReason.Remove:
-                        list.Remove(update.Current);
-                        break;
+                    break;
 
-                    case ChangeReason.Update:
-                        var previousIndex = list.IndexOf(update.Previous.Value);
-                        if (previousIndex >= 0)
-                        {
-                            list[previousIndex] = update.Current;
-                        }
-                        else
-                        {
-                            list.Add(update.Current);
-                        }
+                case ChangeReason.Refresh:
+                    var index = list.IndexOf(update.Current);
+                    if (index != -1)
+                    {
+                        list.ResetItem(index);
+                    }
 
-                        break;
-
-                    case ChangeReason.Refresh:
-                        var index = list.IndexOf(update.Current);
-                        if (index != -1)
-                        {
-                            list.ResetItem(index);
-                        }
-
-                        break;
-                }
+                    break;
             }
         }
     }

--- a/src/DynamicData/Binding/BindingListEventsSuspender.cs
+++ b/src/DynamicData/Binding/BindingListEventsSuspender.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
 
 namespace DynamicData.Binding;
 
-internal sealed class BindingListEventsSuspender<T> : IDisposable
+internal sealed class BindingListEventsSuspender<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IDisposable
 {
     private readonly IDisposable _cleanUp;
 

--- a/src/DynamicData/Binding/SortAndBind.cs
+++ b/src/DynamicData/Binding/SortAndBind.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Cache;
@@ -17,7 +18,7 @@ namespace DynamicData.Binding;
  * collection upon every change in order that the sorted list could be transmitted to the bind operator.
  *
  */
-internal sealed class SortAndBind<TObject, TKey>
+internal sealed class SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>
     where TObject : notnull
     where TKey : notnull
 {

--- a/src/DynamicData/Binding/SortedBindingListAdaptor.cs
+++ b/src/DynamicData/Binding/SortedBindingListAdaptor.cs
@@ -4,118 +4,118 @@
 
 #if SUPPORTS_BINDINGLIST
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
-namespace DynamicData.Binding
+namespace DynamicData.Binding;
+
+/// <summary>
+/// Represents an adaptor which is used to update a binding list from
+/// a sorted change set.
+/// </summary>
+/// <typeparam name="TObject">The type of object.</typeparam>
+/// <typeparam name="TKey">The type of key.</typeparam>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SortedBindingListAdaptor{TObject, TKey}"/> class.
+/// </remarks>
+/// <param name="list">The source list.</param>
+/// <param name="refreshThreshold">The threshold before a refresh is triggered.</param>
+public class SortedBindingListAdaptor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(BindingList<TObject> list, int refreshThreshold = 25) : ISortedChangeSetAdaptor<TObject, TKey>
+    where TObject : notnull
+    where TKey : notnull
 {
-    /// <summary>
-    /// Represents an adaptor which is used to update a binding list from
-    /// a sorted change set.
-    /// </summary>
-    /// <typeparam name="TObject">The type of object.</typeparam>
-    /// <typeparam name="TKey">The type of key.</typeparam>
-    /// <remarks>
-    /// Initializes a new instance of the <see cref="SortedBindingListAdaptor{TObject, TKey}"/> class.
-    /// </remarks>
-    /// <param name="list">The source list.</param>
-    /// <param name="refreshThreshold">The threshold before a refresh is triggered.</param>
-    public class SortedBindingListAdaptor<TObject, TKey>(BindingList<TObject> list, int refreshThreshold = 25) : ISortedChangeSetAdaptor<TObject, TKey>
-        where TObject : notnull
-        where TKey : notnull
+    private readonly BindingList<TObject> _list = list ?? throw new ArgumentNullException(nameof(list));
+
+    /// <inheritdoc />
+    public void Adapt(ISortedChangeSet<TObject, TKey> changes)
     {
-        private readonly BindingList<TObject> _list = list ?? throw new ArgumentNullException(nameof(list));
+        changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
 
-        /// <inheritdoc />
-        public void Adapt(ISortedChangeSet<TObject, TKey> changes)
+        switch (changes.SortedItems.SortReason)
         {
-            changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
+            case SortReason.InitialLoad:
+            case SortReason.ComparerChanged:
+            case SortReason.Reset:
+                using (new BindingListEventsSuspender<TObject>(_list))
+                {
+                    _list.Clear();
+                    _list.AddRange(changes.SortedItems.Select(kv => kv.Value));
+                }
 
-            switch (changes.SortedItems.SortReason)
-            {
-                case SortReason.InitialLoad:
-                case SortReason.ComparerChanged:
-                case SortReason.Reset:
+                break;
+
+            case SortReason.DataChanged:
+                if (changes.Count - changes.Refreshes > refreshThreshold)
+                {
                     using (new BindingListEventsSuspender<TObject>(_list))
                     {
                         _list.Clear();
                         _list.AddRange(changes.SortedItems.Select(kv => kv.Value));
                     }
+                }
+                else
+                {
+                    DoUpdate(changes);
+                }
 
+                break;
+
+            case SortReason.Reorder:
+                DoUpdate(changes);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(changes));
+        }
+    }
+
+    private void DoUpdate(ISortedChangeSet<TObject, TKey> changes)
+    {
+        foreach (var change in changes)
+        {
+            switch (change.Reason)
+            {
+                case ChangeReason.Add:
+                    _list.Insert(change.CurrentIndex, change.Current);
                     break;
 
-                case SortReason.DataChanged:
-                    if (changes.Count - changes.Refreshes > refreshThreshold)
+                case ChangeReason.Remove:
+                    _list.RemoveAt(change.CurrentIndex);
+                    break;
+
+                case ChangeReason.Moved:
+                    _list.RemoveAt(change.PreviousIndex);
+                    _list.Insert(change.CurrentIndex, change.Current);
+                    break;
+
+                case ChangeReason.Update:
+                    if (change.CurrentIndex != change.PreviousIndex)
                     {
-                        using (new BindingListEventsSuspender<TObject>(_list))
-                        {
-                            _list.Clear();
-                            _list.AddRange(changes.SortedItems.Select(kv => kv.Value));
-                        }
+                        _list.RemoveAt(change.PreviousIndex);
+                        _list.Insert(change.CurrentIndex, change.Current);
                     }
                     else
                     {
-                        DoUpdate(changes);
+                        var previousIndex = _list.IndexOf(change.Previous.Value);
+                        if (previousIndex >= 0)
+                        {
+                            _list[previousIndex] = change.Current;
+                        }
+                        else
+                        {
+                            _list.Add(change.Current);
+                        }
                     }
 
                     break;
 
-                case SortReason.Reorder:
-                    DoUpdate(changes);
+                case ChangeReason.Refresh:
+                    var index = _list.IndexOf(change.Current);
+                    if (index != -1)
+                    {
+                        _list.ResetItem(index);
+                    }
+
                     break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(changes));
-            }
-        }
-
-        private void DoUpdate(ISortedChangeSet<TObject, TKey> changes)
-        {
-            foreach (var change in changes)
-            {
-                switch (change.Reason)
-                {
-                    case ChangeReason.Add:
-                        _list.Insert(change.CurrentIndex, change.Current);
-                        break;
-
-                    case ChangeReason.Remove:
-                        _list.RemoveAt(change.CurrentIndex);
-                        break;
-
-                    case ChangeReason.Moved:
-                        _list.RemoveAt(change.PreviousIndex);
-                        _list.Insert(change.CurrentIndex, change.Current);
-                        break;
-
-                    case ChangeReason.Update:
-                        if (change.CurrentIndex != change.PreviousIndex)
-                        {
-                            _list.RemoveAt(change.PreviousIndex);
-                            _list.Insert(change.CurrentIndex, change.Current);
-                        }
-                        else
-                        {
-                            var previousIndex = _list.IndexOf(change.Previous.Value);
-                            if (previousIndex >= 0)
-                            {
-                                _list[previousIndex] = change.Current;
-                            }
-                            else
-                            {
-                                _list.Add(change.Current);
-                            }
-                        }
-
-                        break;
-
-                    case ChangeReason.Refresh:
-                        var index = _list.IndexOf(change.Current);
-                        if (index != -1)
-                        {
-                            _list.ResetItem(index);
-                        }
-
-                        break;
-                }
             }
         }
     }

--- a/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.SortAndBind.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;
-using System.Reactive.Concurrency;
+using System.Diagnostics.CodeAnalysis;
 using DynamicData.Binding;
 
 namespace DynamicData;
@@ -21,7 +21,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
         where TObject : notnull
@@ -42,7 +42,7 @@ public static partial class ObservableCacheEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         SortAndBindOptions options)
@@ -63,7 +63,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="targetList">The list to bind to.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
         IList<TObject> targetList)
         where TObject : notnull
@@ -79,7 +79,7 @@ public static partial class ObservableCacheEx
     /// <param name="targetList">The list to bind to.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, PageContext<TObject>>> source,
         IList<TObject> targetList,
         SortAndBindOptions options)
@@ -95,7 +95,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
         where TObject : notnull
@@ -116,7 +116,7 @@ public static partial class ObservableCacheEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         SortAndBindOptions options)
@@ -137,7 +137,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="targetList">The list to bind to.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         IList<TObject> targetList)
         where TObject : notnull
@@ -153,7 +153,7 @@ public static partial class ObservableCacheEx
     /// <param name="targetList">The list to bind to.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>> source,
         IList<TObject> targetList,
         SortAndBindOptions options)
@@ -169,7 +169,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="targetList">The list to bind to.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList)
         where TObject : notnull, IComparable<TObject>
@@ -185,7 +185,7 @@ public static partial class ObservableCacheEx
     /// <param name="targetList">The list to bind to.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList,
         SortAndBindOptions options)
@@ -202,7 +202,7 @@ public static partial class ObservableCacheEx
     /// <param name="targetList">The list to bind to.</param>
     /// <param name="comparer">The comparer to order the resulting dataset.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList,
         IComparer<TObject> comparer)
@@ -220,7 +220,7 @@ public static partial class ObservableCacheEx
     /// <param name="comparer">The comparer to order the resulting dataset.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList,
         IComparer<TObject> comparer,
@@ -238,7 +238,7 @@ public static partial class ObservableCacheEx
     /// <param name="targetList">The list to bind to.</param>
     /// <param name="comparerChanged">An observable of comparers which enables the sort order to be changed.</param>>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList,
         IObservable<IComparer<TObject>> comparerChanged)
@@ -256,7 +256,7 @@ public static partial class ObservableCacheEx
     /// <param name="comparerChanged">An observable of comparers which enables the sort order to be changed.</param>>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         IList<TObject> targetList,
         IObservable<IComparer<TObject>> comparerChanged,
@@ -273,7 +273,7 @@ public static partial class ObservableCacheEx
     /// <param name="source">The source.</param>
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection)
         where TObject : notnull, IComparable<TObject>
@@ -289,7 +289,7 @@ public static partial class ObservableCacheEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         SortAndBindOptions options)
@@ -306,7 +306,7 @@ public static partial class ObservableCacheEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="comparer">The comparer to order the resulting dataset.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         IComparer<TObject> comparer)
@@ -324,7 +324,7 @@ public static partial class ObservableCacheEx
     /// <param name="comparer">The comparer to order the resulting dataset.</param>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         IComparer<TObject> comparer,
@@ -351,7 +351,7 @@ public static partial class ObservableCacheEx
     /// <param name="readOnlyObservableCollection">The resulting read only observable collection.</param>
     /// <param name="comparerChanged">An observable of comparers which enables the sort order to be changed.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         IObservable<IComparer<TObject>> comparerChanged)
@@ -369,7 +369,7 @@ public static partial class ObservableCacheEx
     /// <param name="comparerChanged">An observable of comparers which enables the sort order to be changed.</param>>
     /// <param name="options">Bind and sort default options.</param>
     /// <returns>An observable which will emit change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<TObject, TKey>(
+    public static IObservable<IChangeSet<TObject, TKey>> SortAndBind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(
         this IObservable<IChangeSet<TObject, TKey>> source,
         out ReadOnlyObservableCollection<TObject> readOnlyObservableCollection,
         IObservable<IComparer<TObject>> comparerChanged,

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -1935,7 +1935,6 @@ public static partial class ObservableCacheEx
     {
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
         groupSelectorKeyObservable.ThrowArgumentNullExceptionIfNull(nameof(groupSelectorKeyObservable));
-        regrouper.ThrowArgumentNullExceptionIfNull(nameof(regrouper));
 
         return new GroupOnDynamic<TObject, TKey, TGroupKey>(source, groupSelectorKeyObservable, regrouper).Run();
     }

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -5056,7 +5056,7 @@ public static partial class ObservableCacheEx
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
         manySelector.ThrowArgumentNullExceptionIfNull(nameof(manySelector));
 
-        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTranformer(manySelector, keySelector), equalityComparer, comparer).Run();
+        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTransformer(manySelector, keySelector), equalityComparer, comparer).Run();
     }
 
     /// <summary>
@@ -5107,7 +5107,7 @@ public static partial class ObservableCacheEx
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
         manySelector.ThrowArgumentNullExceptionIfNull(nameof(manySelector));
 
-        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTranformer(manySelector, keySelector), equalityComparer, comparer).Run();
+        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTransformer(manySelector, keySelector), equalityComparer, comparer).Run();
     }
 
     /// <summary>
@@ -5157,7 +5157,7 @@ public static partial class ObservableCacheEx
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
         manySelector.ThrowArgumentNullExceptionIfNull(nameof(manySelector));
 
-        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTranformer(manySelector), equalityComparer, comparer).Run();
+        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTransformer(manySelector), equalityComparer, comparer).Run();
     }
 
     /// <summary>
@@ -5207,7 +5207,7 @@ public static partial class ObservableCacheEx
         manySelector.ThrowArgumentNullExceptionIfNull(nameof(manySelector));
         errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
 
-        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTranformer(manySelector, keySelector), equalityComparer, comparer, errorHandler).Run();
+        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTransformer(manySelector, keySelector), equalityComparer, comparer, errorHandler).Run();
     }
 
     /// <summary>
@@ -5261,7 +5261,7 @@ public static partial class ObservableCacheEx
         manySelector.ThrowArgumentNullExceptionIfNull(nameof(manySelector));
         errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
 
-        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTranformer(manySelector, keySelector), equalityComparer, comparer, errorHandler).Run();
+        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTransformer(manySelector, keySelector), equalityComparer, comparer, errorHandler).Run();
     }
 
     /// <summary>
@@ -5314,7 +5314,7 @@ public static partial class ObservableCacheEx
         manySelector.ThrowArgumentNullExceptionIfNull(nameof(manySelector));
         errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
 
-        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTranformer(manySelector), equalityComparer, comparer, errorHandler).Run();
+        return new TransformManyAsync<TSource, TSourceKey, TDestination, TDestinationKey>(source, CreateChangeSetTransformer(manySelector), equalityComparer, comparer, errorHandler).Run();
     }
 
     /// <summary>
@@ -6442,20 +6442,20 @@ public static partial class ObservableCacheEx
         where TKey : notnull
         where TValue : notnull => new TrueFor<TObject, TKey, TValue>(source, observableSelector, collectionMatcher).Run();
 
-    private static Func<TSource, TSourceKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> CreateChangeSetTranformer<TDestination, TDestinationKey, TSource, TSourceKey>(Func<TSource, TSourceKey, Task<IEnumerable<TDestination>>> manySelector, Func<TDestination, TDestinationKey> keySelector)
+    private static Func<TSource, TSourceKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> CreateChangeSetTransformer<TDestination, TDestinationKey, TSource, TSourceKey>(Func<TSource, TSourceKey, Task<IEnumerable<TDestination>>> manySelector, Func<TDestination, TDestinationKey> keySelector)
         where TDestination : notnull
         where TDestinationKey : notnull
         where TSource : notnull
         where TSourceKey : notnull => async (val, key) => (await manySelector(val, key).ConfigureAwait(false)).AsObservableChangeSet(keySelector);
 
-    private static Func<TSource, TSourceKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> CreateChangeSetTranformer<TDestination, TDestinationKey, TSource, TSourceKey, TCollection>(Func<TSource, TSourceKey, Task<TCollection>> manySelector, Func<TDestination, TDestinationKey> keySelector)
+    private static Func<TSource, TSourceKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> CreateChangeSetTransformer<TDestination, TDestinationKey, TSource, TSourceKey, TCollection>(Func<TSource, TSourceKey, Task<TCollection>> manySelector, Func<TDestination, TDestinationKey> keySelector)
         where TDestination : notnull
         where TDestinationKey : notnull
         where TSource : notnull
         where TSourceKey : notnull
         where TCollection : INotifyCollectionChanged, IEnumerable<TDestination> => async (val, key) => (await manySelector(val, key).ConfigureAwait(false)).ToObservableChangeSet<TCollection, TDestination>().AddKey(keySelector);
 
-    private static Func<TSource, TSourceKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> CreateChangeSetTranformer<TDestination, TDestinationKey, TSource, TSourceKey>(Func<TSource, TSourceKey, Task<IObservableCache<TDestination, TDestinationKey>>> manySelector)
+    private static Func<TSource, TSourceKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> CreateChangeSetTransformer<TDestination, TDestinationKey, TSource, TSourceKey>(Func<TSource, TSourceKey, Task<IObservableCache<TDestination, TDestinationKey>>> manySelector)
         where TDestination : notnull
         where TDestinationKey : notnull
         where TSource : notnull

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -2499,7 +2499,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2516,7 +2516,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2535,7 +2535,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2554,7 +2554,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2575,7 +2575,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2596,7 +2596,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2619,7 +2619,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2642,7 +2642,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges both observable changesets into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2667,7 +2667,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2688,7 +2688,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2711,7 +2711,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2734,7 +2734,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  Merges the source changeset and the collection of other changesets together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2759,7 +2759,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2778,7 +2778,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2799,7 +2799,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2820,7 +2820,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
+    /// Operator similar to Merge except it is ChangeSet aware.  All of the observable changesets are merged together into a single stream of ChangeSet events that correctly handles multiple Keys.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2843,7 +2843,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Operator similar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2866,7 +2866,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Operator similar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2891,7 +2891,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Operator similar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -2916,7 +2916,7 @@ public static partial class ObservableCacheEx
     }
 
     /// <summary>
-    /// Operator similiar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
+    /// Operator similar to MergeMany except it is ChangeSet aware.  It uses <paramref name="observableSelector"/> to transform each item in the source into a child <see cref="IChangeSet{TObject, TKey}"/> and merges the result children together into a single stream of ChangeSets that correctly handles multiple Keys and removal of the parent items.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -784,7 +784,7 @@ public static partial class ObservableCacheEx
     /// or
     /// targetCollection.
     /// </exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, BindingList<TObject> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, BindingList<TObject> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
         where TObject : notnull
         where TKey : notnull
     {
@@ -808,7 +808,7 @@ public static partial class ObservableCacheEx
     /// or
     /// targetCollection.
     /// </exception>
-    public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, BindingList<TObject> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
+    public static IObservable<IChangeSet<TObject, TKey>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(this IObservable<ISortedChangeSet<TObject, TKey>> source, BindingList<TObject> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
         where TObject : notnull
         where TKey : notnull
     {

--- a/src/DynamicData/List/ObservableListEx.cs
+++ b/src/DynamicData/List/ObservableListEx.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reactive;
 using System.Reactive.Concurrency;
@@ -352,7 +353,7 @@ public static class ObservableListEx
     /// targetCollection.
     /// </exception>
     /// <returns>An observable which emits the change set.</returns>
-    public static IObservable<IChangeSet<T>> Bind<T>(this IObservable<IChangeSet<T>> source, BindingList<T> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
+    public static IObservable<IChangeSet<T>> Bind<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this IObservable<IChangeSet<T>> source, BindingList<T> bindingList, int resetThreshold = BindingOptions.DefaultResetThreshold)
         where T : notnull
     {
         source.ThrowArgumentNullExceptionIfNull(nameof(source));

--- a/src/DynamicData/Polyfills/DynamicallyAccessedMembersAttribute.cs
+++ b/src/DynamicData/Polyfills/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if !NET5_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis;
+
+[Flags]
+internal enum DynamicallyAccessedMemberTypes
+{
+    All = -1,
+    None = 0,
+    PublicParameterlessConstructor = 1,
+    PublicConstructors = 3,
+    NonPublicConstructors = 4,
+    PublicMethods = 8,
+    NonPublicMethods = 16,
+    PublicFields = 32,
+    NonPublicFields = 64,
+    PublicNestedTypes = 128,
+    NonPublicNestedTypes = 256,
+    PublicProperties = 512,
+    NonPublicProperties = 1024,
+    PublicEvents = 2048,
+    NonPublicEvents = 4096,
+    Interfaces = 8192
+}
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, Inherited = false)]
+internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+{
+    public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+    {
+        MemberTypes = memberTypes;
+    }
+
+    public DynamicallyAccessedMemberTypes MemberTypes { get; }
+}
+#endif


### PR DESCRIPTION
## Description
1) Created a Polyfill for the `DynamicallyAccessedMembers` attribute / enum which isn't available until Net5.

2) Updated any class using `BindingList` to include the `DynamicallyAccessedMembers` attribute so that the type have the same attributes as `BindingList`.

3) Recursively walked up the code hierarchy to apply the attribute all the way up.

All of the warnings mentioned in #983 were related to `BindingList<T>`.  Any generic code that uses that class directly (or indirectly) needs to have the same AOT attributes so that the trimmer will be sure to not trim needed type information, so this should resolve all of those warnings.

### Bonus Fixes
Converted two files to use file-scoped namespaces.