### PR TITLE
Fix Cross-Cache Deadlock with Notification Queue

### DIFF
--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
@@ -5,6 +5,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Bogus;
 using DynamicData.Kernel;
@@ -90,9 +91,11 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
                 .Parallelize(priceCount, parallel, obs => obs.StressAddRemove(market.PricesCache, _ => GetRemoveTime(), scheduler))
                 .Finally(market.PricesCache.Dispose);
 
-        var merged = _marketCache.Connect().MergeManyChangeSets(market => market.LatestPrices, Market.RatingCompare, resortOnSourceRefresh: true);
+        var merged = _marketCache.Connect().MergeManyChangeSets(market => market.LatestPrices, Market.RatingCompare, resortOnSourceRefresh: true).Publish();
         var adding = true;
+        var cacheCompleted = merged.LastOrDefaultAsync().ToTask();
         using var priceResults = merged.AsAggregator();
+        using var connect = merged.Connect();
 
         // Start asynchrononously modifying the parent list and the child lists
         using var addingSub = AddRemoveStress(marketCount, priceCount, Environment.ProcessorCount, TaskPoolScheduler.Default)
@@ -118,10 +121,8 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
         }
         while (adding);
 
-        // Allow any in-flight notification deliveries to complete before checking results.
-        // With the queue-based drain pattern, Edit() returns after enqueueing but delivery
-        // may still be in progress on another thread. Give the drain a moment to finish.
-        await Task.Delay(250).ConfigureAwait(false);
+        // Wait for the source cache to finish delivering all notifications.
+        await cacheCompleted;
 
         // Verify the results
         CheckResultContents(_marketCacheResults, priceResults, Market.RatingCompare);

--- a/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
+++ b/src/DynamicData.Tests/Cache/MergeManyChangeSetsCacheSourceCompareFixture.cs
@@ -118,6 +118,11 @@ public sealed class MergeManyChangeSetsCacheSourceCompareFixture : IDisposable
         }
         while (adding);
 
+        // Allow any in-flight notification deliveries to complete before checking results.
+        // With the queue-based drain pattern, Edit() returns after enqueueing but delivery
+        // may still be in progress on another thread. Give the drain a moment to finish.
+        await Task.Delay(250).ConfigureAwait(false);
+
         // Verify the results
         CheckResultContents(_marketCacheResults, priceResults, Market.RatingCompare);
     }

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -228,7 +228,6 @@ public class SourceCacheFixture : IDisposable
         results.Data.Items.Should().BeEquivalentTo([.. cacheA.Items, .. cacheB.Items], "all items should be in the destination");
     }
 
-
     [Fact]
     public async Task DirectCrossWriteDoesNotDeadlock()
     {
@@ -239,27 +238,17 @@ public class SourceCacheFixture : IDisposable
             using var cacheA = new SourceCache<TestItem, string>(static x => x.Key);
             using var cacheB = new SourceCache<TestItem, string>(static x => x.Key);
 
-            using var subA = cacheA.Connect().Subscribe(changes =>
-            {
-                foreach (var c in changes)
-                {
-                    if (c.Reason == ChangeReason.Add && !c.Current.Key.StartsWith("x"))
-                    {
-                        cacheB.AddOrUpdate(new TestItem("x" + c.Current.Key, c.Current.Value));
-                    }
-                }
-            });
+            // Bidirectional: A items flow into B, B items flow into A.
+            // Filter by prefix prevents infinite feedback.
+            using var aToB = cacheA.Connect()
+                .Filter(static x => x.Key.StartsWith('a'))
+                .Transform(static (item, _) => new TestItem("from-a-" + item.Key, item.Value))
+                .PopulateInto(cacheB);
 
-            using var subB = cacheB.Connect().Subscribe(changes =>
-            {
-                foreach (var c in changes)
-                {
-                    if (c.Reason == ChangeReason.Add && !c.Current.Key.StartsWith("x"))
-                    {
-                        cacheA.AddOrUpdate(new TestItem("x" + c.Current.Key, c.Current.Value));
-                    }
-                }
-            });
+            using var bToA = cacheB.Connect()
+                .Filter(static x => x.Key.StartsWith('b'))
+                .Transform(static (item, _) => new TestItem("from-b-" + item.Key, item.Value))
+                .PopulateInto(cacheA);
 
             var barrier = new Barrier(2);
 
@@ -282,9 +271,9 @@ public class SourceCacheFixture : IDisposable
             });
 
             var completed = Task.WhenAll(taskA, taskB);
-            var finished = await Task.WhenAny(completed, Task.Delay(TimeSpan.FromSeconds(5)));
+            var finished = await Task.WhenAny(completed, Task.Delay(TimeSpan.FromSeconds(30)));
 
-            finished.Should().BeSameAs(completed, $"iteration {iter}: direct cross-cache writes should not deadlock");
+            finished.Should().BeSameAs(completed, $"iteration {iter}: bidirectional cross-cache writes should not deadlock");
         }
     }
     private sealed record TestItem(string Key, string Value);

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -281,49 +281,78 @@ public class SourceCacheFixture : IDisposable
     [Fact]
     public void ConnectDuringDeliveryDoesNotDuplicate()
     {
-        // Proves the dequeue-to-delivery gap. A slow subscriber holds delivery
-        // while another thread connects. The new subscriber's snapshot is taken
-        // under the lock, so it will not see a duplicate Add.
+        // Exploits the dequeue-to-OnNext window. Thread A writes two items in
+        // separate batches. The first delivery is held by a slow subscriber.
+        // While item1 delivery is blocked, item2 is committed to ReaderWriter
+        // and sitting in the queue. Thread B calls Connect(), takes a snapshot
+        // (sees both items), subscribes to _changes, then item2 is delivered
+        // via OnNext — producing a duplicate if not guarded by a generation counter.
         using var cache = new SourceCache<TestItem, string>(static x => x.Key);
 
-        var delivering = new ManualResetEventSlim(false);
-        var connectDone = new ManualResetEventSlim(false);
+        using var delivering = new ManualResetEventSlim(false);
+        using var item2Written = new ManualResetEventSlim(false);
+        using var connectDone = new ManualResetEventSlim(false);
 
-        // First subscriber: signals when delivery starts, then waits
+        var firstDelivery = true;
+
+        // First subscriber: blocks on the first delivery to create the window
         using var slowSub = cache.Connect().Subscribe(_ =>
         {
-            delivering.Set();
-            connectDone.Wait(TimeSpan.FromSeconds(5));
+            if (firstDelivery)
+            {
+                firstDelivery = false;
+                delivering.Set();
+
+                // Wait until item2 has been written and the Connect has subscribed
+                connectDone.Wait(TimeSpan.FromSeconds(5));
+            }
         });
 
-        // Write one item -- delivery starts, slow subscriber blocks
-        var writeTask = Task.Run(() => cache.AddOrUpdate(new TestItem("k1", "v1")));
+        // Write item1 on a background thread — delivery starts, slow subscriber blocks
+        var writeTask = Task.Run(() =>
+        {
+            cache.AddOrUpdate(new TestItem("k1", "v1"));
+        });
 
-        // Wait for delivery to be in progress
-        delivering.Wait(TimeSpan.FromSeconds(5));
+        // Wait for delivery of item1 to be in progress (slow sub is blocking)
+        delivering.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("delivery should have started");
 
-        // Now Connect on the main thread while delivery is in progress.
-        // The item is already committed to ReaderWriter and dequeued from
-        // the delivery queue, but OnNext hasn't finished iterating observers.
-        var duplicateKeys = new List<string>();
+        // Now write item2 on another thread. It will acquire the lock, commit to
+        // ReaderWriter, enqueue a notification, and return. The notification sits
+        // in the queue because the deliverer (Thread A) is blocked by the slow sub.
+        var writeTask2 = Task.Run(() =>
+        {
+            cache.AddOrUpdate(new TestItem("k2", "v2"));
+            item2Written.Set();
+        });
+        item2Written.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("item2 should have been written");
+
+        // Now Connect on the main thread. The snapshot from ReaderWriter includes
+        // BOTH k1 and k2. The subscription to _changes is added. When the slow
+        // subscriber unblocks, item2's notification will be delivered via OnNext
+        // and the new subscriber will see k2 again — a duplicate Add.
+        var addCounts = new Dictionary<string, int>();
         using var newSub = cache.Connect().Subscribe(changes =>
         {
             foreach (var c in changes)
             {
                 if (c.Reason == ChangeReason.Add)
                 {
-                    duplicateKeys.Add(c.Current.Key);
+                    var key = c.Current.Key;
+                    addCounts[key] = addCounts.GetValueOrDefault(key) + 1;
                 }
             }
         });
 
-        // Let delivery finish
+        // Unblock the slow subscriber — delivery resumes, item2 delivered
         connectDone.Set();
         writeTask.Wait(TimeSpan.FromSeconds(5));
+        writeTask2.Wait(TimeSpan.FromSeconds(5));
 
-        // Check: k1 should appear exactly once (either in snapshot or stream, not both)
-        var k1Count = duplicateKeys.Count(k => k == "k1");
-        k1Count.Should().Be(1, "k1 should appear exactly once via Connect, not duplicated from snapshot + in-flight delivery");
+        // Each key should appear exactly once in the new subscriber's view
+        addCounts.GetValueOrDefault("k1").Should().Be(1, "k1 should appear once (snapshot only)");
+        addCounts.GetValueOrDefault("k2").Should().Be(1, "k2 should appear once, not duplicated from snapshot + queued delivery");
     }
+
     private sealed record TestItem(string Key, string Value);
 }

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 using DynamicData.Tests.Domain;
 
@@ -188,4 +190,43 @@ public class SourceCacheFixture : IDisposable
 
     public record class SomeObject(int Id, int Value);
 
+
+    [Fact]
+    public async Task ConcurrentEditsShouldNotDeadlockWithSubscribersThatModifyOtherCaches()
+    {
+        const int itemCount = 100;
+
+        using var cacheA = new SourceCache<TestItem, string>(static x => x.Key);
+        using var cacheB = new SourceCache<TestItem, string>(static x => x.Key);
+        using var destination = new SourceCache<TestItem, string>(static x => x.Key);
+        using var subA = cacheA.Connect().PopulateInto(destination);
+        using var subB = cacheB.Connect().PopulateInto(destination);
+        using var results = destination.Connect().AsAggregator();
+
+        var taskA = Task.Run(() =>
+        {
+            for (var i = 0; i < itemCount; i++)
+            {
+                cacheA.AddOrUpdate(new TestItem($"a-{i}", $"ValueA-{i}"));
+            }
+        });
+
+        var taskB = Task.Run(() =>
+        {
+            for (var i = 0; i < itemCount; i++)
+            {
+                cacheB.AddOrUpdate(new TestItem($"b-{i}", $"ValueB-{i}"));
+            }
+        });
+
+        var completed = Task.WhenAll(taskA, taskB);
+        var finished = await Task.WhenAny(completed, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        finished.Should().BeSameAs(completed, "concurrent edits with cross-cache subscribers should not deadlock");
+        results.Error.Should().BeNull();
+        results.Data.Count.Should().Be(itemCount * 2, "all items from both caches should arrive in the destination");
+        results.Data.Items.Should().BeEquivalentTo([.. cacheA.Items, .. cacheB.Items], "all items should be in the destination");
+    }
+
+    private sealed record TestItem(string Key, string Value);
 }

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -193,7 +193,7 @@ public class SourceCacheFixture : IDisposable
 
 
     [Fact]
-    public async Task ConcurrentEditsShouldNotDeadlockWithSubscribersThatModifyOtherCaches()
+    public async Task MultiCacheFanInDoesNotDeadlock()
     {
         const int itemCount = 100;
 
@@ -346,8 +346,8 @@ public class SourceCacheFixture : IDisposable
 
         // Unblock the slow subscriber — delivery resumes, item2 delivered
         connectDone.Set();
-        writeTask.Wait(TimeSpan.FromSeconds(5));
-        writeTask2.Wait(TimeSpan.FromSeconds(5));
+        writeTask.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("writeTask should complete");
+        writeTask2.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("writeTask2 should complete");
 
         // Each key should appear exactly once in the new subscriber's view
         addCounts.GetValueOrDefault("k1").Should().Be(1, "k1 should appear once (snapshot only)");

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
@@ -275,6 +276,54 @@ public class SourceCacheFixture : IDisposable
 
             finished.Should().BeSameAs(completed, $"iteration {iter}: bidirectional cross-cache writes should not deadlock");
         }
+    }
+
+    [Fact]
+    public void ConnectDuringDeliveryDoesNotDuplicate()
+    {
+        // Proves the dequeue-to-delivery gap. A slow subscriber holds delivery
+        // while another thread connects. The new subscriber's snapshot is taken
+        // under the lock, so it will not see a duplicate Add.
+        using var cache = new SourceCache<TestItem, string>(static x => x.Key);
+
+        var delivering = new ManualResetEventSlim(false);
+        var connectDone = new ManualResetEventSlim(false);
+
+        // First subscriber: signals when delivery starts, then waits
+        using var slowSub = cache.Connect().Subscribe(_ =>
+        {
+            delivering.Set();
+            connectDone.Wait(TimeSpan.FromSeconds(5));
+        });
+
+        // Write one item -- delivery starts, slow subscriber blocks
+        var writeTask = Task.Run(() => cache.AddOrUpdate(new TestItem("k1", "v1")));
+
+        // Wait for delivery to be in progress
+        delivering.Wait(TimeSpan.FromSeconds(5));
+
+        // Now Connect on the main thread while delivery is in progress.
+        // The item is already committed to ReaderWriter and dequeued from
+        // the delivery queue, but OnNext hasn't finished iterating observers.
+        var duplicateKeys = new List<string>();
+        using var newSub = cache.Connect().Subscribe(changes =>
+        {
+            foreach (var c in changes)
+            {
+                if (c.Reason == ChangeReason.Add)
+                {
+                    duplicateKeys.Add(c.Current.Key);
+                }
+            }
+        });
+
+        // Let delivery finish
+        connectDone.Set();
+        writeTask.Wait(TimeSpan.FromSeconds(5));
+
+        // Check: k1 should appear exactly once (either in snapshot or stream, not both)
+        var k1Count = duplicateKeys.Count(k => k == "k1");
+        k1Count.Should().Be(1, "k1 should appear exactly once via Connect, not duplicated from snapshot + in-flight delivery");
     }
     private sealed record TestItem(string Key, string Value);
 }

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
@@ -228,5 +228,64 @@ public class SourceCacheFixture : IDisposable
         results.Data.Items.Should().BeEquivalentTo([.. cacheA.Items, .. cacheB.Items], "all items should be in the destination");
     }
 
+
+    [Fact]
+    public async Task DirectCrossWriteDoesNotDeadlock()
+    {
+        const int iterations = 100;
+
+        for (var iter = 0; iter < iterations; iter++)
+        {
+            using var cacheA = new SourceCache<TestItem, string>(static x => x.Key);
+            using var cacheB = new SourceCache<TestItem, string>(static x => x.Key);
+
+            using var subA = cacheA.Connect().Subscribe(changes =>
+            {
+                foreach (var c in changes)
+                {
+                    if (c.Reason == ChangeReason.Add && !c.Current.Key.StartsWith("x"))
+                    {
+                        cacheB.AddOrUpdate(new TestItem("x" + c.Current.Key, c.Current.Value));
+                    }
+                }
+            });
+
+            using var subB = cacheB.Connect().Subscribe(changes =>
+            {
+                foreach (var c in changes)
+                {
+                    if (c.Reason == ChangeReason.Add && !c.Current.Key.StartsWith("x"))
+                    {
+                        cacheA.AddOrUpdate(new TestItem("x" + c.Current.Key, c.Current.Value));
+                    }
+                }
+            });
+
+            var barrier = new Barrier(2);
+
+            var taskA = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (var i = 0; i < 1000; i++)
+                {
+                    cacheA.AddOrUpdate(new TestItem("a" + i, "V" + i));
+                }
+            });
+
+            var taskB = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (var i = 0; i < 1000; i++)
+                {
+                    cacheB.AddOrUpdate(new TestItem("b" + i, "V" + i));
+                }
+            });
+
+            var completed = Task.WhenAll(taskA, taskB);
+            var finished = await Task.WhenAny(completed, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            finished.Should().BeSameAs(completed, $"iteration {iter}: direct cross-cache writes should not deadlock");
+        }
+    }
     private sealed record TestItem(string Key, string Value);
 }

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -251,7 +251,7 @@ public class SourceCacheFixture : IDisposable
                 .Transform(static (item, _) => new TestItem("from-b-" + item.Key, item.Value))
                 .PopulateInto(cacheA);
 
