### PR TITLE
Generalized Solution for avoiding Out-of-Order Cache Child ChangeSets

### DIFF
--- a/src/DynamicData/Cache/Internal/ChangeSetCache.cs
+++ b/src/DynamicData/Cache/Internal/ChangeSetCache.cs
@@ -16,7 +16,7 @@ internal sealed class ChangeSetCache<TObject, TKey>
     where TKey : notnull
 {
     public ChangeSetCache(IObservable<IChangeSet<TObject, TKey>> source) =>
-        Source = source.IgnoreSameReferenceUpdate().Do(Cache.Clone);
+        Source = source.Do(Cache.Clone);
 
     public Cache<TObject, TKey> Cache { get; } = new();
 

--- a/src/DynamicData/Cache/Internal/DynamicGrouper.cs
+++ b/src/DynamicData/Cache/Internal/DynamicGrouper.cs
@@ -44,37 +44,44 @@ internal sealed class DynamicGrouper<TObject, TKey, TGroupKey>(Func<TObject, TKe
 
         foreach (var change in changeSet.ToConcreteType())
         {
-            switch (change.Reason)
-            {
-                case ChangeReason.Add when _groupSelector is not null:
-                    PerformAddOrUpdate(change.Key, _groupSelector(change.Current, change.Key), change.Current, suspendTracker);
-                    break;
-
-                case ChangeReason.Remove:
-                    PerformRemove(change.Key, suspendTracker);
-                    break;
-
-                case ChangeReason.Update when _groupSelector is not null:
-                    PerformAddOrUpdate(change.Key, _groupSelector(change.Current, change.Key), change.Current, suspendTracker);
-                    break;
-
-                case ChangeReason.Update:
-                    PerformUpdate(change.Key, suspendTracker);
-                    break;
-
-                case ChangeReason.Refresh when _groupSelector is not null:
-                    PerformRefresh(change.Key, _groupSelector(change.Current, change.Key), change.Current, suspendTracker);
-                    break;
-
-                case ChangeReason.Refresh:
-                    PerformRefresh(change.Key, suspendTracker);
-                    break;
-            }
+            ProcessChange(change, suspendTracker);
         }
 
         if (observer != null)
         {
             EmitChanges(observer);
+        }
+    }
+
+    public void ProcessChange(Change<TObject, TKey> change) => ProcessChange(change, _suspendTracker);
+
+    private void ProcessChange(Change<TObject, TKey> change, SuspendTracker? suspendTracker)
+    {
+        switch (change.Reason)
+        {
+            case ChangeReason.Add when _groupSelector is not null:
+                PerformAddOrUpdate(change.Key, _groupSelector(change.Current, change.Key), change.Current, suspendTracker);
+                break;
+
+            case ChangeReason.Remove:
+                PerformRemove(change.Key, suspendTracker);
+                break;
+
+            case ChangeReason.Update when _groupSelector is not null:
+                PerformAddOrUpdate(change.Key, _groupSelector(change.Current, change.Key), change.Current, suspendTracker);
+                break;
+
+            case ChangeReason.Update:
+                PerformUpdate(change.Key, suspendTracker);
+                break;
+
+            case ChangeReason.Refresh when _groupSelector is not null:
+                PerformRefresh(change.Key, _groupSelector(change.Current, change.Key), change.Current, suspendTracker);
+                break;
+
+            case ChangeReason.Refresh:
+                PerformRefresh(change.Key, suspendTracker);
+                break;
         }
     }
 

--- a/src/DynamicData/Cache/Internal/GroupOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnObservable.cs
@@ -13,6 +13,62 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
     where TKey : notnull
     where TGroupKey : notnull
 {
+    public IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Run() =>
+        Observable.Create<IGroupChangeSet<TObject, TKey, TGroupKey>>(observer => new Subscription(source, selectGroup, observer));
+
+    // Maintains state for a single subscription
+    private sealed class Subscription : CacheParentSubscription<TObject, TKey, (TGroupKey, TObject), IGroupChangeSet<TObject, TKey, TGroupKey>>
+    {
+        private readonly DynamicGrouper<TObject, TKey, TGroupKey> _grouper = new();
+        private readonly Func<TObject, TKey, IObservable<TGroupKey>> _selectGroup;
+
+        public Subscription(IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, TKey, IObservable<TGroupKey>> selectGroup, IObserver<IGroupChangeSet<TObject, TKey, TGroupKey>> observer)
+            : base(observer)
+        {
+            _selectGroup = selectGroup;
+            CreateParentSubscription(source);
+        }
+
+        protected override void ParentOnNext(IChangeSet<TObject, TKey> changes)
+        {
+            // Process all the changes at once to preserve the changeset order
+            foreach (var change in changes.ToConcreteType())
+            {
+                _grouper.ProcessChange(change);
+
+                switch (change.Reason)
+                {
+                    // Shutdown existing sub (if any) and create a new one that
+                    // Will update the cache and emit the changes
+                    case ChangeReason.Add or ChangeReason.Update:
+                        AddGroupSubscription(change.Current, change.Key);
+                        break;
+
+                    // Shutdown the existing subscription and remove from the cache
+                    case ChangeReason.Remove:
+                        RemoveChildSubscription(change.Key);
+                        break;
+                }
+            }
+        }
+
+        protected override void ChildOnNext((TGroupKey, TObject) tuple, TKey parentKey) =>
+            _grouper.AddOrUpdate(parentKey, tuple.Item1, tuple.Item2);
+
+        protected override void EmitChanges(IObserver<IGroupChangeSet<TObject, TKey, TGroupKey>> observer) =>
+            _grouper.EmitChanges(observer);
+
+        protected override void Dispose(bool disposing)
+        {
+            _grouper.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void AddGroupSubscription(TObject obj, TKey key) =>
+            AddChildSubscription(MakeChildObservable(_selectGroup(obj, key).DistinctUntilChanged().Select(groupKey => (groupKey, obj))), key);
+    }
+
+#if false
     public IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Run() => Observable.Create<IGroupChangeSet<TObject, TKey, TGroupKey>>(observer =>
     {
         var grouper = new DynamicGrouper<TObject, TKey, TGroupKey>();
@@ -58,4 +114,5 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
 
         return new CompositeDisposable(shared.Connect(), subMergeMany, subChanges, grouper);
     });
+#endif
 }

--- a/src/DynamicData/Cache/Internal/GroupOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/GroupOnObservable.cs
@@ -2,7 +2,6 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Internal;
 
@@ -39,12 +38,12 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
                 switch (change.Reason)
                 {
                     // Shutdown existing sub (if any) and create a new one that
-                    // Will update the cache and emit the changes
+                    // Will update the group key for the current item
                     case ChangeReason.Add or ChangeReason.Update:
                         AddGroupSubscription(change.Current, change.Key);
                         break;
 
-                    // Shutdown the existing subscription and remove from the cache
+                    // Shutdown the existing subscription
                     case ChangeReason.Remove:
                         RemoveChildSubscription(change.Key);
                         break;
@@ -67,52 +66,4 @@ internal sealed class GroupOnObservable<TObject, TKey, TGroupKey>(IObservable<IC
         private void AddGroupSubscription(TObject obj, TKey key) =>
             AddChildSubscription(MakeChildObservable(_selectGroup(obj, key).DistinctUntilChanged().Select(groupKey => (groupKey, obj))), key);
     }
-
-#if false
-    public IObservable<IGroupChangeSet<TObject, TKey, TGroupKey>> Run() => Observable.Create<IGroupChangeSet<TObject, TKey, TGroupKey>>(observer =>
-    {
-        var grouper = new DynamicGrouper<TObject, TKey, TGroupKey>();
-        var locker = InternalEx.NewLock();
-        var parentUpdate = false;
-
-        IObservable<TGroupKey> CreateGroupObservable(TObject item, TKey key) =>
-            selectGroup(item, key)
-                .DistinctUntilChanged()
-                .Synchronize(locker!)
-                .Do(
-                    onNext: groupKey => grouper!.AddOrUpdate(key, groupKey, item, !parentUpdate ? observer : null),
-                    onError: observer.OnError);
-
-        // Create a shared connection to the source
-        var shared = source
-            .Synchronize(locker)
-            .Do(_ => parentUpdate = true)
-            .Publish();
-
-        // First process the changesets
-        var subChanges = shared
-            .SubscribeSafe(
-                onNext: changeSet => grouper.ProcessChangeSet(changeSet),
-                onError: observer.OnError);
-
-        // Next process the Grouping observables created for each item
-        var subMergeMany = shared
-            .MergeMany(CreateGroupObservable)
-            .SubscribeSafe(
-                onError: observer.OnError,
-                onCompleted: observer.OnCompleted);
-
-        // Finally, emit the results
-        var subResults = shared
-            .SubscribeSafe(
-                onNext: _ =>
-                {
-                    grouper.EmitChanges(observer);
-                    parentUpdate = false;
-                },
-                onError: observer.OnError);
-
-        return new CompositeDisposable(shared.Connect(), subMergeMany, subChanges, grouper);
-    });
-#endif
 }

--- a/src/DynamicData/Cache/Internal/MergeChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeChangeSets.cs
@@ -43,14 +43,14 @@ internal sealed class MergeChangeSets<TObject, TKey>(IObservable<IObservable<ICh
     // Can optimize for the Add case because that's the only one that applies
 #if NET9_0_OR_GREATER
     private static Change<ChangeSetCache<TObject, TKey>, int> CreateChange(IObservable<IChangeSet<TObject, TKey>> source, int index, Lock locker) =>
-        new(ChangeReason.Add, index, new ChangeSetCache<TObject, TKey>(source.Synchronize(locker)));
+        new(ChangeReason.Add, index, new ChangeSetCache<TObject, TKey>(source.IgnoreSameReferenceUpdate().Synchronize(locker)));
 
     // Create a ChangeSet Observable that produces ChangeSets with a single Add event for each new sub-observable
     private static IObservable<IChangeSet<ChangeSetCache<TObject, TKey>, int>> CreateContainerObservable(IObservable<IObservable<IChangeSet<TObject, TKey>>> source, Lock locker) =>
         source.Select((src, index) => new ChangeSet<ChangeSetCache<TObject, TKey>, int>(new[] { CreateChange(src, index, locker) }));
 #else
     private static Change<ChangeSetCache<TObject, TKey>, int> CreateChange(IObservable<IChangeSet<TObject, TKey>> source, int index, object locker) =>
-        new(ChangeReason.Add, index, new ChangeSetCache<TObject, TKey>(source.Synchronize(locker)));
+        new(ChangeReason.Add, index, new ChangeSetCache<TObject, TKey>(source.IgnoreSameReferenceUpdate().Synchronize(locker)));
 
     // Create a ChangeSet Observable that produces ChangeSets with a single Add event for each new sub-observable
     private static IObservable<IChangeSet<ChangeSetCache<TObject, TKey>, int>> CreateContainerObservable(IObservable<IObservable<IChangeSet<TObject, TKey>>> source, object locker) =>

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSets.cs
@@ -2,8 +2,6 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Internal;
 

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSets.cs
@@ -24,7 +24,6 @@ internal sealed class MergeManyCacheChangeSets<TObject, TKey, TDestination, TDes
     {
         private readonly Cache<ChangeSetCache<TDestination, TDestinationKey>, TKey> _cache = new();
         private readonly ChangeSetMergeTracker<TDestination, TDestinationKey> _changeSetMergeTracker;
-        private readonly Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> _transform;
 
         public Subscription(
             IObservable<IChangeSet<TObject, TKey>> source,
@@ -34,10 +33,9 @@ internal sealed class MergeManyCacheChangeSets<TObject, TKey, TDestination, TDes
             IComparer<TDestination>? comparer)
             : base(observer)
         {
-            _transform = transform;
             _changeSetMergeTracker = new(() => _cache.Items, comparer, equalityComparer);
 
-            CreateParentSubscription(source.Transform((obj, key) => new ChangeSetCache<TDestination, TDestinationKey>(_transform(obj, key))));
+            CreateParentSubscription(source.Transform((obj, key) => new ChangeSetCache<TDestination, TDestinationKey>(transform(obj, key))));
         }
 
         protected override void ParentOnNext(IChangeSet<ChangeSetCache<TDestination, TDestinationKey>, TKey> changes)

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSets.cs
@@ -19,99 +19,30 @@ internal sealed class MergeManyCacheChangeSets<TObject, TKey, TDestination, TDes
     where TDestinationKey : notnull
 {
     public IObservable<IChangeSet<TDestination, TDestinationKey>> Run() => Observable.Create<IChangeSet<TDestination, TDestinationKey>>(
-        observer =>
-#if false
-        {
-            var locker = InternalEx.NewLock();
-            var cache = new Cache<ChangeSetCache<TDestination, TDestinationKey>, TKey>();
-            var parentUpdate = false;
-
-            // This is manages all of the changes
-            var changeTracker = new ChangeSetMergeTracker<TDestination, TDestinationKey>(() => cache.Items, comparer, equalityComparer);
-
-            // Transform to a cache changeset of child caches, synchronize, update the local copy, and publish.
-            var shared = source
-                .Transform((obj, key) => new ChangeSetCache<TDestination, TDestinationKey>(selector(obj, key).Synchronize(locker)))
-                .Synchronize(locker)
-                .Do(changes =>
-                {
-                    cache.Clone(changes);
-                    parentUpdate = true;
-                })
-                .Publish();
-
-            // Merge the child changeset changes together and apply to the tracker
-            var subMergeMany = shared
-                .MergeMany(cacheChangeSet => cacheChangeSet.Source)
-                .SubscribeSafe(
-                    changes => changeTracker.ProcessChangeSet(changes, !parentUpdate ? observer : null),
-                    observer.OnError,
-                    observer.OnCompleted);
-
-            // When a source item is removed, all of its sub-items need to be removed
-            var subRemove = shared
-                .OnItemRemoved(changeSetCache => changeTracker.RemoveItems(changeSetCache.Cache.KeyValues), invokeOnUnsubscribe: false)
-                .OnItemUpdated((_, prev) => changeTracker.RemoveItems(prev.Cache.KeyValues))
-                .SubscribeSafe(
-                    _ =>
-                    {
-                        changeTracker.EmitChanges(observer);
-                        parentUpdate = false;
-                    },
-                    observer.OnError);
-
-            return new CompositeDisposable(shared.Connect(), subMergeMany, subRemove);
-        });
-#else
-        new Subscription(source, selector, observer, equalityComparer, comparer, false));
+        observer => new Subscription(source, selector, observer, equalityComparer, comparer));
 
     // Maintains state for a single subscription
-    private sealed class Subscription : IDisposable
+    private sealed class Subscription : ParentSubscription<ChangeSetCache<TDestination, TDestinationKey>, TKey, IChangeSet<TDestination, TDestinationKey>, IChangeSet<TDestination, TDestinationKey>>
     {
-#if NET9_0_OR_GREATER
-        private readonly Lock _synchronize = new();
-#else
-        private readonly object _synchronize = new();
-#endif
         private readonly Cache<ChangeSetCache<TDestination, TDestinationKey>, TKey> _cache = new();
-        private readonly KeyedDisposable<TKey> _childSubscriptions = new();
         private readonly ChangeSetMergeTracker<TDestination, TDestinationKey> _changeSetMergeTracker;
         private readonly Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> _transform;
-        private readonly IDisposable _parentSubscription;
-        private readonly IObserver<IChangeSet<TDestination, TDestinationKey>> _observer;
-        private readonly bool _transformOnRefresh;
-        private int _subscriptionCounter = 1;
-        private int _updateCounter;
 
         public Subscription(
             IObservable<IChangeSet<TObject, TKey>> source,
             Func<TObject, TKey, IObservable<IChangeSet<TDestination, TDestinationKey>>> transform,
             IObserver<IChangeSet<TDestination, TDestinationKey>> observer,
             IEqualityComparer<TDestination>? equalityComparer,
-            IComparer<TDestination>? comparer,
-            bool transformOnRefresh)
+            IComparer<TDestination>? comparer)
+            : base(observer)
         {
-            _observer = observer;
             _transform = transform;
-            _transformOnRefresh = transformOnRefresh;
             _changeSetMergeTracker = new(() => _cache.Items, comparer, equalityComparer);
-            _parentSubscription = source
-                .Transform((obj, key) => new ChangeSetCache<TDestination, TDestinationKey>(_transform(obj, key)))
-                .Do(_ => IncrementUpdates())
-                .Synchronize(_synchronize)
-                .SubscribeSafe(ParentOnNext, observer.OnError, CheckCompleted);
+
+            CreateParentSubscription(source.Transform((obj, key) => new ChangeSetCache<TDestination, TDestinationKey>(_transform(obj, key))));
         }
 
-        public void Dispose()
-        {
-            lock (_synchronize)
-            {
-                _parentSubscription.Dispose();
-                _childSubscriptions.Dispose();
-            }
-        }
-
-        private void ParentOnNext(IChangeSet<ChangeSetCache<TDestination, TDestinationKey>, TKey> changes)
+        protected override void ParentOnNext(IChangeSet<ChangeSetCache<TDestination, TDestinationKey>, TKey> changes)
         {
             // Process all the changes at once to preserve the changeset order
             foreach (var change in changes.ToConcreteType())
@@ -122,7 +53,7 @@ internal sealed class MergeManyCacheChangeSets<TObject, TKey, TDestination, TDes
                     // Will update the cache and emit the changes
                     case ChangeReason.Add or ChangeReason.Update:
                         _cache.AddOrUpdate(change.Current, change.Key);
-                        CreateChildSubscription(change.Current, change.Key);
+                        AddChildSubscription(change.Current.Source, change.Key);
                         if (change.Previous.HasValue)
                         {
                             _changeSetMergeTracker.RemoveItems(change.Previous.Value.Cache.KeyValues);
@@ -132,63 +63,17 @@ internal sealed class MergeManyCacheChangeSets<TObject, TKey, TDestination, TDes
                     // Shutdown the existing subscription and remove from the cache
                     case ChangeReason.Remove:
                         _cache.Remove(change.Key);
-                        _childSubscriptions.Remove(change.Key);
+                        RemoveChildSubscription(change.Key);
                         _changeSetMergeTracker.RemoveItems(change.Current.Cache.KeyValues);
                         break;
                 }
             }
-
-            // Emit any pending changes
-            EmitChanges();
         }
 
-        private void IncrementUpdates() => Interlocked.Increment(ref _updateCounter);
-
-        private void EmitChanges()
-        {
-            if (Interlocked.Decrement(ref _updateCounter) == 0)
-            {
-                _changeSetMergeTracker.EmitChanges(_observer);
-            }
-
-            Debug.Assert(_updateCounter >= 0, "Should never be negative");
-        }
-
-        private void CheckCompleted()
-        {
-            if (Interlocked.Decrement(ref _subscriptionCounter) == 0)
-            {
-                _observer.OnCompleted();
-            }
-
-            Debug.Assert(_subscriptionCounter >= 0, "Should never be negative");
-        }
-
-        // Create the sub-observable that takes the result of the transformation,
-        // filters out unchanged values, and then updates the cache
-        private void CreateChildSubscription(ChangeSetCache<TDestination, TDestinationKey> childCache, TKey key)
-        {
-            // Add a new subscription.  Do first so cleanup of existing subs doesn't trigger OnCompleted.
-            Interlocked.Increment(ref _subscriptionCounter);
-
-            // Create a container for the Disposable and add to the KeyedDisposable
-            var disposableContainer = _childSubscriptions.Add(key, new SingleAssignmentDisposable());
-
-            // Create the child observable for the source item and update the cache
-            // Will Dispose immediately if OnCompleted fires upon subscription because OnCompleted disposes the container
-            // Remove the TransformSubscription if it completes because its not needed anymore
-            disposableContainer.Disposable = childCache.Source
-                .Do(_ => IncrementUpdates())
-                .Synchronize(_synchronize)
-                .Finally(CheckCompleted)
-                .SubscribeSafe(ChildOnNext, _observer.OnError, () => _childSubscriptions.Remove(key));
-        }
-
-        private void ChildOnNext(IChangeSet<TDestination, TDestinationKey> changes)
-        {
+        protected override void ChildOnNext(IChangeSet<TDestination, TDestinationKey> changes, TKey parentKey) =>
             _changeSetMergeTracker.ProcessChangeSet(changes, null);
-            EmitChanges();
-        }
+
+        protected override void EmitChanges(IObserver<IChangeSet<TDestination, TDestinationKey>> observer) =>
+            _changeSetMergeTracker.EmitChanges(observer);
     }
-#endif
 }

