### PR TITLE
Add DynamicAccessedMembers attributes to BindingListEx methods

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
@@ -323,12 +323,12 @@ namespace DynamicData.Binding
     public static class BindingListEx
     {
         public static System.IObservable<System.Reactive.EventPattern<System.ComponentModel.ListChangedEventArgs>> ObserveCollectionChanges(this System.ComponentModel.IBindingList source) { }
-        public static System.IObservable<DynamicData.IChangeSet<T>> ToObservableChangeSet<T>(this System.ComponentModel.BindingList<T> source)
+        public static System.IObservable<DynamicData.IChangeSet<T>> ToObservableChangeSet<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  T>(this System.ComponentModel.BindingList<T> source)
             where T :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<T>> ToObservableChangeSet<TCollection, T>(this TCollection source)
             where TCollection : System.ComponentModel.IBindingList, System.Collections.Generic.IEnumerable<T>
             where T :  notnull { }
-        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this System.ComponentModel.BindingList<TObject> source, System.Func<TObject, TKey> keySelector)
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> ToObservableChangeSet<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]  TObject, TKey>(this System.ComponentModel.BindingList<TObject> source, System.Func<TObject, TKey> keySelector)
             where TObject :  notnull
             where TKey :  notnull { }
     }

--- a/src/DynamicData/Binding/BindingListEx.cs
+++ b/src/DynamicData/Binding/BindingListEx.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Linq;
 
@@ -30,7 +31,7 @@ public static class BindingListEx
     /// <param name="source">The source.</param>
     /// <returns>An observable which emits change set values.</returns>
     /// <exception cref="ArgumentNullException">source.</exception>
-    public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this BindingList<T> source)
+    public static IObservable<IChangeSet<T>> ToObservableChangeSet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this BindingList<T> source)
         where T : notnull
     {
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
@@ -50,7 +51,7 @@ public static class BindingListEx
     /// <exception cref="ArgumentNullException">source
     /// or
     /// keySelector.</exception>
-    public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<TObject, TKey>(this BindingList<TObject> source, Func<TObject, TKey> keySelector)
+    public static IObservable<IChangeSet<TObject, TKey>> ToObservableChangeSet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TObject, TKey>(this BindingList<TObject> source, Func<TObject, TKey> keySelector)
         where TObject : notnull
         where TKey : notnull
     {
@@ -132,7 +133,7 @@ public static class BindingListEx
             });
     }
 
-    internal static void Clone<T>(this BindingList<T> source, IEnumerable<Change<T>> changes)
+    internal static void Clone<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this BindingList<T> source, IEnumerable<Change<T>> changes)
         where T : notnull
     {
         // ** Copied from ListEx for binding list specific changes
@@ -145,7 +146,7 @@ public static class BindingListEx
         }
     }
 
-    private static void Clone<T>(this BindingList<T> source, Change<T> item, IEqualityComparer<T> equalityComparer)
+    private static void Clone<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this BindingList<T> source, Change<T> item, IEqualityComparer<T> equalityComparer)
         where T : notnull
     {
         switch (item.Reason)

--- a/src/DynamicData/DynamicData.csproj
+++ b/src/DynamicData/DynamicData.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net8.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAotCompatible>true</IsAotCompatible>
     <IsPackable>true</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
This pull request enables `IsAotCompatible` and fixes the few remaining warnings (resolves #1086). By enabling this flag, warning newly introduced in future .NET versions should become visible once new target frameworks are being added.

Notes to reviewers:
1. I removed the duplicate `net8.0` target framework because Visual Studio 2026 did not allow me to build the project with duplicate target frameworks.
2. I used `DynamicallyAccessedMemberTypes.All` for annotating `BindingListEx` which is not exactly the same as [`TypeDescriptor.AllMembersAndInterfaces`](https://source.dot.net/System.ComponentModel.TypeConverter/R/d3c902610b35a0f0.html) which is being used by `BindingList<T>` internally. However, that special value is internal and verbose to replicate in a way compatible with various .NET versions.