### PR TITLE
Added weak-referencing to operators using background scheduling

### DIFF
--- a/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
+++ b/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
@@ -204,11 +204,15 @@ internal static partial class ExpireAfter
                         _nextScheduledManagement = new()
                         {
                             Cancellation = _scheduler.Schedule(
-                                state: this,
+                                state: new WeakReference<SubscriptionBase>(this),
                                 dueTime: nextManagementDueTime,
-                                action: static (_, @this) =>
+                                action: static (_, thisReference) =>
                                 {
-                                    @this.ManageExpirations();
+                                    // Most schedulers won't clear scheduled actions upon cancellation, they'll wait until they were supposed to occur.
+                                    // A WeakReference here prevents the whole subscription from memory leaking
+                                    // Refer to https://github.com/reactivemarbles/DynamicData/issues/1025
+                                    if (thisReference.TryGetTarget(out var @this))
+                                        @this.ManageExpirations();
 
                                     return Disposable.Empty;
                                 }),

--- a/src/DynamicData/Cache/Internal/ExpireAfter.ForStream.cs
+++ b/src/DynamicData/Cache/Internal/ExpireAfter.ForStream.cs
@@ -182,11 +182,15 @@ internal static partial class ExpireAfter
                         _nextScheduledManagement = new()
                         {
                             Cancellation = _scheduler.Schedule(
-                                state: this,
+                                state: new WeakReference<SubscriptionBase>(this),
                                 dueTime: nextManagementDueTime,
-                                action: (_, @this) =>
+                                action: (_, thisReference) =>
                                 {
-                                    @this.ManageExpirations();
+                                    // Most schedulers won't clear scheduled actions upon cancellation, they'll wait until they were supposed to occur.
+                                    // A WeakReference here prevents the whole subscription from memory leaking
+                                    // Refer to https://github.com/reactivemarbles/DynamicData/issues/1025
+                                    if (thisReference.TryGetTarget(out var @this))
+                                        @this.ManageExpirations();
 
                                     return Disposable.Empty;
                                 }),

--- a/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
+++ b/src/DynamicData/Cache/Internal/ToObservableChangeSet.cs
@@ -114,9 +114,7 @@ internal static class ToObservableChangeSet<TObject, TKey>
             _scheduledExpiration?.Cancellation.Dispose();
         }
 
-        private IDisposable OnScheduledExpirationInvoked(
-            IScheduler scheduler,
-            Expiration intendedExpiration)
+        private IDisposable OnScheduledExpirationInvoked(Expiration intendedExpiration)
         {
             try
             {
@@ -256,9 +254,20 @@ internal static class ToObservableChangeSet<TObject, TKey>
                 ScheduledExpiration unfinishedExpiration,
                 IScheduler scheduler)
             => unfinishedExpiration.Cancellation.Disposable = scheduler.Schedule(
-                state: unfinishedExpiration.Expiration,
+                state: (
+                    thisReference: new WeakReference<Subscription>(this),
+                    expiration: unfinishedExpiration.Expiration),
                 dueTime: unfinishedExpiration.Expiration.ExpireAt,
-                action: OnScheduledExpirationInvoked);
+                action: static (_, state) =>
+                {
+                    // Most schedulers won't clear scheduled actions upon cancellation, they'll wait until they were supposed to occur.
+                    // A WeakReference here prevents the whole subscription from memory leaking
+                    // Refer to https://github.com/reactivemarbles/DynamicData/issues/1025
+                    if (state.thisReference.TryGetTarget(out var @this))
+                        @this.OnScheduledExpirationInvoked(state.expiration);
+
+                    return Disposable.Empty;
+                });
 
         private void TryPublishCompletion()
         {


### PR DESCRIPTION
This ensures that schedulers do not leak the operator subscriptions.

Resolves #1025.