-            var barrier = new Barrier(2);
+            using var barrier = new Barrier(2);
 
             var taskA = Task.Run(() =>
             {

--- a/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.cs
+++ b/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.cs
@@ -393,7 +393,7 @@ public sealed class SuspendNotificationsFixture : IDisposable
         results.Messages[1].Adds.Should().Be(dataSet2.Count, $"second message has {dataSet2.Count} adds");
         results.Messages[1].Removes.Should().Be(0, "no removes in second message");
         results.Messages[1].Updates.Should().Be(0, "no updates in second message");
-        results.Messages[1].Select(x => x.Key).Should().Equal(dataSet2, "snapshot should contain first batch keys");
+        results.Messages[1].Select(x => x.Key).Should().Equal(dataSet2, "second message should contain second batch keys");
 
         results.Summary.Overall.Adds.Should().Be(allData.Count, $"exactly {allData.Count} adds total");
         results.Summary.Overall.Removes.Should().Be(0, "no removes");

--- a/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.cs
+++ b/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DynamicData.Kernel;
 using FluentAssertions;
@@ -350,6 +351,234 @@ public sealed class SuspendNotificationsFixture : IDisposable
         _results.Data.Count.Should().Be(100, "Should receive data after resume");
         _results.Messages.Count.Should().Be(1, "Should receive single changeset on resume");
         _results.Messages[0].Adds.Should().Be(100, "Should have 100 adds");
+    }
+
+    [Fact]
+    public void ResumeThenReSuspendDeliversFirstBatchOnly()
+    {
+        // Forces the ordering: resume completes before re-suspend.
+        // The deferred subscriber activates with the first batch snapshot,
+        // then re-suspend holds the second batch until final resume.
+        using var cache = new SourceCache<int, int>(static x => x);
+        var dataSet1 = Enumerable.Range(0, 100).ToList();
+        var dataSet2 = Enumerable.Range(1000, 100).ToList();
+        var allData = dataSet1.Concat(dataSet2).ToList();
+
+        var suspend1 = cache.SuspendNotifications();
+        cache.AddOrUpdate(dataSet1);
+
+        using var results = cache.Connect().AsAggregator();
+        results.Messages.Count.Should().Be(0, "no messages during suspension");
+
+        // Resume first — subscriber activates
+        suspend1.Dispose();
+
+        results.Messages.Count.Should().Be(1, "exactly one message after resume");
+        results.Messages[0].Adds.Should().Be(dataSet1.Count, $"snapshot should have {dataSet1.Count} adds");
+        results.Messages[0].Removes.Should().Be(0, "no removes");
+        results.Messages[0].Updates.Should().Be(0, "no updates");
+        results.Messages[0].Select(x => x.Key).Should().Equal(dataSet1, "snapshot should contain first batch keys");
+
+        // Re-suspend, write second batch
+        var suspend2 = cache.SuspendNotifications();
+        cache.AddOrUpdate(dataSet2);
+
+        results.Messages.Count.Should().Be(1, "still one message — second batch held by suspension");
+        results.Summary.Overall.Adds.Should().Be(dataSet1.Count, $"still {dataSet1.Count} adds total");
+
+        // Final resume
+        suspend2.Dispose();
+
+        results.Messages.Count.Should().Be(2, "two messages total");
+        results.Messages[1].Adds.Should().Be(dataSet2.Count, $"second message has {dataSet2.Count} adds");
+        results.Messages[1].Removes.Should().Be(0, "no removes in second message");
+        results.Messages[1].Updates.Should().Be(0, "no updates in second message");
+        results.Messages[1].Select(x => x.Key).Should().Equal(dataSet2, "snapshot should contain first batch keys");
+
+        results.Summary.Overall.Adds.Should().Be(allData.Count, $"exactly {allData.Count} adds total");
+        results.Summary.Overall.Removes.Should().Be(0, "no removes");
+        results.Data.Count.Should().Be(allData.Count, $"{allData.Count} items in final state");
+        results.Error.Should().BeNull();
+        results.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReSuspendThenResumeDeliversAllInSingleBatch()
+    {
+        // Forces the ordering: re-suspend before resume.
+        // Suspend count goes 1→2→1, no resume signal fires.
+        // Both batches accumulate and arrive as a single changeset on final resume.
+        using var cache = new SourceCache<int, int>(static x => x);
+        var dataSet1 = Enumerable.Range(0, 100).ToList();
+        var dataSet2 = Enumerable.Range(1000, 100).ToList();
+        var allData = dataSet1.Concat(dataSet2).ToList();
+
+        var suspend1 = cache.SuspendNotifications();
+        cache.AddOrUpdate(dataSet1);
+
+        using var results = cache.Connect().AsAggregator();
+        results.Messages.Count.Should().Be(0, "no messages during suspension");
+
+        // Re-suspend first — count goes 1→2
+        var suspend2 = cache.SuspendNotifications();
+
+        // Resume first suspend — count goes 2→1, still suspended
+        suspend1.Dispose();
+
+        results.Messages.Count.Should().Be(0, "no messages — still suspended (count=1)");
+        results.Summary.Overall.Adds.Should().Be(0, "no adds — still suspended");
+
+        // Write second batch while still suspended
+        cache.AddOrUpdate(dataSet2);
+
+        results.Messages.Count.Should().Be(0, "still no messages");
+
+        // Final resume — count goes 1→0
+        suspend2.Dispose();
+
+        results.Messages.Count.Should().Be(1, "single message with all data");
+        results.Messages[0].Adds.Should().Be(allData.Count, $"all {allData.Count} items in one changeset");
+        results.Messages[0].Removes.Should().Be(0, "no removes");
+        results.Messages[0].Updates.Should().Be(0, "no updates");
+        results.Messages[0].Select(c => c.Key).OrderBy(k => k).Should().Equal(allData, "should contain both batches in order");
+
+        results.Summary.Overall.Adds.Should().Be(allData.Count, $"exactly {allData.Count} adds total");
+        results.Summary.Overall.Removes.Should().Be(0, "no removes");
+        results.Summary.Overall.Updates.Should().Be(0, "no updates");
+        results.Data.Count.Should().Be(allData.Count, $"{allData.Count} items in final state");
+        results.Error.Should().BeNull();
+        results.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ConcurrentSuspendDuringResumeDoesNotCorrupt()
+    {
+        // Stress test: races resume against re-suspend on two threads.
+        // Both orderings are correct (tested deterministically above).
+        // This test verifies no corruption, deadlocks, or data loss under contention.
+        const int iterations = 200;
+        var dataSet1 = Enumerable.Range(0, 100).ToList();
+        var dataSet2 = Enumerable.Range(1000, 100).ToList();
+        var allData = dataSet1.Concat(dataSet2).ToList();
+
+        for (var iter = 0; iter < iterations; iter++)
+        {
+            using var cache = new SourceCache<int, int>(static x => x);
+
+            var suspend1 = cache.SuspendNotifications();
+            cache.AddOrUpdate(dataSet1);
+            using var results = cache.Connect().AsAggregator();
+
+            using var barrier = new Barrier(2);
+            var resumeTask = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                suspend1.Dispose();
+            });
+
+            var reSuspendTask = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                return cache.SuspendNotifications();
+            });
+
+            await Task.WhenAll(resumeTask, reSuspendTask);
+            var suspend2 = await reSuspendTask;
+
+            cache.AddOrUpdate(dataSet2);
+            suspend2.Dispose();
+
+            results.Summary.Overall.Adds.Should().Be(allData.Count, $"iteration {iter}: exactly {allData.Count} adds");
+            results.Summary.Overall.Removes.Should().Be(0, $"iteration {iter}: no removes");
+            results.Summary.Overall.Updates.Should().Be(0, $"iteration {iter}: no updates because keys don't overlap");
+            results.Data.Count.Should().Be(allData.Count, $"iteration {iter}: {allData.Count} items in final state");
+            results.Data.Keys.OrderBy(k => k).Should().Equal(allData, $"iteration {iter}: all keys present in order");
+            results.Error.Should().BeNull($"iteration {iter}: no errors");
+            results.IsCompleted.Should().BeFalse($"iteration {iter}: not completed");
+        }
+    }
+
+    [Fact]
+    public async Task ResumeSignalUnderLockPreventsStaleSnapshotFromReSuspend()
+    {
+        // Verifies that a deferred Connect subscriber never sees data written during
+        // a re-suspension. The resume signal fires under the lock (reentrant), so the
+        // deferred subscriber activates and takes its snapshot before any other thread
+        // can re-suspend or write new data.
+        //
+        // A slow first subscriber blocks delivery of accumulated changes, creating a
+        // window where the main thread re-suspends and writes a second batch. The
+        // deferred subscriber's snapshot must contain only the first batch.
+        using var cache = new SourceCache<int, int>(static x => x);
+        var dataSet1 = Enumerable.Range(0, 100).ToList();
+        var dataSet2 = Enumerable.Range(1000, 100).ToList();
+        var allData = dataSet1.Concat(dataSet2).ToList();
+
+        using var delivering = new SemaphoreSlim(0, 1);
+        using var proceedWithResuspend = new SemaphoreSlim(0, 1);
+
+        var suspend1 = cache.SuspendNotifications();
+        cache.AddOrUpdate(dataSet1);
+
+        // First subscriber blocks on delivery to hold the delivery thread
+        var firstDelivery = true;
+        using var slowSub = cache.Connect().Subscribe(_ =>
+        {
+            if (firstDelivery)
+            {
+                firstDelivery = false;
+                delivering.Release();
+                proceedWithResuspend.Wait(TimeSpan.FromSeconds(5));
+            }
+        });
+
+        // Deferred subscriber — will activate when resume signal fires
+        using var results = cache.Connect().AsAggregator();
+        results.Messages.Count.Should().Be(0, "no messages during suspension");
+
+        // Resume on background thread — delivery blocks on slow subscriber
+        var resumeTask = Task.Run(() => suspend1.Dispose());
+        (await delivering.WaitAsync(TimeSpan.FromSeconds(5))).Should().BeTrue("delivery should have started");
+
+        // Re-suspend and write second batch while delivery is blocked
+        var suspend2 = cache.SuspendNotifications();
+        cache.AddOrUpdate(dataSet2);
+
+        // dataSet2 must not appear in any message received so far
+        foreach (var msg in results.Messages)
+        {
+            foreach (var change in msg)
+            {
+                change.Key.Should().BeInRange(0, 99,
+                    "deferred subscriber should only have first-batch keys before second resume");
+            }
+        }
+
+        // Unblock delivery
+        proceedWithResuspend.Release();
+        await resumeTask;
+
+        // Only dataSet1 should have been delivered — dataSet2 is held by second suspension
+        results.Summary.Overall.Adds.Should().Be(dataSet1.Count,
+            $"exactly {dataSet1.Count} adds before second resume — dataSet2 must be held by suspension");
+        results.Messages.Should().HaveCount(1, "exactly one message (snapshot of dataSet1)");
+        results.Messages[0].Adds.Should().Be(dataSet1.Count);
+        results.Messages[0].Select(c => c.Key).Should().Equal(dataSet1,
+            "snapshot should contain exactly first-batch keys in order");
+
+        // Resume second suspension — dataSet2 arrives now
+        suspend2.Dispose();
+
+        results.Summary.Overall.Adds.Should().Be(allData.Count, $"exactly {allData.Count} adds total");
+        results.Summary.Overall.Removes.Should().Be(0, "no removes");
+        results.Messages.Should().HaveCount(2, "two messages: snapshot + second batch");
+        results.Messages[1].Adds.Should().Be(dataSet2.Count);
+        results.Messages[1].Select(c => c.Key).Should().Equal(dataSet2,
+            "second message should contain exactly second-batch keys in order");
+        results.Data.Count.Should().Be(allData.Count);
+        results.Data.Keys.OrderBy(k => k).Should().Equal(allData);
+        results.Error.Should().BeNull();
+        results.IsCompleted.Should().BeFalse();
     }
 
     public void Dispose()

--- a/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
+++ b/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
@@ -316,9 +316,9 @@ public class DeliveryQueueFixture
 
         act.Should().Throw<InvalidOperationException>();
 
-        lock (_gate)
+        using (var rl = queue.AcquireReadLock())
         {
-            queue.PendingCount.Should().Be(1, "only the dequeued item should be decremented");
+            rl.PendingCount.Should().Be(1, "only the dequeued item should be decremented");
         }
     }
 
@@ -334,7 +334,10 @@ public class DeliveryQueueFixture
             notifications.Enqueue("STOP");
         }
 
-        queue.PendingCount.Should().Be(0);
+        using (var rl = queue.AcquireReadLock())
+        {
+            rl.PendingCount.Should().Be(0);
+        }
     }
 
     // Category 6: Stress / Thread Safety

--- a/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
+++ b/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
@@ -73,12 +73,32 @@ public class DeliveryQueueFixture
     {
         var concurrentCount = 0;
         var maxConcurrent = 0;
-        var queue = new DeliveryQueue<int>(_gate, _ =>
+        var deliveryCount = 0;
+        var delivered = new ConcurrentBag<int>();
+        using var firstDeliveryStarted = new ManualResetEventSlim(false);
+        using var allowFirstDeliveryToContinue = new ManualResetEventSlim(false);
+        using var startContenders = new ManualResetEventSlim(false);
+
+        var queue = new DeliveryQueue<int>(_gate, item =>
         {
             var current = Interlocked.Increment(ref concurrentCount);
-            if (current > maxConcurrent)
+            int snapshot;
+            do
             {
-                Interlocked.Exchange(ref maxConcurrent, current);
+                snapshot = maxConcurrent;
+                if (current <= snapshot)
+                {
+                    break;
+                }
+            }
+            while (Interlocked.CompareExchange(ref maxConcurrent, current, snapshot) != snapshot);
+
+            delivered.Add(item);
+
+            if (Interlocked.Increment(ref deliveryCount) == 1)
+            {
+                firstDeliveryStarted.Set();
+                allowFirstDeliveryToContinue.Wait();
             }
 
             Thread.SpinWait(1000);
@@ -86,18 +106,33 @@ public class DeliveryQueueFixture
             return true;
         });
 
-        using (var notifications = queue.AcquireLock())
-        {
-            for (var i = 0; i < 100; i++)
-            {
-                notifications.Enqueue(i);
-            }
-        }
+        // Start delivering the first item — it will block in the callback
+        var firstDelivery = Task.Run(() => EnqueueAndDeliver(queue, -1));
+        firstDeliveryStarted.Wait();
 
-        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() => TriggerDelivery(queue))).ToArray();
-        await Task.WhenAll(tasks);
+        // While first delivery is blocked, enqueue 100 items from concurrent threads
+        var enqueueTasks = Enumerable.Range(0, 100)
+            .Select(i => Task.Run(() =>
+            {
+                startContenders.Wait();
+                EnqueueAndDeliver(queue, i);
+            }));
+
+        var triggerTasks = Enumerable.Range(0, 4)
+            .Select(_ => Task.Run(() =>
+            {
+                startContenders.Wait();
+                TriggerDelivery(queue);
+            }));
+
+        var tasks = enqueueTasks.Concat(triggerTasks).ToArray();
+        startContenders.Set();
+        allowFirstDeliveryToContinue.Set();
+
+        await Task.WhenAll(tasks.Append(firstDelivery));
 
         maxConcurrent.Should().Be(1, "only one thread should be delivering at a time");
+        delivered.Should().HaveCount(101);
     }
 
     [Fact]

