### PR TITLE
Fix race condition in ExpireAfter when items are removed before expiration fires

### DIFF
--- a/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
+++ b/src/DynamicData/Cache/Internal/ExpireAfter.ForSource.cs
@@ -161,11 +161,18 @@ internal static partial class ExpireAfter
                         {
                             _expirationDueTimesByKey.Remove(proposedExpiration.Key);
 
-                            _removedItemsBuffer.Add(new(
-                                key: proposedExpiration.Key,
-                                value: updater.Lookup(proposedExpiration.Key).Value));
+                            // The item may have been removed or updated by another thread between when
+                            // this expiration was scheduled and when it fired. Check that the item is
+                            // still present and still has an expiration before removing it.
+                            var lookup = updater.Lookup(proposedExpiration.Key);
+                            if (lookup.HasValue && _timeSelector.Invoke(lookup.Value) is not null)
+                            {
+                                _removedItemsBuffer.Add(new(
+                                    key: proposedExpiration.Key,
+                                    value: lookup.Value));
 
-                            updater.RemoveKey(proposedExpiration.Key);
+                                updater.RemoveKey(proposedExpiration.Key);
+                            }
                         }
                     }
                     _proposedExpirationsQueue.RemoveRange(0, proposedExpirationIndex);
@@ -273,7 +280,7 @@ internal static partial class ExpireAfter
                                 {
                                     if (_timeSelector.Invoke(change.Current) is { } expireAfter)
                                     {
-                                        haveExpirationsChanged = TrySetExpiration(
+                                        haveExpirationsChanged |= TrySetExpiration(
                                             key: change.Key,
                                             dueTime: now + expireAfter);
                                     }


### PR DESCRIPTION
## Description

Fixes a race condition in `ExpireAfter.ForSource` where the expiration timer callback assumes the item still exists in the source cache. When an item is removed or updated by another thread between when the expiration was scheduled and when it fires, the callback would throw InvalidOperationException from `Lookup().Value` on a missing key.

## Root Cause

The timer callback in `OnEditingSource` unconditionally called:
```csharp
_removedItemsBuffer.Add(new(key: proposedExpiration.Key,
    value: updater.Lookup(proposedExpiration.Key).Value));  // throws if missing!
updater.RemoveKey(proposedExpiration.Key);
```

## Fix

1. **Check item existence before removal** `Lookup()` is checked for `HasValue` before accessing `.Value`
2. **Check expiration still applies** _timeSelector.Invoke(lookup.Value) is not null verifies the item still has a pending expiration
3. **Fix expiration accumulation** `haveExpirationsChanged |= TrySetExpiration(...)` uses |= instead of = to correctly accumulate changes across multiple items in a changeset (previously, only the last item's result was kept)

## Impact

This race was reproducible under moderate concurrent load.  A stress test calling `AddOrUpdate` and `RemoveKey` on a `SourceCache` with `ExpireAfter` from multiple threads would intermittently throw. The fix is minimal and surgical: two guard checks and one operator change.