--- a/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyCacheChangeSetsSourceCompare.cs
@@ -32,7 +32,6 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
     {
         private readonly Cache<ChangeSetCache<ParentChildEntry, TDestinationKey>, TKey> _cache = new();
         private readonly ChangeSetMergeTracker<ParentChildEntry, TDestinationKey> _changeSetMergeTracker;
-        private readonly Func<TObject, TKey, IObservable<IChangeSet<ParentChildEntry, TDestinationKey>>> _changeSetSelector;
         private readonly bool _reevalOnRefresh;
 
         public Subscription(
@@ -44,11 +43,10 @@ internal sealed class MergeManyCacheChangeSetsSourceCompare<TObject, TKey, TDest
             bool reevalOnRefresh)
             : base(observer)
         {
-            _changeSetSelector = changeSetSelector;
             _changeSetMergeTracker = new(() => _cache.Items, comparer, equalityComparer);
             _reevalOnRefresh = reevalOnRefresh;
 
-            CreateParentSubscription(source.Transform((obj, key) => new ChangeSetCache<ParentChildEntry, TDestinationKey>(_changeSetSelector(obj, key))));
+            CreateParentSubscription(source.Transform((obj, key) => new ChangeSetCache<ParentChildEntry, TDestinationKey>(changeSetSelector(obj, key))));
         }
 
         protected override void ParentOnNext(IChangeSet<ChangeSetCache<ParentChildEntry, TDestinationKey>, TKey> changes)

--- a/src/DynamicData/Cache/Internal/MergeManyListChangeSets.cs
+++ b/src/DynamicData/Cache/Internal/MergeManyListChangeSets.cs
@@ -2,7 +2,6 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Internal;
 using DynamicData.List.Internal;
@@ -18,41 +17,53 @@ internal sealed class MergeManyListChangeSets<TObject, TKey, TDestination>(IObse
     where TDestination : notnull
 {
     public IObservable<IChangeSet<TDestination>> Run() => Observable.Create<IChangeSet<TDestination>>(
-        observer =>
+        observer => new Subscription(source, selector, observer, equalityComparer));
+
+    // Maintains state for a single subscription
+    private sealed class Subscription : ParentSubscription<ClonedListChangeSet<TDestination>, TKey, IChangeSet<TDestination>, IChangeSet<TDestination>>
+    {
+        private readonly ChangeSetMergeTracker<TDestination> _changeSetMergeTracker = new();
+
+        public Subscription(
+            IObservable<IChangeSet<TObject, TKey>> source,
+            Func<TObject, TKey, IObservable<IChangeSet<TDestination>>> selector,
+            IObserver<IChangeSet<TDestination>> observer,
+            IEqualityComparer<TDestination>? equalityComparer)
+            : base(observer)
         {
-            var locker = InternalEx.NewLock();
-            var parentUpdate = false;
+            CreateParentSubscription(source.Transform((obj, key) => new ClonedListChangeSet<TDestination>(selector(obj, key), equalityComparer)));
+        }
 
-            // This is manages all of the changes
-            var changeTracker = new ChangeSetMergeTracker<TDestination>();
+        protected override void ParentOnNext(IChangeSet<ClonedListChangeSet<TDestination>, TKey> changes)
+        {
+            // Process all the changes at once to preserve the changeset order
+            foreach (var change in changes.ToConcreteType())
+            {
+                switch (change.Reason)
+                {
+                    // Shutdown existing sub (if any) and create a new one that
+                    // Will update the cache and emit the changes
+                    case ChangeReason.Add or ChangeReason.Update:
+                        AddChildSubscription(change.Current.Source.RemoveIndex(), change.Key);
+                        if (change.Previous.HasValue)
+                        {
+                            _changeSetMergeTracker.RemoveItems(change.Previous.Value.List);
+                        }
+                        break;
 
-            // Transform to a cache changeset of child lists, synchronize, and publish.
-            var shared = source
-                .Transform((obj, key) => new ClonedListChangeSet<TDestination>(selector(obj, key).Synchronize(locker), equalityComparer))
-                .Synchronize(locker)
-                .Do(_ => parentUpdate = true)
-                .Publish();
+                    // Shutdown the existing subscription and remove from the cache
+                    case ChangeReason.Remove:
+                        RemoveChildSubscription(change.Key);
+                        _changeSetMergeTracker.RemoveItems(change.Current.List);
+                        break;
+                }
+            }
+        }
 
-            // Merge the child changeset changes together and apply to the tracker
-            var subMergeMany = shared
-                .MergeMany(clonedList => clonedList.Source.RemoveIndex())
-                .SubscribeSafe(
-                    changes => changeTracker.ProcessChangeSet(changes, !parentUpdate ? observer : null),
-                    observer.OnError,
-                    observer.OnCompleted);
+        protected override void ChildOnNext(IChangeSet<TDestination> child, TKey parentKey) =>
+            _changeSetMergeTracker.ProcessChangeSet(child, null);
 
-            // When a source item is removed, all of its sub-items need to be removed
-            var subRemove = shared
-                .OnItemRemoved(clonedList => changeTracker.RemoveItems(clonedList.List), invokeOnUnsubscribe: false)
-                .OnItemUpdated((_, prev) => changeTracker.RemoveItems(prev.List))
-                .SubscribeSafe(
-                    _ =>
-                    {
-                        changeTracker.EmitChanges(observer);
-                        parentUpdate = false;
-                    },
-                    observer.OnError);
-
-            return new CompositeDisposable(shared.Connect(), subMergeMany, subRemove);
-        });
+        protected override void EmitChanges(IObserver<IChangeSet<TDestination>> observer) =>
+            _changeSetMergeTracker.EmitChanges(observer);
+    }
 }

