### PR TITLE
Removed bogus `.Filter()` overload

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
@@ -279,9 +279,6 @@ namespace DynamicData.Alias
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Where<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Func<TObject, bool>> predicateChanged)
             where TObject :  notnull
             where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Where<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Reactive.Unit> reapplyFilter)
-            where TObject :  notnull
-            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Where<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Func<TObject, bool>> predicateChanged, System.IObservable<System.Reactive.Unit> reapplyFilter)
             where TObject :  notnull
             where TKey :  notnull { }
@@ -1321,9 +1318,6 @@ namespace DynamicData
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Func<TObject, bool>> predicateChanged, bool suppressEmptyChangeSets = true)
-            where TObject :  notnull
-            where TKey :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Reactive.Unit> reapplyFilter, bool suppressEmptyChangeSets = true)
             where TObject :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.IObservable<System.Func<TObject, bool>> predicateChanged, System.IObservable<System.Reactive.Unit> reapplyFilter, bool suppressEmptyChangeSets = true)

--- a/src/DynamicData.Tests/Cache/FilterControllerFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterControllerFixture.cs
@@ -162,7 +162,10 @@ public class FilterControllerFixture : IDisposable
         using var source = new SourceCache<Person, string>(p => p.Key);
         source.AddOrUpdate(Enumerable.Range(1, 100).Select(i => new Person("P" + i, i)).ToArray());
 
-        var ex = Record.Exception(() => source.Connect().Filter(Observable.Return(Unit.Default)).AsObservableCache());
+        var ex = Record.Exception(() => source.Connect().Filter(
+                predicateChanged: Observable.Return<Func<Person, bool>>(static _ => true),
+                reapplyFilter: Observable.Return(Unit.Default))
+            .AsObservableCache());
         Assert.Null(ex);
     }
 

--- a/src/DynamicData/Alias/ObservableCacheAlias.cs
+++ b/src/DynamicData/Alias/ObservableCacheAlias.cs
@@ -298,24 +298,6 @@ public static class ObservableCacheAlias
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <param name="source">The source.</param>
-    /// <param name="reapplyFilter">Observable to re-evaluate whether the filter still matches items. Use when filtering on mutable values.</param>
-    /// <returns>An observable which emits the change set.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Where<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Unit> reapplyFilter)
-        where TObject : notnull
-        where TKey : notnull
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        reapplyFilter.ThrowArgumentNullExceptionIfNull(nameof(reapplyFilter));
-
-        return source.Filter(reapplyFilter);
-    }
-
-    /// <summary>
-    /// Creates a filtered stream which can be dynamically filtered.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <param name="source">The source.</param>
     /// <param name="predicateChanged">Observable to change the underlying predicate.</param>
     /// <param name="reapplyFilter">Observable to re-evaluate whether the filter still matches items. Use when filtering on mutable values.</param>
     /// <returns>An observable which emits the change set.</returns>

--- a/src/DynamicData/Cache/ObservableCacheEx.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.cs
@@ -1507,25 +1507,6 @@ public static partial class ObservableCacheEx
     /// <typeparam name="TObject">The type of the object.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <param name="source">The source.</param>
-    /// <param name="reapplyFilter">Observable to re-evaluate whether the filter still matches items. Use when filtering on mutable values.</param>
-    /// <param name="suppressEmptyChangeSets">By default empty changeset notifications are suppressed for performance reasons.  Set to false to publish empty changesets.  Doing so can be useful for monitoring loading status.</param>
-    /// <returns>An observable which emits change sets.</returns>
-    public static IObservable<IChangeSet<TObject, TKey>> Filter<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, IObservable<Unit> reapplyFilter, bool suppressEmptyChangeSets = true)
-        where TObject : notnull
-        where TKey : notnull
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        reapplyFilter.ThrowArgumentNullExceptionIfNull(nameof(reapplyFilter));
-
-        return source.Filter(Observable.Empty<Func<TObject, bool>>(), reapplyFilter, suppressEmptyChangeSets);
-    }
-
-    /// <summary>
-    /// Creates a filtered stream which can be dynamically filtered.
-    /// </summary>
-    /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <typeparam name="TKey">The type of the key.</typeparam>
-    /// <param name="source">The source.</param>
     /// <param name="predicateChanged">Observable to change the underlying predicate.</param>
     /// <param name="reapplyFilter">Observable to re-evaluate whether the filter still matches items. Use when filtering on mutable values.</param>
     /// <param name="suppressEmptyChangeSets">By default empty changeset notifications are suppressed for performance reasons.  Set to false to publish empty changesets.  Doing so can be useful for monitoring loading status.</param>


### PR DESCRIPTION
Removed a bogus .Filter() overload that did not allow the consumer to supply filtering logic, resulting in all items always being filtered out.

This appears to have been mistakenly introduced during a refactor, in commit 3657fee1cb3144ad505c903466aa8c37b31f2214.