### PR TITLE
Fixed re-grouping on foreign key change, in Join operators

### DIFF
--- a/src/DynamicData.Tests/Cache/InnerJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/InnerJoinManyFixture.cs
@@ -75,6 +75,52 @@ public class InnerJoinManyFixture : IDisposable
     }
 
     [Fact]
+    public void RefreshRightKey()
+    {
+        _people.Edit(
+            innerCache =>
+            {
+                innerCache.AddOrUpdate(new Person() { Name = "Person #1", ParentName = string.Empty } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #3", ParentName = "Person #2" } );
+            });
+
+        var refreshPerson = _people.Lookup("Person #2").Value;
+
+
+        // Change pairing
+        refreshPerson.ParentName = "Person #3";
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(2);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().NotContain(("Person #1", "Person #2"));
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #3", "Person #2"));
+
+
+        // Remove pairing
+        refreshPerson.ParentName = "Person #4";
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(1);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (parentName: family.Parent.Name, chilldName: child.Name))).Should().NotContain(pair => pair.chilldName == "Person #2");
+
+
+        // Restore pairing
+        refreshPerson.ParentName = "Person #1";
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(2);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
+
+
+        // No change
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(2);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
+    }
+
+    [Fact]
     public void RemoveChild()
     {
         var people = Enumerable.Range(1, 10).Select(
@@ -134,6 +180,47 @@ public class InnerJoinManyFixture : IDisposable
         var updatedPeople = people.Take(9).Union(new[] { person10 }).ToArray();
 
         AssertDataIsCorrectlyFormed(updatedPeople);
+    }
+
+    [Fact]
+    public void UpdateRightKey()
+    {
+        _people.Edit(
+            innerCache =>
+            {
+                innerCache.AddOrUpdate(new Person() { Name = "Person #1", ParentName = string.Empty } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #3", ParentName = "Person #2" } );
+            });
+
+        
+        // Change pairing
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #3" });
+
+        _result.Data.Count.Should().Be(2);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().NotContain(("Person #1", "Person #2"));
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #3", "Person #2"));
+
+
+        // Remove pairing
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #4" });
+
+        _result.Data.Count.Should().Be(1);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (parentName: family.Parent.Name, chilldName: child.Name))).Should().NotContain(pair => pair.chilldName == "Person #2");
+
+
+        // Restore pairing
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" });
+
+        _result.Data.Count.Should().Be(2);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
+
+
+        // No change
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" });
+
+        _result.Data.Count.Should().Be(2);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
     }
 
     private void AssertDataIsCorrectlyFormed(Person[] allPeople, params string[] missingParents)

--- a/src/DynamicData.Tests/Cache/LeftJoinManyFixture.cs
+++ b/src/DynamicData.Tests/Cache/LeftJoinManyFixture.cs
@@ -78,6 +78,52 @@ public class LeftJoinManyFixture : IDisposable
     }
 
     [Fact]
+    public void RefreshRightKey()
+    {
+        _people.Edit(
+            innerCache =>
+            {
+                innerCache.AddOrUpdate(new Person() { Name = "Person #1", ParentName = string.Empty } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #3", ParentName = "Person #2" } );
+            });
+
+        var refreshPerson = _people.Lookup("Person #2").Value;
+
+
+        // Change pairing
+        refreshPerson.ParentName = "Person #3";
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().NotContain(("Person #1", "Person #2"));
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #3", "Person #2"));
+
+
+        // Remove pairing
+        refreshPerson.ParentName = "Person #4";
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (parentName: family.Parent.Name, chilldName: child.Name))).Should().NotContain(pair => pair.chilldName == "Person #2");
+
+
+        // Restore pairing
+        refreshPerson.ParentName = "Person #1";
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
+
+
+        // No change
+        _people.Refresh(refreshPerson);
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
+    }
+
+    [Fact]
     public void RemoveChild()
     {
         var people = Enumerable.Range(1, 10).Select(
@@ -137,6 +183,47 @@ public class LeftJoinManyFixture : IDisposable
         var updatedPeople = people.Take(9).Union(new[] { person10 }).ToArray();
 
         AssertDataIsCorrectlyFormed(updatedPeople);
+    }
+
+    [Fact]
+    public void UpdateRightKey()
+    {
+        _people.Edit(
+            innerCache =>
+            {
+                innerCache.AddOrUpdate(new Person() { Name = "Person #1", ParentName = string.Empty } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" } );
+                innerCache.AddOrUpdate(new Person() { Name = "Person #3", ParentName = "Person #2" } );
+            });
+
+        
+        // Change pairing
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #3" });
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().NotContain(("Person #1", "Person #2"));
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #3", "Person #2"));
+
+
+        // Remove pairing
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #4" });
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (parentName: family.Parent.Name, chilldName: child.Name))).Should().NotContain(pair => pair.chilldName == "Person #2");
+
+
+        // Restore pairing
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" });
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
+
+
+        // No change
+        _people.AddOrUpdate(new Person() { Name = "Person #2", ParentName = "Person #1" });
+
+        _result.Data.Count.Should().Be(3);
+        _result.Data.Items.SelectMany(family => family.Children.Select(child => (family.Parent.Name, child.Name))).Should().Contain(("Person #1", "Person #2"));
     }
 
     private void AssertDataIsCorrectlyFormed(Person[] expected, params string[] missingParents)

--- a/src/DynamicData.Tests/Domain/Person.cs
+++ b/src/DynamicData.Tests/Domain/Person.cs
@@ -22,6 +22,7 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>, ICompar
     private int _age;
     private int? _ageNullable;
     private Color _favoriteColor;
+    private string _parentName;
     private AnimalFamily _petType;
 
     public Person()
@@ -39,7 +40,7 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>, ICompar
         Name = name;
         _age = age;
         Gender = gender;
-        ParentName = parentName ?? string.Empty;
+        _parentName = parentName ?? string.Empty;
     }
 
     public Person(string name, int? age, string gender = "F", string? parentName = null)
@@ -47,7 +48,7 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>, ICompar
         Name = name;
         _ageNullable = age;
         Gender = gender;
-        ParentName = parentName ?? string.Empty;
+        _parentName = parentName ?? string.Empty;
     }
 
     private Person(string name, int? age, string gender, Person personCopyKey)
@@ -55,7 +56,7 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>, ICompar
         Name = name;
         _ageNullable = age;
         Gender = gender;
-        ParentName = personCopyKey?.ParentName ?? throw new ArgumentNullException(nameof(personCopyKey));
+        _parentName = personCopyKey?.ParentName ?? throw new ArgumentNullException(nameof(personCopyKey));
         UniqueKey = personCopyKey.UniqueKey;
     }
 
@@ -93,9 +94,13 @@ public class Person : AbstractNotifyPropertyChanged, IEquatable<Person>, ICompar
 
     public string UniqueKey { get; } = Guid.NewGuid().ToString("B");
 
-    public string Name { get; }
+    public string Name { get; init; }
 
-    public string ParentName { get; }
+    public string ParentName
+    {
+        get => _parentName;
+        set => SetAndRaise(ref _parentName, value);
+    }
 
     public static bool operator ==(Person left, Person right) => Equals(left, right);
 


### PR DESCRIPTION
Fixed issues across the Join operators, regarding incomplete or missing support for re-grouping, when foreign key values change.

Resolves #575.