--- a/src/DynamicData/Cache/Internal/TransformManyAsync.cs
+++ b/src/DynamicData/Cache/Internal/TransformManyAsync.cs
@@ -17,7 +17,7 @@ internal sealed class TransformManyAsync<TSource, TKey, TDestination, TDestinati
         observer => new Subscription(source, transformer, observer, equalityComparer, comparer, errorHandler));
 
     // Maintains state for a single subscription
-    private sealed class Subscription : ParentSubscription<ChangeSetCache<TDestination, TDestinationKey>, TKey, IChangeSet<TDestination, TDestinationKey>, IChangeSet<TDestination, TDestinationKey>>
+    private sealed class Subscription : CacheParentSubscription<ChangeSetCache<TDestination, TDestinationKey>, TKey, IChangeSet<TDestination, TDestinationKey>, IChangeSet<TDestination, TDestinationKey>>
     {
         private readonly Cache<ChangeSetCache<TDestination, TDestinationKey>, TKey> _cache = new();
         private readonly ChangeSetMergeTracker<TDestination, TDestinationKey> _changeSetMergeTracker;
@@ -40,10 +40,10 @@ internal sealed class TransformManyAsync<TSource, TKey, TDestination, TDestinati
             }
 
             ChangeSetCache<TDestination, TDestinationKey> Transformer(TSource obj, TKey key) =>