--- a/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
+++ b/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
@@ -1,0 +1,412 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DynamicData.Internal;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace DynamicData.Tests.Internal;
+
+public class DeliveryQueueFixture
+{
+#if NET9_0_OR_GREATER
+    private readonly Lock _gate = new();
+#else
+    private readonly object _gate = new();
+#endif
+
+    private static void EnqueueAndDeliver<T>(DeliveryQueue<T> queue, T item)
+    {
+        using var notifications = queue.AcquireLock();
+        notifications.Enqueue(item);
+    }
+
+    private static void TriggerDelivery<T>(DeliveryQueue<T> queue)
+    {
+        using var notifications = queue.AcquireLock();
+    }
+
+    // Category 1: Basic Behavior
+
+    [Fact]
+    public void EnqueueAndDeliverDeliversItem()
+    {
+        var delivered = new List<string>();
+        var queue = new DeliveryQueue<string>(_gate, item => { delivered.Add(item); return true; });
+
+        EnqueueAndDeliver(queue, "A");
+
+        delivered.Should().Equal("A");
+    }
+
+    [Fact]
+    public void DeliverDeliversItemsInFifoOrder()
+    {
+        var delivered = new List<string>();
+        var queue = new DeliveryQueue<string>(_gate, item => { delivered.Add(item); return true; });
+
+        using (var notifications = queue.AcquireLock())
+        {
+            notifications.Enqueue("A");
+            notifications.Enqueue("B");
+            notifications.Enqueue("C");
+        }
+
+        delivered.Should().Equal("A", "B", "C");
+    }
+
+    [Fact]
+    public void DeliverWithEmptyQueueIsNoOp()
+    {
+        var delivered = new List<string>();
+        var queue = new DeliveryQueue<string>(_gate, item => { delivered.Add(item); return true; });
+
+        TriggerDelivery(queue);
+
+        delivered.Should().BeEmpty();
+    }
+
+    // Category 2: Delivery Token Serialization
+
+    [Fact]
+    public async Task OnlyOneDelivererAtATime()
+    {
+        var concurrentCount = 0;
+        var maxConcurrent = 0;
+        var queue = new DeliveryQueue<int>(_gate, _ =>
+        {
+            var current = Interlocked.Increment(ref concurrentCount);
+            if (current > maxConcurrent)
+            {
+                Interlocked.Exchange(ref maxConcurrent, current);
+            }
+
+            Thread.SpinWait(1000);
+            Interlocked.Decrement(ref concurrentCount);
+            return true;
+        });
+
+        using (var notifications = queue.AcquireLock())
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                notifications.Enqueue(i);
+            }
+        }
+
+        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() => TriggerDelivery(queue))).ToArray();
+        await Task.WhenAll(tasks);
+
+        maxConcurrent.Should().Be(1, "only one thread should be delivering at a time");
+    }
+
+    [Fact]
+    public void SecondWriterItemPickedUpByFirstDeliverer()
+    {
+        var delivered = new List<string>();
+        var deliveryCount = 0;
+        DeliveryQueue<string>? q = null;
+
+        var queue = new DeliveryQueue<string>(_gate, item =>
+        {
+            delivered.Add(item);
+            if (Interlocked.Increment(ref deliveryCount) == 1)
+            {
+                using var notifications = q!.AcquireLock();
+                notifications.Enqueue("B");
+            }
+
+            return true;
+        });
+        q = queue;
+
+        EnqueueAndDeliver(queue, "A");
+
+        delivered.Should().Equal("A", "B");
+    }
+
+    [Fact]
+    public void ReentrantEnqueueDoesNotRecurse()
+    {
+        var callDepth = 0;
+        var maxDepth = 0;
+        var delivered = new List<string>();
+        DeliveryQueue<string>? q = null;
+
+        var queue = new DeliveryQueue<string>(_gate, item =>
+        {
+            callDepth++;
+            if (callDepth > maxDepth)
+            {
+                maxDepth = callDepth;
+            }
+
+            delivered.Add(item);
+
+            if (item == "A")
+            {
+                using var notifications = q!.AcquireLock();
+                notifications.Enqueue("B");
+            }
+
+            callDepth--;
+            return true;
+        });
+        q = queue;
+
+        EnqueueAndDeliver(queue, "A");
+
+        delivered.Should().Equal("A", "B");
+        maxDepth.Should().Be(1, "delivery callback should not recurse");
+    }
+
+    // Category 3: Exception Safety
+
+    [Fact]
+    public void ExceptionInDeliveryResetsDeliveryToken()
+    {
+        var callCount = 0;
+        var queue = new DeliveryQueue<string>(_gate, item =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            return true;
+        });
+
+        var act = () => EnqueueAndDeliver(queue, "A");
+        act.Should().Throw<InvalidOperationException>();
+
+        EnqueueAndDeliver(queue, "B");
+
+        callCount.Should().Be(2, "delivery should work after exception recovery");
+    }
+
+    [Fact]
+    public void RemainingItemsDeliveredAfterExceptionRecovery()
+    {
+        var delivered = new List<string>();
+        var shouldThrow = true;
+        var queue = new DeliveryQueue<string>(_gate, item =>
+        {
+            if (shouldThrow && item == "A")
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            delivered.Add(item);
+            return true;
+        });
+
+        var act = () =>
+        {
+            using var notifications = queue.AcquireLock();
+            notifications.Enqueue("A");
+            notifications.Enqueue("B");
+        };
+
+        act.Should().Throw<InvalidOperationException>();
+
+        shouldThrow = false;
+        TriggerDelivery(queue);
+
+        delivered.Should().Equal("B");
+    }
+
+    // Category 4: Termination
+
+    [Fact]
+    public void TerminalCallbackStopsDelivery()
+    {
+        var delivered = new List<string>();
+        var queue = new DeliveryQueue<string>(_gate, item =>
+        {
+            delivered.Add(item);
+            return item != "STOP";
+        });
+
+        using (var notifications = queue.AcquireLock())
+        {
+            notifications.Enqueue("A");
+            notifications.Enqueue("STOP");
+            notifications.Enqueue("B");
+        }
+
+        delivered.Should().Equal("A", "STOP");
+        queue.IsTerminated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnqueueAfterTerminationIsIgnored()
+    {
+        var delivered = new List<string>();
+        var queue = new DeliveryQueue<string>(_gate, item =>
+        {
+            delivered.Add(item);
+            return item != "STOP";
+        });
+
+        EnqueueAndDeliver(queue, "STOP");
+
+        EnqueueAndDeliver(queue, "AFTER");
+
+        delivered.Should().Equal("STOP");
+    }
+
+    [Fact]
+    public void IsTerminatedIsFalseInitially()
+    {
+        var queue = new DeliveryQueue<string>(_gate, _ => true);
+        queue.IsTerminated.Should().BeFalse();
+    }
+
+    // Category 5: PendingCount
+
+    [Fact]
+    public void PendingCountTracksAutomatically()
+    {
+        var queue = new DeliveryQueue<string>(_gate, _ => true);
+
+        using (var notifications = queue.AcquireLock())
+        {
+            notifications.PendingCount.Should().Be(0);
+
+            notifications.Enqueue("A", countAsPending: true);
+            notifications.Enqueue("B", countAsPending: true);
+            notifications.Enqueue("C");
+
+            notifications.PendingCount.Should().Be(2);
+        }
+
+        using (var notifications = queue.AcquireLock())
+        {
+            notifications.PendingCount.Should().Be(0, "pending count should auto-decrement on delivery");
+        }
+    }
+
+    [Fact]
+    public void PendingCountPreservedOnException()
+    {
+        var callCount = 0;
+        var queue = new DeliveryQueue<string>(_gate, _ =>
+        {
+            if (++callCount == 1)
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            return true;
+        });
+
+        var act = () =>
+        {
+            using var notifications = queue.AcquireLock();
+            notifications.Enqueue("A", countAsPending: true);
+            notifications.Enqueue("B", countAsPending: true);
+        };
+
+        act.Should().Throw<InvalidOperationException>();
+
+        lock (_gate)
+        {
+            queue.PendingCount.Should().Be(1, "only the dequeued item should be decremented");
+        }
+    }
+
+    [Fact]
+    public void PendingCountClearedOnTermination()
+    {
+        var queue = new DeliveryQueue<string>(_gate, item => item != "STOP");
+
+        using (var notifications = queue.AcquireLock())
+        {
+            notifications.Enqueue("A", countAsPending: true);
+            notifications.Enqueue("B", countAsPending: true);
+            notifications.Enqueue("STOP");
+        }
+
+        queue.PendingCount.Should().Be(0);
+    }
+
+    // Category 6: Stress / Thread Safety
+
+    [Fact]
+    public async Task ConcurrentEnqueueAllItemsDelivered()
+    {
+        const int threadCount = 8;
+        const int itemsPerThread = 500;
+        var delivered = new ConcurrentBag<int>();
+        var queue = new DeliveryQueue<int>(_gate, item => { delivered.Add(item); return true; });
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            for (var i = 0; i < itemsPerThread; i++)
+            {
+                EnqueueAndDeliver(queue, (t * itemsPerThread) + i);
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+        TriggerDelivery(queue);
+
+        delivered.Count.Should().Be(threadCount * itemsPerThread);
+    }
+
+    [Fact]
+    public async Task ConcurrentEnqueueNoDuplicates()
+    {
+        const int threadCount = 8;
+        const int itemsPerThread = 500;
+        var delivered = new ConcurrentBag<int>();
+        var queue = new DeliveryQueue<int>(_gate, item => { delivered.Add(item); return true; });
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            for (var i = 0; i < itemsPerThread; i++)
+            {
+                EnqueueAndDeliver(queue, (t * itemsPerThread) + i);
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+        TriggerDelivery(queue);
+
+        delivered.Distinct().Count().Should().Be(threadCount * itemsPerThread, "each item should be delivered exactly once");
+    }
+
+    [Fact]
+    public async Task ConcurrentEnqueuePreservesPerThreadOrdering()
+    {
+        const int threadCount = 4;
+        const int itemsPerThread = 200;
+        var delivered = new ConcurrentQueue<(int Thread, int Seq)>();
+        var queue = new DeliveryQueue<(int Thread, int Seq)>(_gate, item => { delivered.Enqueue(item); return true; });
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        {
+            for (var i = 0; i < itemsPerThread; i++)
+            {
+                EnqueueAndDeliver(queue, (t, i));
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+        TriggerDelivery(queue);
+
+        var itemsByThread = delivered.ToArray().GroupBy(x => x.Thread).ToDictionary(g => g.Key, g => g.Select(x => x.Seq).ToList());
+
+        foreach (var (thread, sequences) in itemsByThread)
+        {
+            sequences.Should().BeInAscendingOrder($"items from thread {thread} should preserve enqueue order");
+        }
+    }
+}

--- a/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
+++ b/src/DynamicData.Tests/Internal/DeliveryQueueFixture.cs
@@ -6,9 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using DynamicData.Internal;
-
 using FluentAssertions;
-
 using Xunit;
 
 namespace DynamicData.Tests.Internal;
@@ -31,8 +29,6 @@ public class DeliveryQueueFixture
     {
         using var notifications = queue.AcquireLock();
     }
-
-    // Category 1: Basic Behavior
 
     [Fact]
     public void EnqueueAndDeliverDeliversItem()
@@ -71,8 +67,6 @@ public class DeliveryQueueFixture
 
         delivered.Should().BeEmpty();
     }
-
-    // Category 2: Delivery Token Serialization
 
     [Fact]
     public async Task OnlyOneDelivererAtATime()
@@ -166,8 +160,6 @@ public class DeliveryQueueFixture
         maxDepth.Should().Be(1, "delivery callback should not recurse");
     }
 
-    // Category 3: Exception Safety
-
     [Fact]
     public void ExceptionInDeliveryResetsDeliveryToken()
     {
@@ -222,8 +214,6 @@ public class DeliveryQueueFixture
         delivered.Should().Equal("B");
     }
 
-    // Category 4: Termination
-
     [Fact]
     public void TerminalCallbackStopsDelivery()
     {
@@ -268,79 +258,6 @@ public class DeliveryQueueFixture
         var queue = new DeliveryQueue<string>(_gate, _ => true);
         queue.IsTerminated.Should().BeFalse();
     }
-
-    // Category 5: PendingCount
-
-    [Fact]
-    public void PendingCountTracksAutomatically()
-    {
-        var queue = new DeliveryQueue<string>(_gate, _ => true);
-
-        using (var notifications = queue.AcquireLock())
-        {
-            notifications.PendingCount.Should().Be(0);
-
-            notifications.Enqueue("A", countAsPending: true);
-            notifications.Enqueue("B", countAsPending: true);
-            notifications.Enqueue("C");
-
-            notifications.PendingCount.Should().Be(2);
-        }
-
-        using (var notifications = queue.AcquireLock())
-        {
-            notifications.PendingCount.Should().Be(0, "pending count should auto-decrement on delivery");
-        }
-    }
-
-    [Fact]
-    public void PendingCountPreservedOnException()
-    {
-        var callCount = 0;
-        var queue = new DeliveryQueue<string>(_gate, _ =>
-        {
-            if (++callCount == 1)
-            {
-                throw new InvalidOperationException("boom");
-            }
-
-            return true;
-        });
-
-        var act = () =>
-        {
-            using var notifications = queue.AcquireLock();
-            notifications.Enqueue("A", countAsPending: true);
-            notifications.Enqueue("B", countAsPending: true);
-        };
-
-        act.Should().Throw<InvalidOperationException>();
-
-        using (var rl = queue.AcquireReadLock())
-        {
-            rl.PendingCount.Should().Be(1, "only the dequeued item should be decremented");
-        }
-    }
-
-    [Fact]
-    public void PendingCountClearedOnTermination()
-    {
-        var queue = new DeliveryQueue<string>(_gate, item => item != "STOP");
-
-        using (var notifications = queue.AcquireLock())
-        {
-            notifications.Enqueue("A", countAsPending: true);
-            notifications.Enqueue("B", countAsPending: true);
-            notifications.Enqueue("STOP");
-        }
-
-        using (var rl = queue.AcquireReadLock())
-        {
-            rl.PendingCount.Should().Be(0);
-        }
-    }
-
-    // Category 6: Stress / Thread Safety
 
     [Fact]
     public async Task ConcurrentEnqueueAllItemsDelivered()

--- a/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
+++ b/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
@@ -161,11 +161,18 @@ internal static partial class ExpireAfter
                         {
                             _expirationDueTimesByKey.Remove(proposedExpiration.Key);
 
-                            _removedItemsBuffer.Add(new(
-                                key: proposedExpiration.Key,
-                                value: updater.Lookup(proposedExpiration.Key).Value));
+                            // The item may have been removed or updated by another thread between when
+                            // this expiration was scheduled and when it fired. Check that the item is
+                            // still present and still has an expiration before removing it.
+                            var lookup = updater.Lookup(proposedExpiration.Key);
+                            if (lookup.HasValue && _timeSelector.Invoke(lookup.Value) is not null)
+                            {
+                                _removedItemsBuffer.Add(new(
+                                    key: proposedExpiration.Key,
+                                    value: lookup.Value));
 
-                            updater.RemoveKey(proposedExpiration.Key);
+                                updater.RemoveKey(proposedExpiration.Key);
+                            }
                         }
                     }
                     _proposedExpirationsQueue.RemoveRange(0, proposedExpirationIndex);

--- a/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
+++ b/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
@@ -280,7 +280,7 @@ internal static partial class ExpireAfter
                                 {
                                     if (_timeSelector.Invoke(change.Current) is { } expireAfter)
                                     {
-                                        haveExpirationsChanged = TrySetExpiration(
+                                        haveExpirationsChanged |= TrySetExpiration(
                                             key: change.Key,
                                             dueTime: now + expireAfter);
                                     }

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -92,11 +92,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Observable.Create<int>(
             observer =>
             {
-                lock (_locker)
-                {
-                    var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
-                    return source.SubscribeSafe(observer);
-                }
+                using var readLock = _notifications.AcquireReadLock();
+
+                var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
+                return source.SubscribeSafe(observer);
             });
 
     public IReadOnlyList<TObject> Items => _readerWriter.Items;
@@ -233,56 +232,54 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Observable.Create<IChangeSet<TObject, TKey>>(
             observer =>
             {
-                lock (_locker)
+                using var readLock = _notifications.AcquireReadLock();
+
+                // Skip pending notifications to avoid duplicating items already in the snapshot.
+                var skipCount = readLock.PendingCount;
+
+                var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
+                var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
+                var changes = initial.Concat(changesStream);
+
+                if (predicate != null)
                 {
-                    // Skip pending notifications to avoid duplicating items already in the snapshot.
-                    var skipCount = _notifications.PendingCount;
-
-                    var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
-                    var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
-                    var changes = initial.Concat(changesStream);
-
-                    if (predicate != null)
-                    {
-                        changes = changes.Filter(predicate, suppressEmptyChangeSets);
-                    }
-                    else if (suppressEmptyChangeSets)
-                    {
-                        changes = changes.NotEmpty();
-                    }
-
-                    return changes.SubscribeSafe(observer);
+                    changes = changes.Filter(predicate, suppressEmptyChangeSets);
                 }
+                else if (suppressEmptyChangeSets)
+                {
+                    changes = changes.NotEmpty();
+                }
+
+                return changes.SubscribeSafe(observer);
             });
 
     private IObservable<Change<TObject, TKey>> CreateWatchObservable(TKey key) =>
         Observable.Create<Change<TObject, TKey>>(
             observer =>
             {
-                lock (_locker)
+                using var readLock = _notifications.AcquireReadLock();
+
+                var skipCount = readLock.PendingCount;
+
+                var initial = _readerWriter.Lookup(key);
+                if (initial.HasValue)
                 {
-                    var skipCount = _notifications.PendingCount;
-
-                    var initial = _readerWriter.Lookup(key);
-                    if (initial.HasValue)
-                    {
-                        observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
-                    }
-
-                    var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
-                    return changesStream.Finally(observer.OnCompleted).Subscribe(
-                        changes =>
-                        {
-                            foreach (var change in changes.ToConcreteType())
-                            {
-                                var match = EqualityComparer<TKey>.Default.Equals(change.Key, key);
-                                if (match)
-                                {
-                                    observer.OnNext(change);
-                                }
-                            }
-                        });
+                    observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
                 }
+
+                var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
+                return changesStream.Finally(observer.OnCompleted).Subscribe(
+                    changes =>
+                    {
+                        foreach (var change in changes.ToConcreteType())
+                        {
+                            var match = EqualityComparer<TKey>.Default.Equals(change.Key, key);
+                            if (match)
+                            {
+                                observer.OnNext(change);
+                            }
+                        }
+                    });
             });
 
     /// <summary>
@@ -325,7 +322,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 if (_suspensionTracker.IsValueCreated)
                 {
-                    _suspensionTracker.Value.Dispose();
+                    lock (_locker)
+                    {
+                        _suspensionTracker.Value.Dispose();
+                    }
                 }
                 return false;
 
@@ -340,7 +340,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 if (_suspensionTracker.IsValueCreated)
                 {
-                    _suspensionTracker.Value.Dispose();
+                    lock (_locker)
+                    {
+                        _suspensionTracker.Value.Dispose();
+                    }
                 }
                 return false;
 

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -318,12 +318,11 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     _countChanged.Value.OnCompleted();
                 }
 
+                // Dispose outside lock — BehaviorSubject.OnCompleted runs observers
+                // synchronously which could execute subscriber code under the lock.
                 if (_suspensionTracker.IsValueCreated)
                 {
-                    lock (_locker)
-                    {
-                        _suspensionTracker.Value.Dispose();
-                    }
+                    _suspensionTracker.Value.Dispose();
                 }
 
                 return false;
@@ -337,12 +336,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     _countChanged.Value.OnError(item.Error!);
                 }
 
+                // Dispose outside lock — same reasoning as Completed path above.
                 if (_suspensionTracker.IsValueCreated)
                 {
-                    lock (_locker)
-                    {
-                        _suspensionTracker.Value.Dispose();
-                    }
+                    _suspensionTracker.Value.Dispose();
                 }
 
                 return false;

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -38,67 +38,132 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     private readonly ReaderWriter<TObject, TKey> _readerWriter;
 
+    private readonly Queue<NotificationItem> _notificationQueue = new();
+
     private int _editLevel; // The level of recursion in editing.
+
+    private bool _isDraining;
+
+    // Set under _locker when terminal events are delivered or Dispose runs.
+    // Checked by DeliverNotification to skip delivery after termination.
+    // Volatile because it's read outside _locker in DrainOutsideLock's delivery path.
+    private volatile bool _isTerminated;
+
+    // Tracks how many items currently in the queue will produce _changes.OnNext.
+    // Excludes suspended, count-only, and terminal items. Incremented at enqueue,
+    // decremented at dequeue (both under _locker). Used by Connect/Watch for
+    // precise Skip(N) that avoids both duplicates and missed notifications.
+    private int _pendingChangesOnNextCount;
 
     public ObservableCache(IObservable<IChangeSet<TObject, TKey>> source)
     {
-        _suspensionTracker = new(() => new SuspensionTracker(_changes.OnNext, InvokeCountNext));
         _readerWriter = new ReaderWriter<TObject, TKey>();
+        _suspensionTracker = new(() => new SuspensionTracker(EnqueueChanges, EnqueueCount));
 
-        var loader = source.Synchronize(_locker).Finally(
-            () =>
-            {
-                _changes.OnCompleted();
-                _changesPreview.OnCompleted();
-            }).Subscribe(
+        var loader = source.Subscribe(
             changeSet =>
             {
-                var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
-                var changes = _readerWriter.Write(changeSet, previewHandler, _changes.HasObservers);
-                InvokeNext(changes);
+                bool shouldDrain;
+                lock (_locker)
+                {
+                    var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
+                    var changes = _readerWriter.Write(changeSet, previewHandler, _changes.HasObservers);
+
+                    if (changes is null)
+                    {
+                        return;
+                    }
+
+                    EnqueueUnderLock(changes);
+                    shouldDrain = TryStartDrain();
+                }
+
+                if (shouldDrain)
+                {
+                    DrainOutsideLock();
+                }
             },
             ex =>
             {
-                _changesPreview.OnError(ex);
-                _changes.OnError(ex);
+                bool shouldDrain;
+                lock (_locker)
+                {
+                    _notificationQueue.Enqueue(NotificationItem.CreateError(ex));
+                    shouldDrain = TryStartDrain();
+                }
+
+                if (shouldDrain)
+                {
+                    DrainOutsideLock();
+                }
+            },
+            () =>
+            {
+                bool shouldDrain;
+                lock (_locker)
+                {
+                    _notificationQueue.Enqueue(NotificationItem.CreateCompleted());
+                    shouldDrain = TryStartDrain();
+                }
+
+                if (shouldDrain)
+                {
+                    DrainOutsideLock();
+                }
             });
 
         _cleanUp = Disposable.Create(
             () =>
             {
                 loader.Dispose();
-                _changes.OnCompleted();
-                _changesPreview.OnCompleted();
-                if (_suspensionTracker.IsValueCreated)
-                {
-                    _suspensionTracker.Value.Dispose();
-                }
 
-                if (_countChanged.IsValueCreated)
+                lock (_locker)
                 {
-                    _countChanged.Value.OnCompleted();
+                    // Dispose is a teardown path. Clear pending items and terminate directly.
+                    _isTerminated = true;
+                    _pendingChangesOnNextCount = 0;
+                    _notificationQueue.Clear();
+                    _changes.OnCompleted();
+                    _changesPreview.OnCompleted();
+
+                    if (_countChanged.IsValueCreated)
+                    {
+                        _countChanged.Value.OnCompleted();
+                    }
+
+                    if (_suspensionTracker.IsValueCreated)
+                    {
+                        _suspensionTracker.Value.Dispose();
+                    }
                 }
             });
     }
 
     public ObservableCache(Func<TObject, TKey>? keySelector = null)
     {
-        _suspensionTracker = new(() => new SuspensionTracker(_changes.OnNext, InvokeCountNext));
         _readerWriter = new ReaderWriter<TObject, TKey>(keySelector);
+        _suspensionTracker = new(() => new SuspensionTracker(EnqueueChanges, EnqueueCount));
 
         _cleanUp = Disposable.Create(
             () =>
             {
-                _changes.OnCompleted();
-                _changesPreview.OnCompleted();
-                if (_suspensionTracker.IsValueCreated)
+                lock (_locker)
                 {
-                    _suspensionTracker.Value.Dispose();
-                }
+                    _isTerminated = true;
+                    _pendingChangesOnNextCount = 0;
+                    _notificationQueue.Clear();
+                    _changes.OnCompleted();
+                    _changesPreview.OnCompleted();
 
-                if (_countChanged.IsValueCreated)
-                {
-                    _countChanged.Value.OnCompleted();
+                    if (_countChanged.IsValueCreated)
+                    {
+                        _countChanged.Value.OnCompleted();
+                    }
+
+                    if (_suspensionTracker.IsValueCreated)
+                    {
+                        _suspensionTracker.Value.Dispose();
+                    }
                 }
             });
     }
@@ -111,7 +176,9 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 lock (_locker)
                 {
-                    var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
+                    var skipCount = _notificationQueue.Count;
+                    var countStream = skipCount > 0 ? _countChanged.Value.Skip(skipCount) : _countChanged.Value;
+                    var source = countStream.StartWith(_readerWriter.Count).DistinctUntilChanged();
                     return source.SubscribeSafe(observer);
                 }
             });
