### PR TITLE
Bug Fix: Virtual sort on same page

### DIFF
--- a/src/DynamicData/Cache/Internal/KeyValueComparer.cs
+++ b/src/DynamicData/Cache/Internal/KeyValueComparer.cs
@@ -33,6 +33,11 @@ internal sealed class KeyValueComparer<TObject, TKey>(IComparer<TObject>? compar
             return -1;
         }
 
+        if (x.Key is IComparable<TKey> xComp)
+        {
+            return xComp.CompareTo(y.Key);
+        }
+
         return x.Key.GetHashCode().CompareTo(y.Key.GetHashCode());
     }
 }

--- a/src/DynamicData/Cache/Internal/SortedKeyValueApplicator.cs
+++ b/src/DynamicData/Cache/Internal/SortedKeyValueApplicator.cs
@@ -79,21 +79,10 @@ internal sealed class SortedKeyValueApplicator<TObject, TKey>
                     {
                         var previous = new KeyValuePair<TKey, TObject>(change.Key, change.Previous.Value);
                         var currentIndex = GetCurrentPosition(previous);
+                        _target.RemoveAt(currentIndex);
+
                         var updatedIndex = GetInsertPosition(item);
-
-                        // We need to recalibrate as GetCurrentPosition includes the current item
-                        updatedIndex = currentIndex < updatedIndex ? updatedIndex - 1 : updatedIndex;
-
-                        // Some control suites and platforms do not support replace, whiles others do, so we opt in.
-                        if (_options.UseReplaceForUpdates && currentIndex == updatedIndex)
-                        {
-                            _target[currentIndex] = item;
-                        }
-                        else
-                        {
-                            _target.RemoveAt(currentIndex);
-                            _target.Insert(updatedIndex, item);
-                        }
+                        _target.Insert(updatedIndex, item);
                     }
                     break;
                 case ChangeReason.Remove:


### PR DESCRIPTION
Fixes #996 

A reset is required for elements that are on the virtual result both before and after the comparer changes.