-                new(Observable.Defer(() => transform(obj, key)));
+                new(MakeChildObservable(Observable.Defer(() => transform(obj, key))));
 
             ChangeSetCache<TDestination, TDestinationKey> SafeTransformer(TSource obj, TKey key) =>
-                new(Observable.Defer(() => ErrorHandlingTransform(obj, key)));
+                new(MakeChildObservable(Observable.Defer(() => ErrorHandlingTransform(obj, key))));
 
             _changeSetMergeTracker = new(() => _cache.Items, comparer, equalityComparer);
 
@@ -91,77 +91,4 @@ internal sealed class TransformManyAsync<TSource, TKey, TDestination, TDestinati
         protected override void EmitChanges(IObserver<IChangeSet<TDestination, TDestinationKey>> observer) =>
             _changeSetMergeTracker.EmitChanges(observer);
     }
-
-#if false
-    public IObservable<IChangeSet<TDestination, TDestinationKey>> Run() => Observable.Create<IChangeSet<TDestination, TDestinationKey>>(
-        observer =>
-        {
-            var locker = InternalEx.NewLock();
-            var cache = new Cache<ChangeSetCache<TDestination, TDestinationKey>, TKey>();
-            var parentUpdate = false;
-
-            // This is manages all of the changes
-            var changeTracker = new ChangeSetMergeTracker<TDestination, TDestinationKey>(() => cache.Items, comparer, equalityComparer);
-
-            // Transform Helper
-            async Task<IObservable<IChangeSet<TDestination, TDestinationKey>>> InvokeSelector(TSource obj, TKey key)
-            {
-                if (errorHandler != null)
-                {
-                    try
-                    {
-                        return await selector(obj, key).ConfigureAwait(false);
-                    }
-                    catch (Exception e)
-                    {
-                        errorHandler.Invoke(new Error<TSource, TKey>(e, obj, key));
-                        return Observable.Empty<IChangeSet<TDestination, TDestinationKey>>();
-                    }
-                }
-
-                return await selector(obj, key).ConfigureAwait(false);
-            }
-
-            // Transformation Function:
-            // Create the Child Observable by invoking the async selector, appending the synchronize, and creating a new ChangeSetCache instance.
-            ChangeSetCache<TDestination, TDestinationKey> Transform_(TSource obj, TKey key) =>
-                new(Observable.Defer(() => InvokeSelector(obj, key)).Synchronize(locker!));
-
-            // Transform to a cache changeset of child caches, synchronize, clone changes to the local copy, and publish.
-            var shared = source
-                .Transform(Transform_)
-                .Synchronize(locker)
-                .Do(
-                    changes =>
-                    {
-                        cache.Clone(changes);
-                        parentUpdate = true;
-                    })
-                .Publish();
-
-            // Merge the child changeset changes together and apply to the tracker
-            // Emit the changeset if not currently handling a parent stream update
-            var subMergeMany = shared
-                .MergeMany(cacheChangeSet => cacheChangeSet.Source)
-                .SubscribeSafe(
-                    changes => changeTracker.ProcessChangeSet(changes, !parentUpdate ? observer : null),
-                    observer.OnError);
-
-            // When a source item is removed, all of its sub-items need to be removed
-            // Emit any pending changes
-            var subRemove = shared
-                .OnItemRemoved(changeSetCache => changeTracker.RemoveItems(changeSetCache.Cache.KeyValues), invokeOnUnsubscribe: false)
-                .OnItemUpdated((_, prev) => changeTracker.RemoveItems(prev.Cache.KeyValues))
-                .SubscribeSafe(
-                    _ =>
-                    {
-                        changeTracker.EmitChanges(observer);
-                        parentUpdate = false;
-                    },
-                    observer.OnError,
-                    observer.OnCompleted);
-
-            return new CompositeDisposable(shared.Connect(), subMergeMany, subRemove);
-        });
-#endif
 }