@@ -188,6 +255,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     {
         updateAction.ThrowArgumentNullExceptionIfNull(nameof(updateAction));
 
+        bool shouldDrain;
         lock (_locker)
         {
             ChangeSet<TObject, TKey>? changes = null;
@@ -207,8 +275,15 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
             if (changes is not null && _editLevel == 0)
             {
-                InvokeNext(changes);
+                EnqueueUnderLock(changes);
             }
+
+            shouldDrain = TryStartDrain();
+        }
+
+        if (shouldDrain)
+        {
+            DrainOutsideLock();
         }
     }
 
@@ -216,6 +291,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     {
         updateAction.ThrowArgumentNullExceptionIfNull(nameof(updateAction));
 
+        bool shouldDrain;
         lock (_locker)
         {
             ChangeSet<TObject, TKey>? changes = null;
@@ -235,8 +311,15 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
             if (changes is not null && _editLevel == 0)
             {
-                InvokeNext(changes);
+                EnqueueUnderLock(changes);
             }
+
+            shouldDrain = TryStartDrain();
+        }
+
+        if (shouldDrain)
+        {
+            DrainOutsideLock();
         }
     }
 
@@ -246,8 +329,14 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 lock (_locker)
                 {
+                    // Skip pending notifications that will emit to _changes.OnNext.
+                    // Uses a precise counter (excludes suspended, count-only, and terminal items)
+                    // to avoid over-skipping future legitimate notifications.
+                    var skipCount = _pendingChangesOnNextCount;
+
                     var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
-                    var changes = initial.Concat(_changes);
+                    var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
+                    var changes = initial.Concat(changesStream);
 
                     if (predicate != null)
                     {
@@ -268,13 +357,16 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 lock (_locker)
                 {
+                    var skipCount = _pendingChangesOnNextCount;
+
                     var initial = _readerWriter.Lookup(key);
                     if (initial.HasValue)
                     {
                         observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
                     }
 
-                    return _changes.Finally(observer.OnCompleted).Subscribe(
+                    var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
+                    return changesStream.Finally(observer.OnCompleted).Subscribe(
                         changes =>
                         {
                             foreach (var change in changes.ToConcreteType())
@@ -289,68 +381,277 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 }
             });
 
-    private void InvokeNext(ChangeSet<TObject, TKey> changes)
-    {
-        lock (_locker)
-        {
-            // If Notifications are not suspended
-            if (!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
-            {
-                // Emit the changes
-                _changes.OnNext(changes);
-            }
-            else
-            {
-                // Don't emit the changes, but add them to the list
-                _suspensionTracker.Value.EnqueueChanges(changes);
-            }
-
-            // If CountChanges are not suspended
-            if (!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.IsCountSuspended)
-            {
-                InvokeCountNext();
-            }
-        }
-    }
-
+    /// <summary>
+    /// Delivers a preview notification synchronously under _locker. Preview is
+    /// called by ReaderWriter during a write, between two data swaps, so it MUST
+    /// fire under the lock with the pre-write state visible to subscribers.
+    /// </summary>
     private void InvokePreview(ChangeSet<TObject, TKey> changes)
     {
-        lock (_locker)
+        if (changes.Count != 0)
         {
-            if (changes.Count != 0)
-            {
-                _changesPreview.OnNext(changes);
-            }
+            _changesPreview.OnNext(changes);
         }
     }
 
-    private void InvokeCountNext()
+    /// <summary>
+    /// Enqueues a changeset (plus associated count) for delivery outside the lock.
+    /// Must be called while _locker is held.
+    /// </summary>
+    private void EnqueueUnderLock(ChangeSet<TObject, TKey> changes)
     {
-        lock (_locker)
+        // Check suspension state under lock to avoid TOCTOU race.
+        var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
+        var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
+
+        _notificationQueue.Enqueue(new NotificationItem(changes, _readerWriter.Count, isSuspended, isCountSuspended));
+
+        if (!isSuspended)
+        {
+            _pendingChangesOnNextCount++;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to claim the drain token. Returns true if this thread should drain.
+    /// Must be called while _locker is held.
+    /// </summary>
+    private bool TryStartDrain()
+    {
+        if (_isDraining || _notificationQueue.Count == 0)
+        {
+            return false;
+        }
+
+        _isDraining = true;
+        return true;
+    }
+
+    /// <summary>
+    /// Delivers all pending notifications outside the lock. Only the thread that
+    /// successfully called TryStartDrain may call this. Serializes all OnNext
+    /// calls for this cache instance, preserving the Rx contract.
+    /// </summary>
+    private void DrainOutsideLock()
+    {
+        try
+        {
+            while (true)
+            {
+                NotificationItem item;
+                lock (_locker)
+                {
+                    if (_notificationQueue.Count == 0)
+                    {
+                        _isDraining = false;
+                        return;
+                    }
+
+                    item = _notificationQueue.Dequeue();
+
+                    // Decrement the per-subject counter for items that will emit _changes.OnNext.
+                    if (!item.IsSuspended && !item.IsCountOnly && !item.IsCompleted && !item.IsError)
+                    {
+                        _pendingChangesOnNextCount--;
+                    }
+                }
+
+                DeliverNotification(item);
+            }
+        }
+        catch
+        {
+            lock (_locker)
+            {
+                _isDraining = false;
+                _pendingChangesOnNextCount = 0;
+            }
+
+            throw;
+        }
+    }
+
+    private void DeliverNotification(NotificationItem item)
+    {
+        // After Dispose or a terminal event has been delivered, skip all delivery.
+        // Subject.OnNext after OnCompleted is a no-op, but this avoids wasted work
+        // and prevents subtle ordering issues.
+        if (_isTerminated)
+        {
+            return;
+        }
+
+        if (item.IsCompleted)
+        {
+            _isTerminated = true;
+            _changes.OnCompleted();
+            _changesPreview.OnCompleted();
+
+            if (_countChanged.IsValueCreated)
+            {
+                _countChanged.Value.OnCompleted();
+            }
+
+            return;
+        }
+
+        if (item.IsError)
+        {
+            _isTerminated = true;
+            _changesPreview.OnError(item.Error!);
+            _changes.OnError(item.Error!);
+            return;
+        }
+
+        if (item.IsCountOnly)
         {
             if (_countChanged.IsValueCreated)
             {
-                _countChanged.Value.OnNext(_readerWriter.Count);
+                _countChanged.Value.OnNext(item.Count);
             }
+
+            return;
+        }
+
+        // Suspension state was captured at enqueue time (under lock) to avoid TOCTOU.
+        // For unsuspended items, deliver directly. For suspended items, re-check the
+        // live state under lock — ResumeNotifications may have run between dequeue and
+        // delivery, in which case we deliver directly instead of orphaning in _pendingChanges.
+        if (!item.IsSuspended)
+        {
+            _changes.OnNext(item.Changes);
+        }
+        else
+        {
+            bool deliverNow;
+            lock (_locker)
+            {
+                if (_suspensionTracker.Value.AreNotificationsSuspended)
+                {
+                    _suspensionTracker.Value.EnqueueChanges(item.Changes);
+                    deliverNow = false;
+                }
+                else
+                {
+                    deliverNow = true;
+                }
+            }
+
+            if (deliverNow)
+            {
+                _changes.OnNext(item.Changes);
+            }
+        }
+
+        if (!item.IsCountSuspended)
+        {
+            if (_countChanged.IsValueCreated)
+            {
+                _countChanged.Value.OnNext(item.Count);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Called by SuspensionTracker.ResumeNotifications to deliver accumulated
+    /// changes. This enqueues under _locker; the caller's TryStartDrain +
+    /// DrainOutsideLock handles delivery outside the lock.
+    /// </summary>
+    private void EnqueueChanges(ChangeSet<TObject, TKey> changes)
+    {
+        _notificationQueue.Enqueue(new NotificationItem(changes, _readerWriter.Count, isSuspended: false, isCountSuspended: false));
+        _pendingChangesOnNextCount++;
+    }
+
+    /// <summary>
+    /// Called by SuspensionTracker.ResumeCount to deliver the current count.
+    /// </summary>
+    private void EnqueueCount()
+    {
+        if (_countChanged.IsValueCreated)
+        {
+            _notificationQueue.Enqueue(NotificationItem.CreateCountOnly(_readerWriter.Count));
         }
     }
 
     private void ResumeCount()
     {
+        bool shouldDrain;
         lock (_locker)
         {
             Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Count without Suspend Count instance");
             _suspensionTracker.Value.ResumeCount();
+            shouldDrain = TryStartDrain();
+        }
+
+        if (shouldDrain)
+        {
+            DrainOutsideLock();
         }
     }
 
     private void ResumeNotifications()
     {
+        bool shouldDrain;
         lock (_locker)
         {
-            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Count instance");
+            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
             _suspensionTracker.Value.ResumeNotifications();
+            shouldDrain = TryStartDrain();
         }
+
+        if (shouldDrain)
+        {
+            DrainOutsideLock();
+        }
+    }
+
+    private readonly record struct NotificationItem
+    {
+        public ChangeSet<TObject, TKey> Changes { get; }
+
+        public int Count { get; }
+
+        public bool IsCountOnly { get; }
+
+        public bool IsSuspended { get; }
+
+        public bool IsCountSuspended { get; }
+
+        public bool IsCompleted { get; }
+
+        public bool IsError { get; }
+
+        public Exception? Error { get; }
+
+        public NotificationItem(ChangeSet<TObject, TKey> changes, int count, bool isSuspended, bool isCountSuspended)
+        {
+            Changes = changes;
+            Count = count;
+            IsSuspended = isSuspended;
+            IsCountSuspended = isCountSuspended;
+        }
+
+        private NotificationItem(int count, bool isCountOnly)
+        {
+            Changes = [];
+            Count = count;
+            IsCountOnly = isCountOnly;
+        }
+
+        private NotificationItem(bool isCompleted, Exception? error)
+        {
+            Changes = [];
+            IsCompleted = isCompleted;
+            IsError = error is not null;
+            Error = error;
+        }
+
+        public static NotificationItem CreateCountOnly(int count) => new(count, isCountOnly: true);
+
+        public static NotificationItem CreateCompleted() => new(isCompleted: true, error: null);
+
+        public static NotificationItem CreateError(Exception error) => new(isCompleted: false, error: error);
     }
 
     private sealed class SuspensionTracker(Action<ChangeSet<TObject, TKey>> onResumeNotifications, Action onResumeCount) : IDisposable
@@ -396,15 +697,21 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             if (--_notifySuspendCount == 0 && !_areNotificationsSuspended.IsDisposed)
             {
-                // Fire pending changes to existing subscribers
+                // Swap out pending changes before the callback to handle re-entrant
+                // suspend/resume correctly. If a subscriber re-suspends during the
+                // callback, new changes go into the fresh list, not the one being delivered.
                 if (_pendingChanges.Count > 0)
                 {
-                    _onResumeNotifications(new ChangeSet<TObject, TKey>(_pendingChanges));
-                    _pendingChanges.Clear();
+                    var changesToDeliver = _pendingChanges;
+                    _pendingChanges = [];
+                    _onResumeNotifications(new ChangeSet<TObject, TKey>(changesToDeliver));
                 }
 
-                // Tell deferred subscribers they can continue
-                _areNotificationsSuspended.OnNext(false);
+                // Re-check: a subscriber callback may have re-suspended during delivery.
+                if (_notifySuspendCount == 0)
+                {
+                    _areNotificationsSuspended.OnNext(false);
+                }
             }
         }
 

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2025 Roland Pheasant. All rights reserved.
+﻿// Copyright (c) 2011-2025 Roland Pheasant. All rights reserved.
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
@@ -9,6 +9,7 @@ using System.Reactive.Subjects;
 using DynamicData.Binding;
 using DynamicData.Cache;
 using DynamicData.Cache.Internal;
+using DynamicData.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace DynamicData;
@@ -38,134 +39,51 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     private readonly ReaderWriter<TObject, TKey> _readerWriter;
 
-    private readonly Queue<NotificationItem> _notificationQueue = new();
+    private readonly DeliveryQueue<NotificationItem> _notifications;
 
     private int _editLevel; // The level of recursion in editing.
-
-    private bool _isDraining;
-
-    // Set under _locker when terminal events are delivered or Dispose runs.
-    // Checked by DeliverNotification to skip delivery after termination.
-    // Volatile because it's read outside _locker in DrainOutsideLock's delivery path.
-    private volatile bool _isTerminated;
-
-    // Tracks how many items currently in the queue will produce _changes.OnNext.
-    // Excludes suspended, count-only, and terminal items. Incremented at enqueue,
-    // decremented at dequeue (both under _locker). Used by Connect/Watch for
-    // precise Skip(N) that avoids both duplicates and missed notifications.
-    private int _pendingChangesOnNextCount;
 
     public ObservableCache(IObservable<IChangeSet<TObject, TKey>> source)
     {
         _readerWriter = new ReaderWriter<TObject, TKey>();
-        _suspensionTracker = new(() => new SuspensionTracker(EnqueueChanges, EnqueueCount));
+        _notifications = new DeliveryQueue<NotificationItem>(_locker, DeliverNotification);
+        _suspensionTracker = new(() => new SuspensionTracker());
 
         var loader = source.Subscribe(
             changeSet =>
             {
-                bool shouldDrain;
-                lock (_locker)
+                using var notifications = _notifications.AcquireLock();
+
+                var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
+                var changes = _readerWriter.Write(changeSet, previewHandler, _changes.HasObservers);
+
+                if (changes is not null)
                 {
-                    var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
-                    var changes = _readerWriter.Write(changeSet, previewHandler, _changes.HasObservers);
-
-                    if (changes is null)
-                    {
-                        return;
-                    }
-
-                    EnqueueUnderLock(changes);
-                    shouldDrain = TryStartDrain();
-                }
-
-                if (shouldDrain)
-                {
-                    DrainOutsideLock();
+                    var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
+                    var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
+                    notifications.Enqueue(
+                        NotificationItem.CreateChanges(changes, _readerWriter.Count, isSuspended, isCountSuspended),
+                        countAsPending: !isSuspended);
                 }
             },
-            ex =>
-            {
-                bool shouldDrain;
-                lock (_locker)
-                {
-                    _notificationQueue.Enqueue(NotificationItem.CreateError(ex));
-                    shouldDrain = TryStartDrain();
-                }
-
-                if (shouldDrain)
-                {
-                    DrainOutsideLock();
-                }
-            },
-            () =>
-            {
-                bool shouldDrain;
-                lock (_locker)
-                {
-                    _notificationQueue.Enqueue(NotificationItem.CreateCompleted());
-                    shouldDrain = TryStartDrain();
-                }
-
-                if (shouldDrain)
-                {
-                    DrainOutsideLock();
-                }
-            });
+            NotifyError,
+            NotifyCompleted);
 
         _cleanUp = Disposable.Create(
             () =>
             {
                 loader.Dispose();
-
-                lock (_locker)
-                {
-                    // Dispose is a teardown path. Clear pending items and terminate directly.
-                    _isTerminated = true;
-                    _pendingChangesOnNextCount = 0;
-                    _notificationQueue.Clear();
-                    _changes.OnCompleted();
-                    _changesPreview.OnCompleted();
-
-                    if (_countChanged.IsValueCreated)
-                    {
-                        _countChanged.Value.OnCompleted();
-                    }
-
-                    if (_suspensionTracker.IsValueCreated)
-                    {
-                        _suspensionTracker.Value.Dispose();
-                    }
-                }
+                NotifyCompleted();
             });
     }
 
     public ObservableCache(Func<TObject, TKey>? keySelector = null)
     {
         _readerWriter = new ReaderWriter<TObject, TKey>(keySelector);
-        _suspensionTracker = new(() => new SuspensionTracker(EnqueueChanges, EnqueueCount));
+        _notifications = new DeliveryQueue<NotificationItem>(_locker, DeliverNotification);
+        _suspensionTracker = new(() => new SuspensionTracker());
 
-        _cleanUp = Disposable.Create(
-            () =>
-            {
-                lock (_locker)
-                {
-                    _isTerminated = true;
-                    _pendingChangesOnNextCount = 0;
-                    _notificationQueue.Clear();
-                    _changes.OnCompleted();
-                    _changesPreview.OnCompleted();
-
-                    if (_countChanged.IsValueCreated)
-                    {
-                        _countChanged.Value.OnCompleted();
-                    }
-
-                    if (_suspensionTracker.IsValueCreated)
-                    {
-                        _suspensionTracker.Value.Dispose();
-                    }
-                }
-            });
+        _cleanUp = Disposable.Create(NotifyCompleted);
     }
 
     public int Count => _readerWriter.Count;
@@ -176,9 +94,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 lock (_locker)
                 {
-                    var skipCount = _notificationQueue.Count;
-                    var countStream = skipCount > 0 ? _countChanged.Value.Skip(skipCount) : _countChanged.Value;
-                    var source = countStream.StartWith(_readerWriter.Count).DistinctUntilChanged();
+                    var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
                     return source.SubscribeSafe(observer);
                 }
             });
@@ -255,35 +171,30 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     {
         updateAction.ThrowArgumentNullExceptionIfNull(nameof(updateAction));
 
-        bool shouldDrain;
-        lock (_locker)
+        using var notifications = _notifications.AcquireLock();
+
+        ChangeSet<TObject, TKey>? changes = null;
+
+        _editLevel++;
+        if (_editLevel == 1)
         {
-            ChangeSet<TObject, TKey>? changes = null;
-
-            _editLevel++;
-            if (_editLevel == 1)
-            {
-                var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
-                changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
-            }
-            else
-            {
-                _readerWriter.WriteNested(updateAction);
-            }
-
-            _editLevel--;
-
-            if (changes is not null && _editLevel == 0)
-            {
-                EnqueueUnderLock(changes);
-            }
-
-            shouldDrain = TryStartDrain();
+            var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
+            changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
+        }
+        else
+        {
+            _readerWriter.WriteNested(updateAction);
         }
 
-        if (shouldDrain)
+        _editLevel--;
+
+        if (changes is not null && _editLevel == 0)
         {
-            DrainOutsideLock();
+            var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
+            var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
+            notifications.Enqueue(
+                NotificationItem.CreateChanges(changes, _readerWriter.Count, isSuspended, isCountSuspended),
+                countAsPending: !isSuspended);
         }
     }
 
@@ -291,35 +202,30 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     {
         updateAction.ThrowArgumentNullExceptionIfNull(nameof(updateAction));
 
-        bool shouldDrain;
-        lock (_locker)
+        using var notifications = _notifications.AcquireLock();
+
+        ChangeSet<TObject, TKey>? changes = null;
+
+        _editLevel++;
+        if (_editLevel == 1)
         {
-            ChangeSet<TObject, TKey>? changes = null;
-
-            _editLevel++;
-            if (_editLevel == 1)
-            {
-                var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
-                changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
-            }
-            else
-            {
-                _readerWriter.WriteNested(updateAction);
-            }
-
-            _editLevel--;
-
-            if (changes is not null && _editLevel == 0)
-            {
-                EnqueueUnderLock(changes);
-            }
-
-            shouldDrain = TryStartDrain();
+            var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
+            changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
+        }
+        else
+        {
+            _readerWriter.WriteNested(updateAction);
         }
 
-        if (shouldDrain)
+        _editLevel--;
+
+        if (changes is not null && _editLevel == 0)
         {
-            DrainOutsideLock();
+            var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
+            var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
+            notifications.Enqueue(
+                NotificationItem.CreateChanges(changes, _readerWriter.Count, isSuspended, isCountSuspended),
+                countAsPending: !isSuspended);
         }
     }
 
@@ -329,10 +235,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 lock (_locker)
                 {
-                    // Skip pending notifications that will emit to _changes.OnNext.
-                    // Uses a precise counter (excludes suspended, count-only, and terminal items)
-                    // to avoid over-skipping future legitimate notifications.
-                    var skipCount = _pendingChangesOnNextCount;
+                    // Skip pending notifications to avoid duplicating items already in the snapshot.
+                    var skipCount = _notifications.PendingCount;
 
                     var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
                     var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
@@ -357,7 +261,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 lock (_locker)
                 {
-                    var skipCount = _pendingChangesOnNextCount;
+                    var skipCount = _notifications.PendingCount;
 
                     var initial = _readerWriter.Lookup(key);
                     if (initial.HasValue)
@@ -388,279 +292,183 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     /// </summary>
     private void InvokePreview(ChangeSet<TObject, TKey> changes)
     {
-        if (changes.Count != 0)
+        if (changes.Count != 0 && !_notifications.IsTerminated)
         {
             _changesPreview.OnNext(changes);
         }
     }
 
-    /// <summary>
-    /// Enqueues a changeset (plus associated count) for delivery outside the lock.
-    /// Must be called while _locker is held.
-    /// </summary>
-    private void EnqueueUnderLock(ChangeSet<TObject, TKey> changes)
+    private void NotifyCompleted()
     {
-        // Check suspension state under lock to avoid TOCTOU race.
-        var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
-        var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
-
-        _notificationQueue.Enqueue(new NotificationItem(changes, _readerWriter.Count, isSuspended, isCountSuspended));
-
-        if (!isSuspended)
-        {
-            _pendingChangesOnNextCount++;
-        }
+        using var notifications = _notifications.AcquireLock();
+        notifications.Enqueue(NotificationItem.CreateCompleted());
     }
 
-    /// <summary>
-    /// Attempts to claim the drain token. Returns true if this thread should drain.
-    /// Must be called while _locker is held.
-    /// </summary>
-    private bool TryStartDrain()
+    private void NotifyError(Exception ex)
     {
-        if (_isDraining || _notificationQueue.Count == 0)
-        {
-            return false;
-        }
-
-        _isDraining = true;
-        return true;
+        using var notifications = _notifications.AcquireLock();
+        notifications.Enqueue(NotificationItem.CreateError(ex));
     }
 
-    /// <summary>
-    /// Delivers all pending notifications outside the lock. Only the thread that
-    /// successfully called TryStartDrain may call this. Serializes all OnNext
-    /// calls for this cache instance, preserving the Rx contract.
-    /// </summary>
-    private void DrainOutsideLock()
+    private bool DeliverNotification(NotificationItem item)
     {
-        try
+        switch (item.Kind)
         {
-            while (true)
-            {
-                NotificationItem item;
-                lock (_locker)
+            case NotificationKind.Completed:
+                _changes.OnCompleted();
+                _changesPreview.OnCompleted();
+
+                if (_countChanged.IsValueCreated)
                 {
-                    if (_notificationQueue.Count == 0)
-                    {
-                        _isDraining = false;
-                        return;
-                    }
-
-                    item = _notificationQueue.Dequeue();
-
-                    // Decrement the per-subject counter for items that will emit _changes.OnNext.
-                    if (!item.IsSuspended && !item.IsCountOnly && !item.IsCompleted && !item.IsError)
-                    {
-                        _pendingChangesOnNextCount--;
-                    }
+                    _countChanged.Value.OnCompleted();
                 }
 
-                DeliverNotification(item);
-            }
-        }
-        catch
-        {
-            lock (_locker)
-            {
-                _isDraining = false;
-                _pendingChangesOnNextCount = 0;
-            }
-
-            throw;
-        }
-    }
-
-    private void DeliverNotification(NotificationItem item)
-    {
-        // After Dispose or a terminal event has been delivered, skip all delivery.
-        // Subject.OnNext after OnCompleted is a no-op, but this avoids wasted work
-        // and prevents subtle ordering issues.
-        if (_isTerminated)
-        {
-            return;
-        }
-
-        if (item.IsCompleted)
-        {
-            _isTerminated = true;
-            _changes.OnCompleted();
-            _changesPreview.OnCompleted();
-
-            if (_countChanged.IsValueCreated)
-            {
-                _countChanged.Value.OnCompleted();
-            }
-
-            return;
-        }
-
-        if (item.IsError)
-        {
-            _isTerminated = true;
-            _changesPreview.OnError(item.Error!);
-            _changes.OnError(item.Error!);
-            return;
-        }
-
-        if (item.IsCountOnly)
-        {
-            if (_countChanged.IsValueCreated)
-            {
-                _countChanged.Value.OnNext(item.Count);
-            }
-
-            return;
-        }
-
-        // Suspension state was captured at enqueue time (under lock) to avoid TOCTOU.
-        // For unsuspended items, deliver directly. For suspended items, re-check the
-        // live state under lock — ResumeNotifications may have run between dequeue and
-        // delivery, in which case we deliver directly instead of orphaning in _pendingChanges.
-        if (!item.IsSuspended)
-        {
-            _changes.OnNext(item.Changes);
-        }
-        else
-        {
-            bool deliverNow;
-            lock (_locker)
-            {
-                if (_suspensionTracker.Value.AreNotificationsSuspended)
+                if (_suspensionTracker.IsValueCreated)
                 {
-                    _suspensionTracker.Value.EnqueueChanges(item.Changes);
-                    deliverNow = false;
+                    _suspensionTracker.Value.Dispose();
+                }
+                return false;
+
+            case NotificationKind.Error:
+                _changesPreview.OnError(item.Error!);
+                _changes.OnError(item.Error!);
+
+                if (_countChanged.IsValueCreated)
+                {
+                    _countChanged.Value.OnError(item.Error!);
+                }
+
+                if (_suspensionTracker.IsValueCreated)
+                {
+                    _suspensionTracker.Value.Dispose();
+                }
+                return false;
+
+            case NotificationKind.CountOnly:
+                if (_countChanged.IsValueCreated)
+                {
+                    _countChanged.Value.OnNext(item.Count);
+                }
+
+                return true;
+
+            default:
+                if (!item.IsSuspended)
+                {
+                    _changes.OnNext(item.Changes);
                 }
                 else
                 {
-                    deliverNow = true;
+                    bool deliverNow;
+                    lock (_locker)
+                    {
+                        if (_suspensionTracker.Value.AreNotificationsSuspended)
+                        {
+                            _suspensionTracker.Value.EnqueueChanges(item.Changes);
+                            deliverNow = false;
+                        }
+                        else
+                        {
+                            deliverNow = true;
+                        }
+                    }
+
+                    if (deliverNow)
+                    {
+                        _changes.OnNext(item.Changes);
+                    }
                 }
-            }
 
-            if (deliverNow)
-            {
-                _changes.OnNext(item.Changes);
-            }
-        }
+                if (!item.IsCountSuspended)
+                {
+                    if (_countChanged.IsValueCreated)
+                    {
+                        _countChanged.Value.OnNext(item.Count);
+                    }
+                }
 
-        if (!item.IsCountSuspended)
-        {
-            if (_countChanged.IsValueCreated)
-            {
-                _countChanged.Value.OnNext(item.Count);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Called by SuspensionTracker.ResumeNotifications to deliver accumulated
-    /// changes. This enqueues under _locker; the caller's TryStartDrain +
-    /// DrainOutsideLock handles delivery outside the lock.
-    /// </summary>
-    private void EnqueueChanges(ChangeSet<TObject, TKey> changes)
-    {
-        _notificationQueue.Enqueue(new NotificationItem(changes, _readerWriter.Count, isSuspended: false, isCountSuspended: false));
-        _pendingChangesOnNextCount++;
-    }
-
-    /// <summary>
-    /// Called by SuspensionTracker.ResumeCount to deliver the current count.
-    /// </summary>
-    private void EnqueueCount()
-    {
-        if (_countChanged.IsValueCreated)
-        {
-            _notificationQueue.Enqueue(NotificationItem.CreateCountOnly(_readerWriter.Count));
+                return true;
         }
     }
 
     private void ResumeCount()
     {
-        bool shouldDrain;
-        lock (_locker)
-        {
-            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Count without Suspend Count instance");
-            _suspensionTracker.Value.ResumeCount();
-            shouldDrain = TryStartDrain();
-        }
+        using var notifications = _notifications.AcquireLock();
+        Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Count without Suspend Count instance");
 
-        if (shouldDrain)
+        if (_suspensionTracker.Value.ResumeCount() && _countChanged.IsValueCreated)
         {
-            DrainOutsideLock();
+            notifications.Enqueue(NotificationItem.CreateCountOnly(_readerWriter.Count));
         }
     }
 
     private void ResumeNotifications()
     {
-        bool shouldDrain;
-        lock (_locker)
+        using var notifications = _notifications.AcquireLock();
+        Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
+
+        var (resumedChanges, emitResume) = _suspensionTracker.Value.ResumeNotifications();
+        if (resumedChanges is not null)
         {
-            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
-            _suspensionTracker.Value.ResumeNotifications();
-            shouldDrain = TryStartDrain();
+            notifications.Enqueue(
+                NotificationItem.CreateChanges(resumedChanges, _readerWriter.Count, isSuspended: false, isCountSuspended: false),
+                countAsPending: true);
         }
 
-        if (shouldDrain)
+        if (emitResume)
         {
-            DrainOutsideLock();
+            _suspensionTracker.Value.EmitResumeNotification();
         }
+    }
+
+    private enum NotificationKind
+    {
+        Changes,
+        CountOnly,
+        Completed,
+        Error,
     }
 
     private readonly record struct NotificationItem
     {
+        public NotificationKind Kind { get; }
+
         public ChangeSet<TObject, TKey> Changes { get; }
 
         public int Count { get; }
-
-        public bool IsCountOnly { get; }
 
         public bool IsSuspended { get; }
 
         public bool IsCountSuspended { get; }
 
-        public bool IsCompleted { get; }
-
-        public bool IsError { get; }
-
         public Exception? Error { get; }
 
-        public NotificationItem(ChangeSet<TObject, TKey> changes, int count, bool isSuspended, bool isCountSuspended)
+        private NotificationItem(NotificationKind kind, ChangeSet<TObject, TKey> changes, int count = 0, bool isSuspended = false, bool isCountSuspended = false, Exception? error = null)
         {
+            Kind = kind;
             Changes = changes;
             Count = count;
             IsSuspended = isSuspended;
             IsCountSuspended = isCountSuspended;
-        }
-
-        private NotificationItem(int count, bool isCountOnly)
-        {
-            Changes = [];
-            Count = count;
-            IsCountOnly = isCountOnly;
-        }
-
-        private NotificationItem(bool isCompleted, Exception? error)
-        {
-            Changes = [];
-            IsCompleted = isCompleted;
-            IsError = error is not null;
             Error = error;
         }
 
-        public static NotificationItem CreateCountOnly(int count) => new(count, isCountOnly: true);
+        public static NotificationItem CreateChanges(ChangeSet<TObject, TKey> changes, int count, bool isSuspended, bool isCountSuspended) =>
+            new(NotificationKind.Changes, changes, count, isSuspended, isCountSuspended);
 
-        public static NotificationItem CreateCompleted() => new(isCompleted: true, error: null);
+        public static NotificationItem CreateCountOnly(int count) =>
+            new(NotificationKind.CountOnly, [], count: count);
 
-        public static NotificationItem CreateError(Exception error) => new(isCompleted: false, error: error);
+        public static NotificationItem CreateCompleted() =>
+            new(NotificationKind.Completed, []);
+
+        public static NotificationItem CreateError(Exception error) =>
+            new(NotificationKind.Error, [], error: error);
     }
 
-    private sealed class SuspensionTracker(Action<ChangeSet<TObject, TKey>> onResumeNotifications, Action onResumeCount) : IDisposable
+    private sealed class SuspensionTracker : IDisposable
     {
         private readonly BehaviorSubject<bool> _areNotificationsSuspended = new(false);
-
-        private readonly Action<ChangeSet<TObject, TKey>> _onResumeNotifications = onResumeNotifications;
-
-        private readonly Action _onResumeCount = onResumeCount;
 
         private List<Change<TObject, TKey>> _pendingChanges = [];
 
@@ -693,35 +501,28 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         public void SuspendCount() => ++_countSuspendCount;
 
-        public void ResumeNotifications()
+        public bool ResumeCount() => --_countSuspendCount == 0;
+
+        public (ChangeSet<TObject, TKey>? Changes, bool EmitResume) ResumeNotifications()
         {
             if (--_notifySuspendCount == 0 && !_areNotificationsSuspended.IsDisposed)
             {
-                // Swap out pending changes before the callback to handle re-entrant
-                // suspend/resume correctly. If a subscriber re-suspends during the
-                // callback, new changes go into the fresh list, not the one being delivered.
+                ChangeSet<TObject, TKey>? changes = null;
+
                 if (_pendingChanges.Count > 0)
                 {
                     var changesToDeliver = _pendingChanges;
                     _pendingChanges = [];
-                    _onResumeNotifications(new ChangeSet<TObject, TKey>(changesToDeliver));
+                    changes = new ChangeSet<TObject, TKey>(changesToDeliver);
                 }
 
-                // Re-check: a subscriber callback may have re-suspended during delivery.
-                if (_notifySuspendCount == 0)
-                {
-                    _areNotificationsSuspended.OnNext(false);
-                }
+                return (changes, _notifySuspendCount == 0);
             }
+
+            return (null, false);
         }
 
-        public void ResumeCount()
-        {
-            if (--_countSuspendCount == 0)
-            {
-                _onResumeCount();
-            }
-        }
+        public void EmitResumeNotification() => _areNotificationsSuspended.OnNext(false);
 
         public void Dispose()
         {

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 using DynamicData.Binding;
 using DynamicData.Cache;
 using DynamicData.Cache.Internal;
@@ -43,6 +44,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     private int _editLevel; // The level of recursion in editing.
 
+    private long _currentVersion; // Monotonic counter incremented under lock for each enqueued change notification.
+
+    private long _currentDeliveryVersion; // Version of the item currently being delivered. Set before _changes.OnNext.
+
     public ObservableCache(IObservable<IChangeSet<TObject, TKey>> source)
     {
         _readerWriter = new ReaderWriter<TObject, TKey>();
@@ -59,7 +64,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 if (changes is not null)
                 {
-                    notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
+                    notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
                 }
             },
             NotifyError,
@@ -186,7 +191,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         if (changes is not null && _editLevel == 0)
         {
-            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
+            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
         }
     }
 
@@ -213,7 +218,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         if (changes is not null && _editLevel == 0)
         {
-            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
+            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
         }
     }
 
@@ -221,53 +226,64 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Observable.Create<IChangeSet<TObject, TKey>>(
             observer =>
             {
-                // Subject<T> snapshots its observer array before iterating OnNext, so a
-                // subscriber added here will not receive any in-flight notification.
-                lock (_locker)
+                using var readLock = _notifications.AcquireReadLock();
+
+                var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
+
+                // The current snapshot may contain changes that have been made but the notifications
+                // have yet to be delivered.  We need to filter those out to avoid delivering an update
+                // that has already been applied (but detect this possiblity and skip filtering unless absolutely needed)
+                var snapshotVersion = _currentVersion;
+                var changes = readLock.HasPending
+                    ? _changes.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)
+                    : (IObservable<IChangeSet<TObject, TKey>>)_changes;
+
+                changes = initial.Concat(changes);
+
+                if (predicate != null)
                 {
-                    var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
-                    var changes = initial.Concat(_changes);
-
-                    if (predicate != null)
-                    {
-                        changes = changes.Filter(predicate, suppressEmptyChangeSets);
-                    }
-                    else if (suppressEmptyChangeSets)
-                    {
-                        changes = changes.NotEmpty();
-                    }
-
-                    return changes.SubscribeSafe(observer);
+                    changes = changes.Filter(predicate, suppressEmptyChangeSets);
                 }
+                else if (suppressEmptyChangeSets)
+                {
+                    changes = changes.NotEmpty();
+                }
+
+                return changes.SubscribeSafe(observer);
             });
 
     private IObservable<Change<TObject, TKey>> CreateWatchObservable(TKey key) =>
         Observable.Create<Change<TObject, TKey>>(
             observer =>
             {
-                // Subject<T> snapshots its observer array before iterating OnNext, so a
-                // subscriber added here will not receive any in-flight notification.
-                lock (_locker)
-                {
-                    var initial = _readerWriter.Lookup(key);
-                    if (initial.HasValue)
-                    {
-                        observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
-                    }
+                using var readLock = _notifications.AcquireReadLock();
 
-                    return _changes.Finally(observer.OnCompleted).Subscribe(
-                        changes =>
-                        {
-                            foreach (var change in changes.ToConcreteType())
-                            {
-                                var match = EqualityComparer<TKey>.Default.Equals(change.Key, key);
-                                if (match)
-                                {
-                                    observer.OnNext(change);
-                                }
-                            }
-                        });
+                var initial = _readerWriter.Lookup(key);
+                if (initial.HasValue)
+                {
+                    observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
                 }
+
+                // The current snapshot may contain changes that have been made but the notifications
+                // have yet to be delivered.  We need to filter those out to avoid delivering an update
+                // that has already been applied (but detect this possiblity and skip filtering unless absolutely needed)
+                var snapshotVersion = _currentVersion;
+                var changes = readLock.HasPending
+                    ? _changes.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)
+                    : _changes;
+
+                return changes.Finally(observer.OnCompleted).Subscribe(
+                    changes =>
+                    {
+                        foreach (var change in changes)
+                        {
+                            var match = EqualityComparer<TKey>.Default.Equals(change.Key, key);
+                            if (match)
+                            {
+                                observer.OnNext(change);
+                            }
+                        }
+                    });
             });
 
     /// <summary>
@@ -318,8 +334,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     _countChanged.Value.OnCompleted();
                 }
 
-                // Dispose outside lock — BehaviorSubject.OnCompleted runs observers
-                // synchronously which could execute subscriber code under the lock.
+                // Dispose outside lock because it fires OnCompleted
                 if (_suspensionTracker.IsValueCreated)
                 {
                     _suspensionTracker.Value.Dispose();
@@ -336,7 +351,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     _countChanged.Value.OnError(item.Error!);
                 }
 
-                // Dispose outside lock — same reasoning as Completed path above.
+                // Dispose outside lock because it fires OnCompleted
                 if (_suspensionTracker.IsValueCreated)
                 {
                     _suspensionTracker.Value.Dispose();
@@ -349,6 +364,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 return true;
 
             default:
+                Volatile.Write(ref _currentDeliveryVersion, item.Version);
                 EmitChanges(item.Changes);
                 EmitCount(item.Count);
                 return true;
@@ -411,7 +427,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             var (changes, emitResume) = _suspensionTracker.Value.ResumeNotifications();
             if (changes is not null)
             {
-                notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
+                notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
             }
 
             if (!emitResume)
@@ -433,10 +449,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Error,
     }
 
-    private readonly record struct NotificationItem(NotificationKind Kind, ChangeSet<TObject, TKey> Changes, int Count = 0, Exception? Error = null)
+    private readonly record struct NotificationItem(NotificationKind Kind, ChangeSet<TObject, TKey> Changes, int Count = 0, long Version = 0, Exception? Error = null)
     {
-        public static NotificationItem CreateChanges(ChangeSet<TObject, TKey> changes, int count) =>
-            new(NotificationKind.Changes, changes, count);
+        public static NotificationItem CreateChanges(ChangeSet<TObject, TKey> changes, int count, long version) =>
+            new(NotificationKind.Changes, changes, count, version);
 
         public static NotificationItem CreateCountOnly(int count) =>
             new(NotificationKind.CountOnly, [], count);

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -420,24 +420,23 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     private void ResumeNotifications()
     {
-        using (var notifications = _notifications.AcquireLock())
+        using var notifications = _notifications.AcquireLock();
+
+        Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
+
+        var (changes, emitResume) = _suspensionTracker.Value.ResumeNotifications();
+        if (changes is not null)
         {
-            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
-
-            var (changes, emitResume) = _suspensionTracker.Value.ResumeNotifications();
-            if (changes is not null)
-            {
-                notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
-            }
-
-            if (!emitResume)
-            {
-                return;
-            }
+            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
         }
 
-        // Emit the resume signal after releasing the lock so that deferred
-        // Connect/Watch subscribers are activated outside the lock scope.
+        if (!emitResume)
+        {
+            return;
+        }
+
+        // Emit the resume signal under the lock to eliminate the race where a concurrent
+        // SuspendNotifications could produce overlapping emissions.
         _suspensionTracker.Value.EmitResumeNotification();
     }
 

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -59,11 +59,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 if (changes is not null)
                 {
-                    var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
-                    var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
-                    notifications.Enqueue(
-                        NotificationItem.CreateChanges(changes, _readerWriter.Count, isSuspended, isCountSuspended),
-                        countAsPending: !isSuspended);
+                    notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
                 }
             },
             NotifyError,
@@ -92,10 +88,11 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Observable.Create<int>(
             observer =>
             {
-                using var readLock = _notifications.AcquireReadLock();
-
-                var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
-                return source.SubscribeSafe(observer);
+                lock (_locker)
+                {
+                    var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
+                    return source.SubscribeSafe(observer);
+                }
             });
 
     public IReadOnlyList<TObject> Items => _readerWriter.Items;
@@ -189,11 +186,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         if (changes is not null && _editLevel == 0)
         {
-            var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
-            var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
-            notifications.Enqueue(
-                NotificationItem.CreateChanges(changes, _readerWriter.Count, isSuspended, isCountSuspended),
-                countAsPending: !isSuspended);
+            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
         }
     }
 
@@ -220,11 +213,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         if (changes is not null && _editLevel == 0)
         {
-            var isSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended;
-            var isCountSuspended = _suspensionTracker.IsValueCreated && _suspensionTracker.Value.IsCountSuspended;
-            notifications.Enqueue(
-                NotificationItem.CreateChanges(changes, _readerWriter.Count, isSuspended, isCountSuspended),
-                countAsPending: !isSuspended);
+            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
         }
     }
 
@@ -232,54 +221,53 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Observable.Create<IChangeSet<TObject, TKey>>(
             observer =>
             {
-                using var readLock = _notifications.AcquireReadLock();
-
-                // Skip pending notifications to avoid duplicating items already in the snapshot.
-                var skipCount = readLock.PendingCount;
-
-                var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
-                var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
-                var changes = initial.Concat(changesStream);
-
-                if (predicate != null)
+                // Subject<T> snapshots its observer array before iterating OnNext, so a
+                // subscriber added here will not receive any in-flight notification.
+                lock (_locker)
                 {
-                    changes = changes.Filter(predicate, suppressEmptyChangeSets);
-                }
-                else if (suppressEmptyChangeSets)
-                {
-                    changes = changes.NotEmpty();
-                }
+                    var initial = InternalEx.Return(() => (IChangeSet<TObject, TKey>)GetInitialUpdates(predicate));
+                    var changes = initial.Concat(_changes);
 
-                return changes.SubscribeSafe(observer);
+                    if (predicate != null)
+                    {
+                        changes = changes.Filter(predicate, suppressEmptyChangeSets);
+                    }
+                    else if (suppressEmptyChangeSets)
+                    {
+                        changes = changes.NotEmpty();
+                    }
+
+                    return changes.SubscribeSafe(observer);
+                }
             });
 
     private IObservable<Change<TObject, TKey>> CreateWatchObservable(TKey key) =>
         Observable.Create<Change<TObject, TKey>>(
             observer =>
             {
-                using var readLock = _notifications.AcquireReadLock();
-
-                var skipCount = readLock.PendingCount;
-
-                var initial = _readerWriter.Lookup(key);
-                if (initial.HasValue)
+                // Subject<T> snapshots its observer array before iterating OnNext, so a
+                // subscriber added here will not receive any in-flight notification.
+                lock (_locker)
                 {
-                    observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
-                }
-
-                var changesStream = skipCount > 0 ? _changes.Skip(skipCount) : _changes;
-                return changesStream.Finally(observer.OnCompleted).Subscribe(
-                    changes =>
+                    var initial = _readerWriter.Lookup(key);
+                    if (initial.HasValue)
                     {
-                        foreach (var change in changes.ToConcreteType())
+                        observer.OnNext(new Change<TObject, TKey>(ChangeReason.Add, key, initial.Value));
+                    }
+
+                    return _changes.Finally(observer.OnCompleted).Subscribe(
+                        changes =>
                         {
-                            var match = EqualityComparer<TKey>.Default.Equals(change.Key, key);
-                            if (match)
+                            foreach (var change in changes.ToConcreteType())
                             {
-                                observer.OnNext(change);
+                                var match = EqualityComparer<TKey>.Default.Equals(change.Key, key);
+                                if (match)
+                                {
+                                    observer.OnNext(change);
+                                }
                             }
-                        }
-                    });
+                        });
+                }
             });
 
     /// <summary>
@@ -307,6 +295,16 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         notifications.Enqueue(NotificationItem.CreateError(ex));
     }
 
+    /// <summary>
+    /// Delivers a single notification to subscribers. This method is the delivery
+    /// callback for <see cref="_notifications"/> and must never be called directly.
+    /// It is invoked by the <see cref="DeliveryQueue{TItem}"/> after releasing the
+    /// lock, which guarantees that no lock is held when subscriber code runs. The
+    /// queue's single-deliverer token ensures this method is never called concurrently,
+    /// preserving the Rx serialization contract across all subjects.
+    /// Returns true to continue delivery, or false for terminal items (OnCompleted/OnError)
+    /// which causes the queue to self-terminate.
+    /// </summary>
     private bool DeliverNotification(NotificationItem item)
     {
         switch (item.Kind)
@@ -327,6 +325,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                         _suspensionTracker.Value.Dispose();
                     }
                 }
