### PR TITLE
Enhanced .WhenValueChanged() to support type casting within the expression.

### DIFF
--- a/src/DynamicData/Binding/ObservablePropertyFactory.cs
+++ b/src/DynamicData/Binding/ObservablePropertyFactory.cs
@@ -55,11 +55,11 @@ internal sealed class ObservablePropertyFactory<TObject, TProperty>
     // create notifier for all parts of the property path
     private static IEnumerable<IObservable<Unit>> GetNotifiers(TObject source, IEnumerable<ObservablePropertyPart> chain)
     {
-        object value = source;
+        object? value = source;
         foreach (var metadata in chain.Reverse())
         {
             var obs = metadata.Factory(value).Publish().RefCount();
-            value = metadata.Accessor(value);
+            value = metadata.Invoker(value);
             yield return obs;
 
             if (value is null)
@@ -72,10 +72,10 @@ internal sealed class ObservablePropertyFactory<TObject, TProperty>
     // walk the tree and break at a null, or return the value [should reduce this to a null an expression]
     private static PropertyValue<TObject, TProperty> GetPropertyValue(TObject source, IEnumerable<ObservablePropertyPart> chain, Func<TObject, TProperty> valueAccessor)
     {
-        object value = source;
+        object? value = source;
         foreach (var metadata in chain.Reverse())
         {
-            value = metadata.Accessor(value);
+            value = metadata.Invoker(value);
             if (value is null)
             {
                 return new PropertyValue<TObject, TProperty>(source);

--- a/src/DynamicData/Binding/ObservablePropertyFactoryCache.cs
+++ b/src/DynamicData/Binding/ObservablePropertyFactoryCache.cs
@@ -27,13 +27,13 @@ internal sealed class ObservablePropertyFactoryCache
             key,
             _ =>
             {
-                var memberChain = expression.GetMemberChain().ToArray();
-                if (memberChain.Length == 1)
+                var steps = expression.SplitIntoSteps().ToArray();
+                if (steps.Length == 1)
                 {
                     return new ObservablePropertyFactory<TObject, TProperty>(expression);
                 }
 
-                var chain = memberChain.Select(m => new ObservablePropertyPart(m)).ToArray();
+                var chain = steps.Select(m => new ObservablePropertyPart(m)).ToArray();
                 var accessor = expression.Compile() ?? throw new ArgumentNullException(nameof(expression));
 
                 return new ObservablePropertyFactory<TObject, TProperty>(accessor, chain);

--- a/src/DynamicData/Binding/ObservablePropertyPart.cs
+++ b/src/DynamicData/Binding/ObservablePropertyPart.cs
@@ -9,9 +9,9 @@ using System.Reactive;
 namespace DynamicData.Binding;
 
 [DebuggerDisplay("ObservablePropertyPart<{" + nameof(expression) + "}>")]
-internal sealed class ObservablePropertyPart(MemberExpression expression)
+internal sealed class ObservablePropertyPart(Expression expression)
 {
-    public Func<object, object> Accessor { get; } = expression.CreateValueAccessor();
+    public Func<object, object?> Invoker { get; } = expression.CreateInvoker();
 
     public Func<object, IObservable<Unit>> Factory { get; } = expression.CreatePropertyChangedFactory();
 }


### PR DESCRIPTION
In particular, this allows the use of null as a fallback value for non-nullable value types.

Resolves #1057