--- a/src/DynamicData/Cache/Internal/TransformManyAsync.cs
+++ b/src/DynamicData/Cache/Internal/TransformManyAsync.cs
@@ -2,19 +2,97 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
-
 using DynamicData.Internal;
 
 namespace DynamicData.Cache.Internal;
 
-internal sealed class TransformManyAsync<TSource, TKey, TDestination, TDestinationKey>(IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> selector, IEqualityComparer<TDestination>? equalityComparer, IComparer<TDestination>? comparer, Action<Error<TSource, TKey>>? errorHandler = null)
+internal sealed class TransformManyAsync<TSource, TKey, TDestination, TDestinationKey>(IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> transformer, IEqualityComparer<TDestination>? equalityComparer, IComparer<TDestination>? comparer, Action<Error<TSource, TKey>>? errorHandler = null)
     where TSource : notnull
     where TKey : notnull
     where TDestination : notnull
     where TDestinationKey : notnull
 {
+    public IObservable<IChangeSet<TDestination, TDestinationKey>> Run() => Observable.Create<IChangeSet<TDestination, TDestinationKey>>(
+        observer => new Subscription(source, transformer, observer, equalityComparer, comparer, errorHandler));
+
+    // Maintains state for a single subscription
+    private sealed class Subscription : ParentSubscription<ChangeSetCache<TDestination, TDestinationKey>, TKey, IChangeSet<TDestination, TDestinationKey>, IChangeSet<TDestination, TDestinationKey>>
+    {
+        private readonly Cache<ChangeSetCache<TDestination, TDestinationKey>, TKey> _cache = new();
+        private readonly ChangeSetMergeTracker<TDestination, TDestinationKey> _changeSetMergeTracker;
+
+        public Subscription(IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, Task<IObservable<IChangeSet<TDestination, TDestinationKey>>>> transform, IObserver<IChangeSet<TDestination, TDestinationKey>> observer, IEqualityComparer<TDestination>? equalityComparer, IComparer<TDestination>? comparer, Action<Error<TSource, TKey>>? errorHandler = null)
+            : base(observer)
+        {
+            // Transform Helper
+            async Task<IObservable<IChangeSet<TDestination, TDestinationKey>>> ErrorHandlingTransform(TSource obj, TKey key)
+            {
+                try
+                {
+                    return await transform(obj, key).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    errorHandler.Invoke(new Error<TSource, TKey>(e, obj, key));
+                    return Observable.Empty<IChangeSet<TDestination, TDestinationKey>>();
+                }
+            }
+
+            ChangeSetCache<TDestination, TDestinationKey> Transformer(TSource obj, TKey key) =>
+                new(Observable.Defer(() => transform(obj, key)));
+
+            ChangeSetCache<TDestination, TDestinationKey> SafeTransformer(TSource obj, TKey key) =>
+                new(Observable.Defer(() => ErrorHandlingTransform(obj, key)));
+
+            _changeSetMergeTracker = new(() => _cache.Items, comparer, equalityComparer);
+
+            if (errorHandler is null)
+            {
+                CreateParentSubscription(source.Transform(Transformer));
+            }
+            else
+            {
+                CreateParentSubscription(source.Transform(SafeTransformer));
+            }
+        }
+
+        protected override void ParentOnNext(IChangeSet<ChangeSetCache<TDestination, TDestinationKey>, TKey> changes)
+        {
+            // Process all the changes at once to preserve the changeset order
+            foreach (var change in changes.ToConcreteType())
+            {
+                switch (change.Reason)
+                {
+                    // Shutdown existing sub (if any) and create a new one that
+                    // Will update the cache and emit the changes
+                    case ChangeReason.Add or ChangeReason.Update:
+                        _cache.AddOrUpdate(change.Current, change.Key);
+                        AddChildSubscription(change.Current.Source, change.Key);
+                        if (change.Previous.HasValue)
+                        {
+                            _changeSetMergeTracker.RemoveItems(change.Previous.Value.Cache.KeyValues);
+                        }
+                        break;
+
+                    // Shutdown the existing subscription and remove from the cache
+                    case ChangeReason.Remove:
+                        _cache.Remove(change.Key);
+                        RemoveChildSubscription(change.Key);
+                        _changeSetMergeTracker.RemoveItems(change.Current.Cache.KeyValues);
+                        break;
+                }
+            }
+        }
+
+        protected override void ChildOnNext(IChangeSet<TDestination, TDestinationKey> child, TKey parentKey) =>
+            _changeSetMergeTracker.ProcessChangeSet(child);
+
+        protected override void EmitChanges(IObserver<IChangeSet<TDestination, TDestinationKey>> observer) =>
+            _changeSetMergeTracker.EmitChanges(observer);
+    }
+
+#if false
     public IObservable<IChangeSet<TDestination, TDestinationKey>> Run() => Observable.Create<IChangeSet<TDestination, TDestinationKey>>(
         observer =>
         {
@@ -85,4 +163,5 @@ internal sealed class TransformManyAsync<TSource, TKey, TDestination, TDestinati
 
             return new CompositeDisposable(shared.Connect(), subMergeMany, subRemove);
         });
+#endif
 }