+
                 return false;
 
             case NotificationKind.Error:
@@ -345,52 +344,53 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                         _suspensionTracker.Value.Dispose();
                     }
                 }
+
                 return false;
 
             case NotificationKind.CountOnly:
-                if (_countChanged.IsValueCreated)
-                {
-                    _countChanged.Value.OnNext(item.Count);
-                }
-
+                EmitCount(item.Count);
                 return true;
 
             default:
-                if (!item.IsSuspended)
-                {
-                    _changes.OnNext(item.Changes);
-                }
-                else
-                {
-                    bool deliverNow;
-                    lock (_locker)
-                    {
-                        if (_suspensionTracker.Value.AreNotificationsSuspended)
-                        {
-                            _suspensionTracker.Value.EnqueueChanges(item.Changes);
-                            deliverNow = false;
-                        }
-                        else
-                        {
-                            deliverNow = true;
-                        }
-                    }
-
-                    if (deliverNow)
-                    {
-                        _changes.OnNext(item.Changes);
-                    }
-                }
-
-                if (!item.IsCountSuspended)
-                {
-                    if (_countChanged.IsValueCreated)
-                    {
-                        _countChanged.Value.OnNext(item.Count);
-                    }
-                }
-
+                EmitChanges(item.Changes);
+                EmitCount(item.Count);
                 return true;
