### PR TITLE
Fixed dynamic Cache .Filter() for older framework targets

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -10,4 +10,8 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net6')) or $(TargetFramework.StartsWith('net7')) or $(TargetFramework.StartsWith('net8')) or $(TargetFramework.StartsWith('net9')) or $(TargetFramework.StartsWith('net10'))">
     <DefineConstants>$(DefineConstants);NETSTANDARD;P_LINQ;SUPPORTS_BINDINGLIST;SUPPORTS_ASYNC_DISPOSABLE</DefineConstants>
   </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard2.1')) or $(TargetFramework.StartsWith('netcoreapp3')) or $(TargetFramework.StartsWith('net5')) or $(TargetFramework.StartsWith('net6')) or $(TargetFramework.StartsWith('net7')) or $(TargetFramework.StartsWith('net8')) or $(TargetFramework.StartsWith('net9')) or $(TargetFramework.StartsWith('net10'))">
+    <DefineConstants>$(DefineConstants);SUPPORTS_DICTIONARY_MUTATION_DURING_ENUMERATION</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/DynamicData/Cache/Internal/Filter.Dynamic.cs
+++ b/src/DynamicData/Cache/Internal/Filter.Dynamic.cs
@@ -378,7 +378,11 @@ internal static partial class Filter
 
             private void ReFilter(TState predicateState)
             {
+                #if SUPPORTS_DICTIONARY_MUTATION_DURING_ENUMERATION
                 foreach (var key in _itemStatesByKey.Keys)
+                #else
+                foreach (var key in _itemStatesByKey.Keys.ToArray())
+                #endif
                 {
                     var itemState = _itemStatesByKey[key];
 


### PR DESCRIPTION
Fixed that the cache-land dynamic `.Filter()` operator relied on limited mutation of an internal `Dictionary<,>` during enumeration, a behavior that is not supported on target frameworks older than .NET Core 3.0. Additional logic to copy the keys to iterate, before mutation, should now be injected for builds targeting such older frameworks.

Resolves #1083.