--- a/src/DynamicData/Cache/Internal/TransformOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/TransformOnObservable.cs
@@ -2,8 +2,6 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Internal;
 

--- a/src/DynamicData/Cache/Internal/TransformOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/TransformOnObservable.cs
@@ -16,7 +16,7 @@ internal sealed class TransformOnObservable<TSource, TKey, TDestination>(IObserv
         Observable.Create<IChangeSet<TDestination, TKey>>(observer => new Subscription(source, transform, observer, transformOnRefresh));
 
     // Maintains state for a single subscription
-    private sealed class Subscription : ParentSubscription<TSource, TKey, TDestination, IChangeSet<TDestination, TKey>>
+    private sealed class Subscription : CacheParentSubscription<TSource, TKey, TDestination, IChangeSet<TDestination, TKey>>
     {
         private readonly ChangeAwareCache<TDestination, TKey> _cache = new();
         private readonly Func<TSource, TKey, IObservable<TDestination>> _transform;
@@ -77,6 +77,6 @@ internal sealed class TransformOnObservable<TSource, TKey, TDestination>(IObserv
         }
 
         private void AddTransformSubscription(TSource obj, TKey key) =>
-            AddChildSubscription(_transform(obj, key).DistinctUntilChanged(), key);
+            AddChildSubscription(MakeChildObservable(_transform(obj, key).DistinctUntilChanged()), key);
     }
 }