+        }
+
+        void EmitChanges(ChangeSet<TObject, TKey> changes)
+        {
+            if (_suspensionTracker.IsValueCreated)
+            {
+                lock (_locker)
+                {
+                    if (_suspensionTracker.Value.AreNotificationsSuspended)
+                    {
+                        _suspensionTracker.Value.EnqueueChanges(changes);
+                        return;
+                    }
+                }
+            }
+
+            _changes.OnNext(changes);
+        }
+
+        void EmitCount(int count)
+        {
+            if (_suspensionTracker.IsValueCreated)
+            {
+                lock (_locker)
+                {
+                    if (_suspensionTracker.Value.IsCountSuspended)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            if (_countChanged.IsValueCreated)
+            {
+                _countChanged.Value.OnNext(count);
+            }
         }
     }
 
@@ -407,21 +407,25 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     private void ResumeNotifications()
     {
-        using var notifications = _notifications.AcquireLock();
-        Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
-
-        var (resumedChanges, emitResume) = _suspensionTracker.Value.ResumeNotifications();
-        if (resumedChanges is not null)
+        using (var notifications = _notifications.AcquireLock())
         {
-            notifications.Enqueue(
-                NotificationItem.CreateChanges(resumedChanges, _readerWriter.Count, isSuspended: false, isCountSuspended: false),
-                countAsPending: true);
+            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
+
+            var (changes, emitResume) = _suspensionTracker.Value.ResumeNotifications();
+            if (changes is not null)
+            {
+                notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
+            }
+
+            if (!emitResume)
+            {
+                return;
+            }
         }
 
-        if (emitResume)
-        {
-            _suspensionTracker.Value.EmitResumeNotification();
-        }
+        // Emit the resume signal after releasing the lock so that deferred
+        // Connect/Watch subscribers are activated outside the lock scope.
+        _suspensionTracker.Value.EmitResumeNotification();
     }
 
     private enum NotificationKind
@@ -432,41 +436,19 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Error,
     }
 
-    private readonly record struct NotificationItem
+    private readonly record struct NotificationItem(NotificationKind Kind, ChangeSet<TObject, TKey> Changes, int Count = 0, Exception? Error = null)
     {
-        public NotificationKind Kind { get; }
-
-        public ChangeSet<TObject, TKey> Changes { get; }
-
-        public int Count { get; }
-
-        public bool IsSuspended { get; }
-
-        public bool IsCountSuspended { get; }
-
-        public Exception? Error { get; }
-
-        private NotificationItem(NotificationKind kind, ChangeSet<TObject, TKey> changes, int count = 0, bool isSuspended = false, bool isCountSuspended = false, Exception? error = null)
-        {
-            Kind = kind;
-            Changes = changes;
-            Count = count;
-            IsSuspended = isSuspended;
-            IsCountSuspended = isCountSuspended;
-            Error = error;
-        }
-
-        public static NotificationItem CreateChanges(ChangeSet<TObject, TKey> changes, int count, bool isSuspended, bool isCountSuspended) =>
-            new(NotificationKind.Changes, changes, count, isSuspended, isCountSuspended);
+        public static NotificationItem CreateChanges(ChangeSet<TObject, TKey> changes, int count) =>
+            new(NotificationKind.Changes, changes, count);
 
         public static NotificationItem CreateCountOnly(int count) =>
-            new(NotificationKind.CountOnly, [], count: count);
+            new(NotificationKind.CountOnly, [], count);
 
         public static NotificationItem CreateCompleted() =>
             new(NotificationKind.Completed, []);
 
         public static NotificationItem CreateError(Exception error) =>
-            new(NotificationKind.Error, [], error: error);
+            new(NotificationKind.Error, [], Error: error);
     }
 
     private sealed class SuspensionTracker : IDisposable