--- a/src/DynamicData/Cache/Internal/TransformOnObservable.cs
+++ b/src/DynamicData/Cache/Internal/TransformOnObservable.cs
@@ -17,135 +17,6 @@ internal sealed class TransformOnObservable<TSource, TKey, TDestination>(IObserv
     public IObservable<IChangeSet<TDestination, TKey>> Run() =>
         Observable.Create<IChangeSet<TDestination, TKey>>(observer => new Subscription(source, transform, observer, transformOnRefresh));
 
-#if false
-    // Maintains state for a single subscription
-    private sealed class Subscription : IDisposable
-    {
-#if NET9_0_OR_GREATER
-        private readonly Lock _synchronize = new();
-#else
-        private readonly object _synchronize = new();
-#endif
-        private readonly ChangeAwareCache<TDestination, TKey> _cache = new();
-        private readonly KeyedDisposable<TKey> _transformSubscriptions = new();
-        private readonly Func<TSource, TKey, IObservable<TDestination>> _transform;
-        private readonly IDisposable _sourceSubscription;
-        private readonly IObserver<IChangeSet<TDestination, TKey>> _observer;
-        private readonly bool _transformOnRefresh;
-        private int _subscriptionCounter = 1;
-        private int _updateCounter;
-
-        public Subscription(IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, TKey, IObservable<TDestination>> transform, IObserver<IChangeSet<TDestination, TKey>> observer, bool transformOnRefresh)
-        {
-            _observer = observer;
-            _transform = transform;
-            _transformOnRefresh = transformOnRefresh;
-            _sourceSubscription = source
-                .Do(_ => IncrementUpdates())
-                .Synchronize(_synchronize)
-                .SubscribeSafe(ProcessSourceChangeSet, observer.OnError, CheckCompleted);
-        }
-
-        public void Dispose()
-        {
-            lock (_synchronize)
-            {
-                _sourceSubscription.Dispose();
-                _transformSubscriptions.Dispose();
-            }
-        }
-
-        private void ProcessSourceChangeSet(IChangeSet<TSource, TKey> changes)
-        {
-            // Process all the changes at once to preserve the changeset order
-            foreach (var change in changes.ToConcreteType())
-            {
-                switch (change.Reason)
-                {
-                    // Shutdown existing sub (if any) and create a new one that
-                    // Will update the cache and emit the changes
-                    case ChangeReason.Add or ChangeReason.Update:
-                        CreateTransformSubscription(change.Current, change.Key);
-                        break;
-
-                    // Shutdown the existing subscription and remove from the cache
-                    case ChangeReason.Remove:
-                        _transformSubscriptions.Remove(change.Key);
-                        _cache.Remove(change.Key);
-                        break;
-
-                    case ChangeReason.Refresh:
-                        if (_transformOnRefresh)
-                        {
-                            CreateTransformSubscription(change.Current, change.Key);
-                        }
-                        else
-                        {
-                            // Let the downstream decide what this means
-                            _cache.Refresh(change.Key);
-                        }
-                        break;
-                }
-            }
-
-            // Emit any pending changes
-            EmitChanges();
-        }
-
-        private void IncrementUpdates() => Interlocked.Increment(ref _updateCounter);
-
-        private void EmitChanges()
-        {
-            if (Interlocked.Decrement(ref _updateCounter) == 0)
-            {
-                var changes = _cache.CaptureChanges();
-                if (changes.Count > 0)
-                {
-                    _observer.OnNext(changes);
-                }
-            }
-
-            Debug.Assert(_updateCounter >= 0, "Should never be negative");
-        }
-
-        private void CheckCompleted()
-        {
-            if (Interlocked.Decrement(ref _subscriptionCounter) == 0)
-            {
-                _observer.OnCompleted();
-            }
-
-            Debug.Assert(_subscriptionCounter >= 0, "Should never be negative");
-        }
-
-        // Create the sub-observable that takes the result of the transformation,
-        // filters out unchanged values, and then updates the cache
-        private void CreateTransformSubscription(TSource obj, TKey key)
-        {
-            // Add a new subscription.  Do first so cleanup of existing subs doesn't trigger OnCompleted.
-            Interlocked.Increment(ref _subscriptionCounter);
-
-            // Create a container for the Disposable and add to the KeyedDisposable
-            var disposableContainer = _transformSubscriptions.Add(key, new SingleAssignmentDisposable());
-
-            // Create the transformation observable for the source item, filter unchanged, and update the cache
-            // Will Dispose immediately if OnCompleted fires upon subscription because OnCompleted disposes the container
-            // Remove the TransformSubscription if it completes because its not needed anymore
-            disposableContainer.Disposable = _transform(obj, key)
-                .DistinctUntilChanged()
-                .Do(_ => IncrementUpdates())
-                .Synchronize(_synchronize)
-                .Finally(CheckCompleted)
-                .SubscribeSafe(val => TransformOnNext(val, key), _observer.OnError, () => _transformSubscriptions.Remove(key));
-        }
-
-        private void TransformOnNext(TDestination latestValue, TKey key)
-        {
-            _cache.AddOrUpdate(latestValue, key);
-            EmitChanges();
-        }
-    }
-#else
     // Maintains state for a single subscription
     private sealed class Subscription : ParentSubscription<TSource, TKey, TDestination, IChangeSet<TDestination, TKey>>
     {
@@ -176,8 +47,8 @@ internal sealed class TransformOnObservable<TSource, TKey, TDestination>(IObserv
 
                     // Shutdown the existing subscription and remove from the cache
                     case ChangeReason.Remove:
-                        RemoveChildSubscription(change.Key);
                         _cache.Remove(change.Key);
+                        RemoveChildSubscription(change.Key);
                         break;
 
                     case ChangeReason.Refresh:
@@ -210,5 +81,4 @@ internal sealed class TransformOnObservable<TSource, TKey, TDestination>(IObserv
         private void AddTransformSubscription(TSource obj, TKey key) =>
             AddChildSubscription(_transform(obj, key).DistinctUntilChanged(), key);
     }
-#endif
 }

--- a/src/DynamicData/Internal/ParentSubscription.cs
+++ b/src/DynamicData/Internal/ParentSubscription.cs
@@ -41,11 +41,11 @@ internal abstract class ParentSubscription<TParent, TKey, TChild, TObserver>(IOb
         GC.SuppressFinalize(this);
     }
 
-    protected abstract void EmitChanges(IObserver<TObserver> observer);
-
     protected abstract void ParentOnNext(IChangeSet<TParent, TKey> changes);
 
     protected abstract void ChildOnNext(TChild child, TKey parentKey);
+
+    protected abstract void EmitChanges(IObserver<TObserver> observer);
 
     protected void AddChildSubscription(IObservable<TChild> observable, TKey parentKey)
     {

--- a/src/DynamicData/Internal/ParentSubscription.cs
+++ b/src/DynamicData/Internal/ParentSubscription.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) 2011-2023 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace DynamicData.Internal;
+
+/// <summary>
+/// Base class for subscriptions that need to manage child subscriptions and emit updates
+/// when either the parent or child gets a new value.
+/// </summary>
+/// <typeparam name="TParent">Type of the Parent ChangeSet.</typeparam>
+/// <typeparam name="TKey">Type for the Parent ChangeSet Key.</typeparam>
+/// <typeparam name="TChild">Type for the Child Subscriptions.</typeparam>
+/// <typeparam name="TObserver">Type for the Final Observable.</typeparam>
+/// <param name="observer">Observer to use for emitting events.</param>
+internal abstract class ParentSubscription<TParent, TKey, TChild, TObserver>(IObserver<TObserver> observer) : IDisposable
+    where TParent : notnull
+    where TKey : notnull
+    where TChild : notnull
+{
+#if NET9_0_OR_GREATER
+    private readonly Lock _synchronize = new();
+#else
+    private readonly object _synchronize = new();
+#endif
+    private readonly KeyedDisposable<TKey> _childSubscriptions = new();
+    private readonly SingleAssignmentDisposable _parentSubscription = new();
+    private readonly IObserver<TObserver> _observer = observer;
+    private int _subscriptionCounter = 1;
+    private int _updateCounter;
+    private bool _disposedValue;
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected abstract void EmitChanges(IObserver<TObserver> observer);
+
+    protected abstract void ParentOnNext(IChangeSet<TParent, TKey> changes);
+
+    protected abstract void ChildOnNext(TChild child, TKey parentKey);
+
+    protected void AddChildSubscription(IObservable<TChild> observable, TKey parentKey)
+    {
+        // Add a new subscription.  Do first so cleanup of existing subs doesn't trigger OnCompleted.
+        Interlocked.Increment(ref _subscriptionCounter);
+
+        // Create a container for the Disposable and add to the KeyedDisposable
+        var disposableContainer = _childSubscriptions.Add(parentKey, new SingleAssignmentDisposable());
+
+        // Create the subscription
+        // Will Dispose immediately if OnCompleted fires upon subscription because OnCompleted disposes the container
+        // Remove the child subscription if it completes because its not needed anymore
+        disposableContainer.Disposable = observable
+            .Do(_ => EnterUpdate())
+            .Synchronize(_synchronize)
+            .Finally(CheckCompleted)
+            .SubscribeSafe(
+                val =>
+                {
+                    ChildOnNext(val, parentKey);
+                    ExitUpdate();
+                },
+                _observer.OnError,
+                () => RemoveChildSubscription(parentKey));
+    }
+
+    protected void RemoveChildSubscription(TKey parentKey) => _childSubscriptions.Remove(parentKey);
+
+    protected void CreateParentSubscription(IObservable<IChangeSet<TParent, TKey>> source) =>
+        _parentSubscription.Disposable =
+            source
+                .Do(_ => EnterUpdate())
+                .Synchronize(_synchronize)
+                .SubscribeSafe(
+                    changes =>
+                    {
+                        ParentOnNext(changes);
+                        ExitUpdate();
+                    },
+                    _observer.OnError,
+                    CheckCompleted);
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                lock (_synchronize)
+                {
+                    _parentSubscription.Dispose();
+                    _childSubscriptions.Dispose();
+                }
+            }
+            _disposedValue = true;
+        }
+    }
+
+    private void EnterUpdate() => Interlocked.Increment(ref _updateCounter);
+
+    private void ExitUpdate()
+    {
+        if (Interlocked.Decrement(ref _updateCounter) == 0)
+        {
+            EmitChanges(_observer);
+        }
+
+        Debug.Assert(_updateCounter >= 0, "Should never be negative");
+    }
+
+    private void CheckCompleted()
+    {
+        if (Interlocked.Decrement(ref _subscriptionCounter) == 0)
+        {
+            _observer.OnCompleted();
+        }
+
+        Debug.Assert(_subscriptionCounter >= 0, "Should never be negative");
+    }
+}

--- a/src/DynamicData/Internal/ParentSubscription.cs
+++ b/src/DynamicData/Internal/ParentSubscription.cs
@@ -59,8 +59,8 @@ internal abstract class ParentSubscription<TParent, TKey, TChild, TObserver>(IOb
         // Will Dispose immediately if OnCompleted fires upon subscription because OnCompleted disposes the container
         // Remove the child subscription if it completes because its not needed anymore
         disposableContainer.Disposable = observable
-            .Do(_ => EnterUpdate())
             .Synchronize(_synchronize)
+            .Do(_ => EnterUpdate())
             .Finally(CheckCompleted)
             .SubscribeSafe(
                 val =>
@@ -77,8 +77,8 @@ internal abstract class ParentSubscription<TParent, TKey, TChild, TObserver>(IOb
     protected void CreateParentSubscription(IObservable<IChangeSet<TParent, TKey>> source) =>
         _parentSubscription.Disposable =
             source
-                .Do(_ => EnterUpdate())
                 .Synchronize(_synchronize)
+                .Do(_ => EnterUpdate())
                 .SubscribeSafe(
                     changes =>
                     {


### PR DESCRIPTION
## Description

As a follow up to #1007, I looked for other operators that are handling Remove/Update changes as a separate step and found that `MergeManyChangeSets` has a similar defect (as shown by the newly included unit test).

This PR introduces a base class that implements the general solution for handling a parent changeset where each item owns a child subscription and then it adapts existing operators to use it:
1) TransformOnObservable
1) MergeManyChangeSets
1) MergeManyChangeSets (Source Compare)
1) MergeManyChangeSets (Cache -> List)
1) TransformManyAsync
1) GroupOnObservable

I think that is all of them for Cache.  The List versions of the MergeManyChangeSets have a similar issue, but I will need to make a List version of `CacheParentSubcription`, so I will address that in another PR.