@@ -519,7 +501,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     changes = new ChangeSet<TObject, TKey>(changesToDeliver);
                 }
 
-                return (changes, _notifySuspendCount == 0);
+                return (changes, true);
             }
 
             return (null, false);

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -93,11 +93,15 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         Observable.Create<int>(
             observer =>
             {
-                lock (_locker)
-                {
-                    var source = _countChanged.Value.StartWith(_readerWriter.Count).DistinctUntilChanged();
-                    return source.SubscribeSafe(observer);
-                }
+                using var readLock = _notifications.AcquireReadLock();
+
+                var snapshotVersion = _currentVersion;
+                var countChanged = readLock.HasPending
+                    ? _countChanged.Value.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)
+                    : _countChanged.Value;
+
+                var source = countChanged.StartWith(_readerWriter.Count).DistinctUntilChanged();
+                return source.SubscribeSafe(observer);
             });
 
     public IReadOnlyList<TObject> Items => _readerWriter.Items;
@@ -232,7 +236,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 // The current snapshot may contain changes that have been made but the notifications
                 // have yet to be delivered.  We need to filter those out to avoid delivering an update
-                // that has already been applied (but detect this possiblity and skip filtering unless absolutely needed)
+                // that has already been applied (but detect this possibility and skip filtering unless absolutely needed)
                 var snapshotVersion = _currentVersion;
                 var changes = readLock.HasPending
                     ? _changes.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)
@@ -266,7 +270,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 // The current snapshot may contain changes that have been made but the notifications
                 // have yet to be delivered.  We need to filter those out to avoid delivering an update
-                // that has already been applied (but detect this possiblity and skip filtering unless absolutely needed)
+                // that has already been applied (but detect this possibility and skip filtering unless absolutely needed)
                 var snapshotVersion = _currentVersion;
                 var changes = readLock.HasPending
                     ? _changes.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)
@@ -420,24 +424,26 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     private void ResumeNotifications()
     {
-        using var notifications = _notifications.AcquireLock();
+        bool emitResume;
 
-        Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
-
-        var (changes, emitResume) = _suspensionTracker.Value.ResumeNotifications();
-        if (changes is not null)
+        using (var notifications = _notifications.AcquireLock())
         {
-            notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
+            Debug.Assert(_suspensionTracker.IsValueCreated, "Should not be Resuming Notifications without Suspend Notifications instance");
+
+            (var changes, emitResume) = _suspensionTracker.Value.ResumeNotifications();
+            if (changes is not null)
+            {
+                notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count, ++_currentVersion));
+            }
         }
 
-        if (!emitResume)
+        // Emit the resume signal after releasing the delivery scope so that
+        // accumulated changes are delivered first
+        if (emitResume)
         {
-            return;
+            using var readLock = _notifications.AcquireReadLock();
+            _suspensionTracker.Value.EmitResumeNotification();
         }
-
-        // Emit the resume signal under the lock to eliminate the race where a concurrent
-        // SuspendNotifications could produce overlapping emissions.
-        _suspensionTracker.Value.EmitResumeNotification();
     }
 
     private enum NotificationKind

--- a/src/DynamicData/Internal/DeliveryQueue.cs
+++ b/src/DynamicData/Internal/DeliveryQueue.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) 2011-2025 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace DynamicData.Internal;
+
+/// <summary>
+/// A queue that serializes item delivery outside a caller-owned lock.
+/// Use <see cref="AcquireLock"/> to obtain a scoped ScopedAccess for enqueueing items
+/// and reading queue state. When the ScopedAccess is disposed, the lock is released
+/// and pending items are delivered. Only one thread delivers at a time.
+/// </summary>
+/// <typeparam name="TItem">The item type.</typeparam>
+internal sealed class DeliveryQueue<TItem>
+{
+    private readonly Queue<(TItem Item, bool CountAsPending)> _queue = new();
+    private readonly Func<TItem, bool> _deliver;
+
+#if NET9_0_OR_GREATER
+    private readonly Lock _gate;
+#else
+    private readonly object _gate;
+#endif
+
+    private bool _isDelivering;
+    private volatile bool _isTerminated;
+    private int _pendingCount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeliveryQueue{TItem}"/> class.
+    /// </summary>
+    /// <param name="gate">The lock shared with the caller. The queue acquires this
+    /// lock during <see cref="AcquireLock"/> and during the dequeue step of delivery.</param>
+    /// <param name="deliver">Callback invoked for each item, outside the lock. Returns false if the item was terminal, which stops further delivery.</param>
+#if NET9_0_OR_GREATER
+    public DeliveryQueue(Lock gate, Func<TItem, bool> deliver)
+#else
+    public DeliveryQueue(object gate, Func<TItem, bool> deliver)
+#endif
+    {
+        _gate = gate;
+        _deliver = deliver;
+    }
+
+    /// <summary>
+    /// Gets whether this queue has been terminated. Safe to read from any thread.
+    /// </summary>
+    public bool IsTerminated => _isTerminated;
+
+    /// <summary>
+    /// Gets the number of pending items enqueued with <c>countAsPending: true</c>.
+    /// Must be read while the caller holds the gate.
+    /// </summary>
+    public int PendingCount => _pendingCount;
+
+    /// <summary>
+    /// Acquires the gate and returns a scoped ScopedAccess for enqueueing items and
+    /// reading queue state. When the ScopedAccess is disposed, the gate is released
+    /// and delivery runs if needed. The ScopedAccess is a ref struct and cannot
+    /// escape the calling method.
+    /// </summary>
+    public ScopedAccess AcquireLock() => new(this);
+
+    private void EnterLock()
+    {
+#if NET9_0_OR_GREATER
+        _gate.Enter();
+#else
+        Monitor.Enter(_gate);
+#endif
+    }
+
+    private void EnqueueItem(TItem item, bool countAsPending)
+    {
+        if (_isTerminated)
+        {
+            return;
+        }
+
+        _queue.Enqueue((item, countAsPending));
+
+        if (countAsPending)
+        {
+            _pendingCount++;
+        }
+    }
+
+    private void ExitLockAndDeliver()
+    {
+        // Before releasing the lock, check if we should start delivery. Only one thread can succeed
+        var shouldDeliver = TryStartDelivery();
+
+        // Now release the lock. We do this before delivering to allow other threads to enqueue items while delivery is in progress.
+#if NET9_0_OR_GREATER
+        _gate.Exit();
+#else
+        Monitor.Exit(_gate);
+#endif
+
+        // If this thread has been chosen to deliver, do it now that the lock is released.
+        // If not, another thread is already delivering or there are no items to deliver.
+        if (shouldDeliver)
+        {
+            DeliverAll();
+        }
+
+        bool TryStartDelivery()
+        {
+            // Bail if something is already delivering or there's nothing to do
+            if (_isDelivering || _queue.Count == 0)
+            {
+                return false;
+            }
+
+            // Mark that we're doing the delivering
+            _isDelivering = true;
+            return true;
+        }
+
+        void DeliverAll()
+        {
+            try
+            {
+                while (true)
+                {
+                    TItem item;
+
+                    // Inside of the lock, see if there is work and get the next item to deliver.
+                    // If there is no work, mark that we're done delivering and exit.
+                    lock (_gate)
+                    {
+                        if (_queue.Count == 0)
+                        {
+                            _isDelivering = false;
+                            return;
+                        }
+
+                        var entry = _queue.Dequeue();
+                        item = entry.Item;
+
+                        if (entry.CountAsPending)
+                        {
+                            _pendingCount--;
+                        }
+                    }
+
+                    // Now the lock is release, we can deliver the item
+                    // If delivery returns false, it means the item was terminal and we should stop delivering and clear the queue.
+                    if (!_deliver(item))
+                    {
+                        lock (_gate)
+                        {
+                            _isTerminated = true;
+                            _isDelivering = false;
+                            _pendingCount = 0;
+                            _queue.Clear();
+                        }
+
+                        return;
+                    }
+                }
+            }
+            catch
+            {
+                // If anything bad happens, we must release the flag so that deliveries aren't stuck
+                lock (_gate)
+                {
+                    _isDelivering = false;
+                }
+
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A scoped ScopedAccess for working under the gate lock. All queue mutation and
+    /// state reads go through this ScopedAccess, ensuring the lock is held. Disposing
+    /// releases the lock and triggers delivery if needed.
+    /// </summary>
+    public ref struct ScopedAccess
+    {
+        private DeliveryQueue<TItem>? _owner;
+
+        internal ScopedAccess(DeliveryQueue<TItem> owner)
+        {
+            _owner = owner;
+            owner.EnterLock();
+        }
+
+        /// <summary>
+        /// Gets the number of pending items that were enqueued with
+        /// <c>countAsPending: true</c> and have not yet been dequeued for delivery.
+        /// </summary>
+        public readonly int PendingCount => _owner?._pendingCount ?? 0;
+
+        /// <summary>
+        /// Adds an item to the queue. Ignored if the queue has been terminated.
+        /// </summary>
+        /// <param name="item">The item to enqueue.</param>
+        /// <param name="countAsPending">True if this item should be tracked by
+        /// <see cref="PendingCount"/>. The count is automatically decremented
+        /// when the item is dequeued for delivery.</param>
+        public readonly void Enqueue(TItem item, bool countAsPending = false) => _owner?.EnqueueItem(item, countAsPending);
+
+        /// <summary>
+        /// Releases the gate lock and delivers pending items if this thread
+        /// holds the delivery token.
+        /// </summary>
+        public void Dispose()
+        {
+            var owner = _owner;
+            if (owner is null)
+            {
+                return;
+            }
+
+            _owner = null;
+            owner.ExitLockAndDeliver();
+        }
+    }
+}

--- a/src/DynamicData/Internal/DeliveryQueue.cs
+++ b/src/DynamicData/Internal/DeliveryQueue.cs
@@ -139,7 +139,7 @@ internal sealed class DeliveryQueue<TItem>
                     }
                 }
             }
-            finally
+            catch
             {
                 // Safety net: if an exception bypassed the normal exit paths,
                 // ensure _isDelivering is reset so the queue doesn't get stuck.
@@ -147,6 +147,8 @@ internal sealed class DeliveryQueue<TItem>
                 {
                     _isDelivering = false;
                 }
+
+                throw;
             }
         }
     }

--- a/src/DynamicData/Internal/DeliveryQueue.cs
+++ b/src/DynamicData/Internal/DeliveryQueue.cs
@@ -6,14 +6,14 @@ namespace DynamicData.Internal;
 
 /// <summary>
 /// A queue that serializes item delivery outside a caller-owned lock.
-/// Use <see cref="AcquireLock"/> to obtain a scoped ScopedAccess for enqueueing items
-/// and reading queue state. When the ScopedAccess is disposed, the lock is released
+/// Use <see cref="AcquireLock"/> to obtain a scoped ScopedAccess for enqueueing items.
+/// When the ScopedAccess is disposed, the lock is released
 /// and pending items are delivered. Only one thread delivers at a time.
 /// </summary>
 /// <typeparam name="TItem">The item type.</typeparam>
 internal sealed class DeliveryQueue<TItem>
 {
-    private readonly Queue<(TItem Item, bool CountAsPending)> _queue = new();
+    private readonly Queue<TItem> _queue = new();
     private readonly Func<TItem, bool> _deliver;
 
 #if NET9_0_OR_GREATER
@@ -24,7 +24,6 @@ internal sealed class DeliveryQueue<TItem>
 
     private bool _isDelivering;
     private volatile bool _isTerminated;
-    private int _pendingCount;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DeliveryQueue{TItem}"/> class.
@@ -48,57 +47,31 @@ internal sealed class DeliveryQueue<TItem>
     public bool IsTerminated => _isTerminated;
 
     /// <summary>
-    /// Gets the number of pending items enqueued with <c>countAsPending: true</c>.
-    /// Must be read while the caller holds the gate.
-    /// </summary>
-    private int PendingCount => _pendingCount;
-
-    /// <summary>
-    /// Acquires the gate and returns a scoped ScopedAccess for enqueueing items and
-    /// reading queue state. When the ScopedAccess is disposed, the gate is released
+    /// Acquires the gate and returns a scoped ScopedAccess for enqueueing items.
+    /// When the ScopedAccess is disposed, the gate is released
     /// and delivery runs if needed. The ScopedAccess is a ref struct and cannot
     /// escape the calling method.
     /// </summary>
     public ScopedAccess AcquireLock() => new(this);
 
-    /// <summary>
-    /// Acquires the gate for read-only access and returns a scoped handle.
-    /// Provides access to queue state (e.g., <see cref="PendingCount"/>) but
-    /// cannot enqueue items and does not trigger delivery on dispose.
-    /// </summary>
-    public ReadOnlyScopedAccess AcquireReadLock() => new(this);
-
-    private void EnterLock()
-    {
 #if NET9_0_OR_GREATER
-        _gate.Enter();
-#else
-        Monitor.Enter(_gate);
-#endif
-    }
+    private void EnterLock() => _gate.Enter();
 
-    private void ExitLock()
-    {
-#if NET9_0_OR_GREATER
-        _gate.Exit();
+    private void ExitLock() => _gate.Exit();
 #else
-        Monitor.Exit(_gate);
-#endif
-    }
+    private void EnterLock() => Monitor.Enter(_gate);
 
-    private void EnqueueItem(TItem item, bool countAsPending)
+    private void ExitLock() => Monitor.Exit(_gate);
+#endif
+
+    private void EnqueueItem(TItem item)
     {
         if (_isTerminated)
         {
             return;
         }
 
-        _queue.Enqueue((item, countAsPending));
-
-        if (countAsPending)
-        {
-            _pendingCount++;
-        }
+        _queue.Enqueue(item);
     }
 
     private void ExitLockAndDeliver()
@@ -147,24 +120,18 @@ internal sealed class DeliveryQueue<TItem>
                             return;
                         }
 
-                        var entry = _queue.Dequeue();
-                        item = entry.Item;
-
-                        if (entry.CountAsPending)
-                        {
-                            _pendingCount--;
-                        }
+                        item = _queue.Dequeue();
                     }
 
-                    // Now the lock is release, we can deliver the item
-                    // If delivery returns false, it means the item was terminal and we should stop delivering and clear the queue.
+                    // Outside of the lock, invoke the callback to deliver the item.
+                    // If delivery returns false, it means the item was terminal
+                    // and we should stop delivering and clear the queue.
                     if (!_deliver(item))
                     {
                         lock (_gate)
                         {
                             _isTerminated = true;
                             _isDelivering = false;
-                            _pendingCount = 0;
                             _queue.Clear();
                         }
 
@@ -172,22 +139,21 @@ internal sealed class DeliveryQueue<TItem>
                     }
                 }
             }
-            catch
+            finally
             {
-                // If anything bad happens, we must release the flag so that deliveries aren't stuck
+                // Safety net: if an exception bypassed the normal exit paths,
+                // ensure _isDelivering is reset so the queue doesn't get stuck.
                 lock (_gate)
                 {
                     _isDelivering = false;
                 }
-
-                throw;
             }
         }
     }
 
     /// <summary>
-    /// A scoped ScopedAccess for working under the gate lock. All queue mutation and
-    /// state reads go through this ScopedAccess, ensuring the lock is held. Disposing
+    /// A scoped ScopedAccess for working under the gate lock. All queue mutation
+    /// goes through this ScopedAccess, ensuring the lock is held. Disposing
     /// releases the lock and triggers delivery if needed.
     /// </summary>
     public ref struct ScopedAccess
@@ -201,19 +167,10 @@ internal sealed class DeliveryQueue<TItem>
         }
 
         /// <summary>
-        /// Gets the number of pending items that were enqueued with
-        /// <c>countAsPending: true</c> and have not yet been dequeued for delivery.
-        /// </summary>
-        public readonly int PendingCount => _owner?._pendingCount ?? 0;
-
-        /// <summary>
         /// Adds an item to the queue. Ignored if the queue has been terminated.
         /// </summary>
         /// <param name="item">The item to enqueue.</param>
-        /// <param name="countAsPending">True if this item should be tracked by
-        /// <see cref="PendingCount"/>. The count is automatically decremented
-        /// when the item is dequeued for delivery.</param>
-        public readonly void Enqueue(TItem item, bool countAsPending = false) => _owner?.EnqueueItem(item, countAsPending);
+        public readonly void Enqueue(TItem item) => _owner?.EnqueueItem(item);
 
         /// <summary>
         /// Releases the gate lock and delivers pending items if this thread
@@ -229,42 +186,6 @@ internal sealed class DeliveryQueue<TItem>
 
             _owner = null;
             owner.ExitLockAndDeliver();
-        }
-    }
-
-    /// <summary>
-    /// A read-only scoped handle for reading queue state under the gate lock.
-    /// Cannot enqueue items and does not trigger delivery on dispose.
-    /// </summary>
-    public ref struct ReadOnlyScopedAccess
-    {
-        private DeliveryQueue<TItem>? _owner;
-
-        internal ReadOnlyScopedAccess(DeliveryQueue<TItem> owner)
-        {
-            _owner = owner;
-            owner.EnterLock();
-        }
-
-        /// <summary>
-        /// Gets the number of pending items that were enqueued with
-        /// <c>countAsPending: true</c> and have not yet been dequeued for delivery.
-        /// </summary>
-        public readonly int PendingCount => _owner?._pendingCount ?? 0;
-
-        /// <summary>
-        /// Releases the gate lock. Does not trigger delivery.
-        /// </summary>
-        public void Dispose()
-        {
-            var owner = _owner;
-            if (owner is null)
-            {
-                return;
-            }
-
-            _owner = null;
-            owner.ExitLock();
         }
     }
 }

--- a/src/DynamicData/Internal/DeliveryQueue.cs
+++ b/src/DynamicData/Internal/DeliveryQueue.cs
@@ -54,6 +54,13 @@ internal sealed class DeliveryQueue<TItem>
     /// </summary>
     public ScopedAccess AcquireLock() => new(this);
 
+    /// <summary>
+    /// Acquires the gate and returns a read-only scoped access for inspecting
+    /// queue state. No mutation is possible and disposing does not trigger
+    /// delivery — the lock is simply released.
+    /// </summary>
+    public ReadOnlyScopedAccess AcquireReadLock() => new(this);
+
 #if NET9_0_OR_GREATER
     private void EnterLock() => _gate.Enter();
 
@@ -188,6 +195,44 @@ internal sealed class DeliveryQueue<TItem>
 
             _owner = null;
             owner.ExitLockAndDeliver();
+        }
+    }
+
+    /// <summary>
+    /// A read-only scoped access for inspecting queue state under the gate lock.
+    /// No mutation is possible. Disposing releases the lock without triggering
+    /// delivery.
+    /// </summary>
+    public ref struct ReadOnlyScopedAccess
+    {
+        private DeliveryQueue<TItem>? _owner;
+
+        internal ReadOnlyScopedAccess(DeliveryQueue<TItem> owner)
+        {
+            _owner = owner;
+            owner.EnterLock();
+        }
+
+        /// <summary>
+        /// Gets whether there are notifications pending delivery (queued or
+        /// currently being delivered outside the lock).
+        /// </summary>
+        public readonly bool HasPending =>
+            _owner is not null && (_owner._queue.Count > 0 || _owner._isDelivering);
+
+        /// <summary>
+        /// Releases the gate lock. Does not trigger delivery.
+        /// </summary>
+        public void Dispose()
+        {
+            var owner = _owner;
+            if (owner is null)
+            {
+                return;
+            }
+
+            _owner = null;
+            owner.ExitLock();
         }
     }
 }

--- a/src/DynamicData/Internal/DeliveryQueue.cs
+++ b/src/DynamicData/Internal/DeliveryQueue.cs
@@ -51,7 +51,7 @@ internal sealed class DeliveryQueue<TItem>
     /// Gets the number of pending items enqueued with <c>countAsPending: true</c>.
     /// Must be read while the caller holds the gate.
     /// </summary>
-    public int PendingCount => _pendingCount;
+    private int PendingCount => _pendingCount;
 
     /// <summary>
     /// Acquires the gate and returns a scoped ScopedAccess for enqueueing items and
@@ -61,12 +61,28 @@ internal sealed class DeliveryQueue<TItem>
     /// </summary>
     public ScopedAccess AcquireLock() => new(this);
 
+    /// <summary>
+    /// Acquires the gate for read-only access and returns a scoped handle.
+    /// Provides access to queue state (e.g., <see cref="PendingCount"/>) but
+    /// cannot enqueue items and does not trigger delivery on dispose.
+    /// </summary>
+    public ReadOnlyScopedAccess AcquireReadLock() => new(this);
+
     private void EnterLock()
     {
 #if NET9_0_OR_GREATER
         _gate.Enter();
 #else
         Monitor.Enter(_gate);
+#endif
+    }
+
+    private void ExitLock()
+    {
+#if NET9_0_OR_GREATER
+        _gate.Exit();
+#else
+        Monitor.Exit(_gate);
 #endif
     }
 
@@ -91,11 +107,7 @@ internal sealed class DeliveryQueue<TItem>
         var shouldDeliver = TryStartDelivery();
 
         // Now release the lock. We do this before delivering to allow other threads to enqueue items while delivery is in progress.
-#if NET9_0_OR_GREATER
-        _gate.Exit();
-#else
-        Monitor.Exit(_gate);
-#endif
+        ExitLock();
 
         // If this thread has been chosen to deliver, do it now that the lock is released.
         // If not, another thread is already delivering or there are no items to deliver.
@@ -217,6 +229,42 @@ internal sealed class DeliveryQueue<TItem>
 
             _owner = null;
             owner.ExitLockAndDeliver();
+        }
+    }
+
+    /// <summary>
+    /// A read-only scoped handle for reading queue state under the gate lock.
+    /// Cannot enqueue items and does not trigger delivery on dispose.
+    /// </summary>
+    public ref struct ReadOnlyScopedAccess
+    {
+        private DeliveryQueue<TItem>? _owner;
+
+        internal ReadOnlyScopedAccess(DeliveryQueue<TItem> owner)
+        {
+            _owner = owner;
+            owner.EnterLock();
+        }
+
+        /// <summary>
+        /// Gets the number of pending items that were enqueued with
+        /// <c>countAsPending: true</c> and have not yet been dequeued for delivery.
+        /// </summary>
+        public readonly int PendingCount => _owner?._pendingCount ?? 0;
+
+        /// <summary>
+        /// Releases the gate lock. Does not trigger delivery.
+        /// </summary>
+        public void Dispose()
+        {
+            var owner = _owner;
+            if (owner is null)
+            {
+                return;
+            }
+
+            _owner = null;
+            owner.ExitLock();
         }
     }
 }

--- a/src/DynamicData/Internal/SwappableLock.cs
+++ b/src/DynamicData/Internal/SwappableLock.cs
@@ -18,6 +18,14 @@ internal ref struct SwappableLock
         return result;
     }
 
+#if NET9_0_OR_GREATER
+    public static SwappableLock CreateAndEnter(Lock gate)
+    {
+        gate.Enter();
+        return new SwappableLock() { _lockGate = gate };
+    }
+#endif
+
     public void SwapTo(object gate)
     {
         if (_gate is null)
@@ -33,8 +41,35 @@ internal ref struct SwappableLock
         _gate = gate;
     }
 
+#if NET9_0_OR_GREATER
+    public void SwapTo(Lock gate)
+    {
+        if (_lockGate is null && _gate is null)
+            throw new InvalidOperationException("Lock is not initialized");
+
+        gate.Enter();
+
+        if (_lockGate is not null)
+            _lockGate.Exit();
+        else if (_hasLock)
+            Monitor.Exit(_gate!);
+
+        _lockGate = gate;
+        _hasLock = false;
+        _gate = null;
+    }
+#endif
+
     public void Dispose()
     {
+#if NET9_0_OR_GREATER
+        if (_lockGate is not null)
+        {
+            _lockGate.Exit();
+            _lockGate = null;
+        }
+        else
+#endif
         if (_hasLock && (_gate is not null))
         {
             Monitor.Exit(_gate);
@@ -45,4 +80,8 @@ internal ref struct SwappableLock
 
     private bool _hasLock;
     private object? _gate;
+
+#if NET9_0_OR_GREATER
+    private Lock? _lockGate;
+#endif
 }

--- a/src/DynamicData/Internal/SwappableLock.cs
+++ b/src/DynamicData/Internal/SwappableLock.cs
@@ -28,14 +28,29 @@ internal ref struct SwappableLock
 
     public void SwapTo(object gate)
     {
+#if NET9_0_OR_GREATER
+        if (_gate is null && _lockGate is null)
+            throw new InvalidOperationException("Lock is not initialized");
+#else
         if (_gate is null)
             throw new InvalidOperationException("Lock is not initialized");
+#endif
 
         var hasNewLock = false;
         Monitor.Enter(gate, ref hasNewLock);
 
+#if NET9_0_OR_GREATER
+        if (_lockGate is not null)
+        {
+            _lockGate.Exit();
+            _lockGate = null;
+        }
+        else
+#endif
         if (_hasLock)
-            Monitor.Exit(_gate);
+        {
+            Monitor.Exit(_gate!);
+        }
 
         _hasLock = hasNewLock;
         _gate = gate;


### PR DESCRIPTION
﻿## Fix cross-cache deadlock in ObservableCache

Fixes the cross-cache deadlock described in #1073 by using a queue to avoid holding a lock while firing downstream events.

## Problem

ObservableCache held its lock (`_locker`) while calling `_changes.OnNext()` to deliver notifications to subscribers. When a subscriber's callback propagated through a pipeline (Transform, PopulateInto, MergeMany) into a second cache, the callback needed that second cache's lock. If another thread was simultaneously writing to the second cache and its subscriber callback chained back to the first cache, both threads blocked permanently waiting for each other's lock.

This was confirmed through analysis of a production hang where 6 threads were deadlocked across multiple ObservableCache instances. The stacks showed the classic pattern: Thread A held CacheA._locker and was blocked on CacheB._locker, while Thread B held CacheB._locker and was blocked on CacheA._locker.

## Solution: Queue-Based Drain Pattern

The fix separates mutation from notification delivery. Instead of calling `OnNext` while holding the lock, writes now enqueue a notification item under the lock, then deliver it after releasing the lock. No lock is ever held when subscriber code runs, which eliminates the cross-cache deadlock entirely.

The core of this approach is a new `DeliveryQueue<TItem>` class that encapsulates the pattern.

### DeliveryQueue

`DeliveryQueue<TItem>` is a generic, reusable concurrency primitive in `src/DynamicData/Internal/DeliveryQueue.cs`. It manages a FIFO queue of items and a delivery token that ensures only one thread delivers at a time.

The public API is designed to make incorrect usage difficult:

- `AcquireLock()` returns a `ref struct ScopedAccess` that holds the caller's lock. Queue operations (`Enqueue`) go through this scoped handle. When it is disposed, the lock is released and pending items are delivered outside the lock. Because it is a `ref struct`, it cannot escape the calling method.
- `AcquireReadLock()` returns a `ref struct ReadOnlyScopedAccess` for inspecting queue state without mutation. It exposes a single property, `HasPending`, which reports whether items are queued or mid-delivery. Disposing releases the lock without triggering delivery. This is used by `Connect` and `Watch` to determine whether version filtering is needed.
- The delivery callback is a `Func<TItem, bool>` that returns `true` to continue or `false` to signal termination. When the callback returns `false`, the queue sets itself as terminated, clears remaining items, and stops. This gives the queue full ownership of its lifecycle.
- `IsTerminated` is a volatile flag safe to read from any thread.
- The delivery loop acquires the lock only for the dequeue step, then releases it before calling the delivery callback. If the callback throws, a `catch/throw` block resets the delivery token so the queue recovers on the next write.
- NET9+ uses `System.Threading.Lock` with `Lock.Enter()`/`Lock.Exit()`. Older TFMs use `Monitor.Enter()`/`Monitor.Exit()`. Both are defined under a single `#if` block for clarity.

### How ObservableCache Uses It

Write paths (`UpdateFromSource`, `UpdateFromIntermediate`, source subscription `OnNext`):
```csharp
using var notifications = _notifications.AcquireLock();
var changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
if (changes is not null)
{
    notifications.Enqueue(NotificationItem.CreateChanges(changes, _readerWriter.Count));
}
// ScopedAccess.Dispose releases lock, then delivers if this thread holds the delivery token
```

Terminal events (source completion, source error, dispose) go through the same queue as sentinel items. The delivery callback returns `false` for these, and the queue self-terminates. This means all terminal cleanup (completing subjects, disposing suspension tracker) happens through a single code path in `DeliverNotification`.

`Connect` and `Watch` use `DeliveryQueue.AcquireReadLock()` to atomically read queue state, take a snapshot, and subscribe (all under a single lock acquisition). When `ReadOnlyScopedAccess.HasPending` indicates notifications are queued or mid-delivery, the snapshot may contain data whose notification hasn't fired yet. To prevent duplicates, each enqueued change notification carries a monotonically increasing version (`_currentVersion`, incremented under lock). Before calling `_changes.OnNext()`, the delivery callback stamps the item's version into `_currentDeliveryVersion` via `Volatile.Write`. The subscriber's stream is wrapped with `.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)`, which drops notifications already covered by the snapshot. Once the first post-snapshot notification arrives, Rx's `SkipWhile` nulls out its predicate (zero ongoing cost). When no notifications are pending, the subscriber gets the raw `_changes` Subject with no filter overhead.

### Suspension

Suspension state is checked at delivery time via local helper methods `EmitOrSuspendChanges` and `EmitOrSuspendCount`. These check the live `AreNotificationsSuspended`/`IsCountSuspended` state under the lock at the moment of delivery, avoiding TOCTOU issues that would arise from capturing the state at enqueue time. A fast-path check on `_suspensionTracker.IsValueCreated` (a monotone volatile flag on `Lazy<T>`) skips the lock entirely when suspension has never been used.

`SuspensionTracker` no longer holds delegates into the queue. `ResumeNotifications` returns the accumulated changes; the caller enqueues them through `ScopedAccess`. The resume signal (`_areNotificationsSuspended.OnNext(false)`) is emitted after releasing the lock so that deferred `Connect`/`Watch` subscribers are activated outside the lock scope.

### NotificationItem

`NotificationItem` uses a `NotificationKind` enum (`Changes`, `CountOnly`, `Completed`, `Error`) and all instances are created through factory methods (`CreateChanges`, `CreateCountOnly`, `CreateCompleted`, `CreateError`). The delivery callback uses a switch on the kind for dispatch.

### Connect/Watch Snapshot-Duplicate Fix

The drain-outside-lock design introduced a race where `Connect()` could take a snapshot containing data whose notification was still queued or mid-delivery. When that notification later fired via `_changes.OnNext()`, the new subscriber saw duplicate Adds.

The fix uses version-tagged delivery: each enqueued change notification carries a monotonically increasing version (`_currentVersion`, incremented under lock). Before calling `_changes.OnNext()`, the delivery callback stamps the item's version into `_currentDeliveryVersion` via `Volatile.Write`. `CreateConnectObservable` and `CreateWatchObservable` capture `snapshotVersion = _currentVersion` under lock and, only when `DeliveryQueue.ReadOnlyScopedAccess.HasPending` is true, apply `.SkipWhile(_ => Volatile.Read(ref _currentDeliveryVersion) <= snapshotVersion)` to the `_changes` stream. Once the first post-snapshot notification arrives, `SkipWhile` nulls out its predicate (zero ongoing cost).

`ReadOnlyScopedAccess` is a new `ref struct` on `DeliveryQueue` that acquires the gate for inspection only (exposes `HasPending` but no mutation methods), and its `Dispose` releases the lock without triggering delivery.

## Testing

All existing tests pass, including all multi-threaded stress tests. 21 new tests across 3 fixtures, plus 1 existing test updated for timing reliability.

### DeliveryQueueFixture (14 tests)

Covers the new `DeliveryQueue<T>` concurrency primitive.

| Test | Description |
|------|-------------|
| `EnqueueAndDeliverDeliversItem` | Basic enqueue → deliver round-trip |
| `DeliverDeliversItemsInFifoOrder` | FIFO ordering guarantee |
| `DeliverWithEmptyQueueIsNoOp` | No delivery callback when queue is empty |
| `OnlyOneDelivererAtATime` | Delivery token serialization under concurrent writers |
| `SecondWriterItemPickedUpByFirstDeliverer` | Late-enqueued items delivered by the active deliverer |
| `ReentrantEnqueueDoesNotRecurse` | Enqueue from within delivery callback does not stack-overflow |
| `ExceptionInDeliveryResetsDeliveryToken` | Delivery token recovery after callback exception |
| `RemainingItemsDeliveredAfterExceptionRecovery` | Queue resumes after exception on next write |
| `TerminalCallbackStopsDelivery` | `return false` terminates queue and clears remaining items |
| `EnqueueAfterTerminationIsIgnored` | Writes after terminal callback are silently dropped |
| `IsTerminatedIsFalseInitially` | Initial state verification |
| `ConcurrentEnqueueAllItemsDelivered` | Stress: all items from concurrent writers are delivered |
| `ConcurrentEnqueueNoDuplicates` | Stress: no item delivered more than once |
| `ConcurrentEnqueuePreservesPerThreadOrdering` | Stress: per-writer FIFO ordering preserved under contention |

### SourceCacheFixture (3 tests)

Covers the cross-cache deadlock fix and snapshot-duplicate prevention.

| Test | Description |
|------|-------------|
| `DirectCrossWriteDoesNotDeadlock` 🐛 | **Proves original deadlock.** Bidirectional cross-cache writes via Filter → Transform → PopulateInto. 100 iterations, 2000 concurrent writes per iteration. Deadlocks on `main`. |
| `MultiCacheFanInDoesNotDeadlock` | Fan-in pattern stress test with subscribers that write back to other caches |
| `ConnectDuringDeliveryDoesNotDuplicate` 🐛 | **Proves snapshot-duplicate bug.** Slow subscriber blocks delivery of item1 while item2 is committed and queued. New Connect subscriber verifies each key appears exactly once. Validates version-tagged SkipWhile filtering. |

### SuspendNotificationsFixture (4 tests)

Covers the resume signal atomicity fix and suspend/resume ordering.

| Test | Description |
|------|-------------|
| `ResumeThenReSuspendDeliversFirstBatchOnly` | Deterministic: resume before re-suspend. Verifies exact message shape (2 messages with exact key ranges per message). |
| `ReSuspendThenResumeDeliversAllInSingleBatch` | Deterministic: re-suspend before resume. Verifies single changeset containing both batches. |
| `ConcurrentSuspendDuringResumeDoesNotCorrupt` | Stress: races resume vs re-suspend, 200 iterations. Verifies final state invariants. |
| `ResumeSignalUnderLockPreventsStaleSnapshotFromReSuspend` 🐛 | **Proves resume signal race.** Slow subscriber blocks delivery, creating a window for re-suspend + write. Deferred subscriber's snapshot must not contain data from the re-suspension. Fails without the fix (200 adds instead of 100). |

### MergeManyChangeSetsCacheSourceCompareFixture (1 modified test)

Existing test updated for queue-based delivery timing.

| Test | Change |
|------|--------|
| `MergeManyStress` | Added `Publish`/`Connect` and `LastOrDefaultAsync` await to ensure all notifications are delivered before assertions |

## Also Included

- **SwappableLock**: Added NET9+ `Lock` type overloads. Fixed `SwapTo(object)` to handle the case where the lock was initialized via `CreateAndEnter(Lock)`.
- **ExpireAfter**: Fixed a race condition where an item could be removed or updated by another thread between when its expiration was scheduled and when it fired. Also fixed `=` to `|=` for `haveExpirationsChanged` in the Update case to prevent silently dropping a prior change flag.