### PR TITLE
Add Preview workflows and enforce versioning rules

### DIFF
--- a/.github/workflows/bump-major-preview.yml
+++ b/.github/workflows/bump-major-preview.yml
@@ -1,0 +1,97 @@
+name: Bump main to next major preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_major:
+        description: 'Next major version (e.g., 10) for the new preview line on main'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - name: Configure git
+      run: |
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+
+    - name: Validate inputs
+      shell: pwsh
+      run: |
+        $next = '${{ inputs.next_major }}'
+        if ($next -notmatch '^\d+$') {
+          throw "next_major must be a single integer (got: '$next')"
+        }
+        $nextInt = [int]$next
+
+        $versionJson = Get-Content version.json -Raw | ConvertFrom-Json
+        $ver = $versionJson.version
+        if ($ver -notmatch '^(\d+)\.\d+-preview') {
+          throw "main's version is '$ver' but should be '<major>.<minor>-preview.{height}'"
+        }
+        $currentMajor = [int]$matches[1]
+        if ($nextInt -le $currentMajor) {
+          throw "next_major ($nextInt) must be greater than current major ($currentMajor)"
+        }
+
+        $newVersion = "$next.0-preview.{height}"
+        Add-Content -Path $env:GITHUB_ENV -Value "NEW_VERSION=$newVersion"
+        Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAJOR=$next"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-major-$next"
+
+    - name: Create bump branch
+      run: git checkout -b "$BUMP_BRANCH"
+
+    - name: Bump version.json
+      shell: pwsh
+      run: |
+        $path = 'version.json'
+        $content = [System.IO.File]::ReadAllText($path)
+        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEW_VERSION`"")
+        [System.IO.File]::WriteAllText($path, $new)
+
+    - name: Commit and push
+      run: |
+        git add version.json
+        git commit -m "Bump main to $NEW_VERSION (next major preview line)"
+        git push -u origin "$BUMP_BRANCH"
+
+    - name: Open PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: pwsh
+      run: |
+        $body = @"
+        Bumps ``main`` from its current preview to ``$env:NEW_VERSION`` ahead of upcoming breaking changes for ``$env:NEXT_MAJOR.0``.
+
+        Merge this **before** any PR labeled ``breaking-change`` so the prereleases are correctly versioned as ``$env:NEXT_MAJOR.0.0-preview.N``.
+        "@
+        $url = gh pr create `
+          --base main `
+          --head "$env:BUMP_BRANCH" `
+          --title "Bump main to $env:NEW_VERSION (next major preview)" `
+          --body $body
+        Add-Content -Path $env:GITHUB_ENV -Value "PR_URL=$url"
+
+    - name: Summary
+      shell: pwsh
+      run: |
+        $summary = @"
+        ## Major preview bump
+
+        - **PR**: $env:PR_URL
+        - Merge this before landing the first breaking-change PR.
+        "@
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/bump-major-preview.yml
+++ b/.github/workflows/bump-major-preview.yml
@@ -46,6 +46,24 @@ jobs:
           throw "next_major ($nextInt) must be greater than current major ($currentMajor)"
         }
 
+        git fetch --tags --force 2>$null
+        $latestStable = git tag --list --sort=-v:refname |
+            Where-Object { $_ -match '^(\d+)\.\d+\.\d+$' } |
+            Select-Object -First 1
+        if ($latestStable) {
+          if ($latestStable -notmatch '^(\d+)\.') {
+            throw "Could not parse latest stable tag: '$latestStable'"
+          }
+          $latestStableMajor = [int]$matches[1]
+          $expectedMajor = $latestStableMajor + 1
+          if ($nextInt -ne $expectedMajor) {
+            throw "next_major ($nextInt) must be exactly one greater than the latest stable major ($latestStableMajor; tag '$latestStable'). Expected: $expectedMajor. Major versions must be incremented sequentially to avoid accidentally skipping a major."
+          }
+          Write-Host "OK: next_major ($nextInt) is exactly one greater than latest stable major ($latestStableMajor)."
+        } else {
+          Write-Host "No stable tags found; skipping sequential-major check."
+        }
+
         $newVersion = "$next.0-preview.{height}"
         Add-Content -Path $env:GITHUB_ENV -Value "NEW_VERSION=$newVersion"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAJOR=$next"

--- a/.github/workflows/bump-major-preview.yml
+++ b/.github/workflows/bump-major-preview.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: bump-major-preview-${{ inputs.next_major }}
+  group: main-version-mutator
   cancel-in-progress: false
 
 jobs:
@@ -37,7 +37,6 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
 
         $next = $env:NEXT_MAJOR_INPUT
         if ($next -notmatch '^(0|[1-9]\d*)$') {
@@ -46,7 +45,14 @@ jobs:
         $nextInt = [int]$next
         $next = [string]$nextInt
 
-        $versionJson = Get-Content version.json -Raw | ConvertFrom-Json
+        git fetch --tags --force origin
+        if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot validate sequential-major rule." }
+
+        $mainHeadSha = (git rev-parse origin/main).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $mainHeadSha) { throw "git rev-parse origin/main failed (exit $LASTEXITCODE)." }
+
+        $versionJson = git show "${mainHeadSha}:version.json" | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0) { throw "Failed to read version.json from origin/main." }
         $ver = $versionJson.version
         if ($ver -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)-preview') {
           throw "main's version is '$ver' but should be '<major>.<minor>-preview.{height}'"
@@ -55,9 +61,6 @@ jobs:
         if ($nextInt -le $currentMajor) {
           throw "next_major ($nextInt) must be greater than current major ($currentMajor)"
         }
-
-        git fetch --tags --force origin
-        if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot validate sequential-major rule." }
 
         $latestStable = git tag --list --sort=-v:refname |
             Where-Object { $_ -match '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' } |
@@ -70,12 +73,10 @@ jobs:
           $latestStableMajor = [int]$matches[1]
           $expectedMajor = $latestStableMajor + 1
           if ($nextInt -ne $expectedMajor) {
-            throw "next_major ($nextInt) must be exactly one greater than the latest stable major ($latestStableMajor; tag '$latestStable'). Expected: $expectedMajor. Major versions must be incremented sequentially to avoid accidentally skipping a major."
+            throw "next_major ($nextInt) must be exactly one greater than the latest stable major ($latestStableMajor; tag '$latestStable'). Expected: $expectedMajor. Major versions must be incremented sequentially."
           }
           Write-Host "OK: next_major ($nextInt) is exactly one greater than latest stable major ($latestStableMajor)."
         } else {
-          # Fail closed: if no stable tags exist, require next_major == currentMajor + 1 against version.json,
-          # so we still preserve the no-skipping invariant for fresh repos.
           $expectedMajor = $currentMajor + 1
           if ($nextInt -ne $expectedMajor) {
             throw "No stable tags found; falling back to comparing against main's current major ($currentMajor). next_major ($nextInt) must be exactly $expectedMajor."
@@ -85,12 +86,20 @@ jobs:
 
         $newVersion = "$next.0-preview.{height}"
         $runId = $env:GITHUB_RUN_ID
+        $runAttempt = $env:GITHUB_RUN_ATTEMPT
         Add-Content -Path $env:GITHUB_ENV -Value "NEW_VERSION=$newVersion"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAJOR=$next"
-        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-major-$next-$runId"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-major-$next-$runId-$runAttempt"
+        Add-Content -Path $env:GITHUB_ENV -Value "MAIN_HEAD_SHA=$mainHeadSha"
 
-    - name: Create bump branch
-      run: git checkout -b "$BUMP_BRANCH"
+    - name: Create bump branch (from validated main SHA)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        git checkout "$env:MAIN_HEAD_SHA"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout failed (exit $LASTEXITCODE)." }
+        git checkout -b "$env:BUMP_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout -b failed (exit $LASTEXITCODE)." }
 
     - name: Bump version.json
       shell: pwsh
@@ -99,18 +108,36 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEW_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
+        $obj = $content | ConvertFrom-Json
+        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
+          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        }
 
     - name: Commit and push
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
+        if ($LASTEXITCODE -ne 0) { throw "git add failed (exit $LASTEXITCODE)." }
         git commit -m "Bump main to $env:NEW_VERSION (next major preview line)"
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)." }
         git push --force-with-lease -u origin "$env:BUMP_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git push failed (exit $LASTEXITCODE)." }
+
+    - name: Verify main hasn't moved since validation
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        git fetch origin main --quiet
+        if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)." }
+        $currentMainSha = (git rev-parse origin/main).Trim()
+        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
+          throw "main moved during bump-major-preview (was $env:MAIN_HEAD_SHA, now $currentMainSha). The bump branch was pushed but no PR was created. Delete the bump branch and re-run."
+        }
+        Write-Host "OK: main is still at $env:MAIN_HEAD_SHA."
 
     - name: Open PR
       env:
@@ -118,18 +145,21 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         $nextMajor = $env:NEXT_MAJOR
         $body = @"
         Bumps ``main`` from its current preview to ``$env:NEW_VERSION`` ahead of upcoming breaking changes for ``${nextMajor}.0``.
 
         Merge this **before** any PR labeled ``breaking-change`` so the prereleases are correctly versioned as ``${nextMajor}.0.0-preview.N``.
         "@
-        $url = (gh pr create `
-          --base main `
-          --head "$env:BUMP_BRANCH" `
-          --title "Bump main to $env:NEW_VERSION (next major preview)" `
-          --body $body | Select-Object -Last 1).Trim()
+        try {
+          $url = (gh pr create `
+            --base main `
+            --head "$env:BUMP_BRANCH" `
+            --title "Bump main to $env:NEW_VERSION (next major preview)" `
+            --body $body | Select-Object -Last 1).Trim()
+        } catch {
+          throw "gh pr create failed: $($_.Exception.Message)"
+        }
         if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
           throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
         }

--- a/.github/workflows/bump-major-preview.yml
+++ b/.github/workflows/bump-major-preview.yml
@@ -12,9 +12,15 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: bump-major-preview-${{ inputs.next_major }}
+  cancel-in-progress: false
+
 jobs:
   bump:
     runs-on: ubuntu-latest
+    env:
+      NEXT_MAJOR_INPUT: ${{ inputs.next_major }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -30,15 +36,19 @@ jobs:
     - name: Validate inputs
       shell: pwsh
       run: |
-        $next = '${{ inputs.next_major }}'
-        if ($next -notmatch '^\d+$') {
-          throw "next_major must be a single integer (got: '$next')"
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
+        $next = $env:NEXT_MAJOR_INPUT
+        if ($next -notmatch '^(0|[1-9]\d*)$') {
+          throw "next_major must be a positive integer with no leading zeros (got: '$next')"
         }
         $nextInt = [int]$next
+        $next = [string]$nextInt
 
         $versionJson = Get-Content version.json -Raw | ConvertFrom-Json
         $ver = $versionJson.version
-        if ($ver -notmatch '^(\d+)\.\d+-preview') {
+        if ($ver -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)-preview') {
           throw "main's version is '$ver' but should be '<major>.<minor>-preview.{height}'"
         }
         $currentMajor = [int]$matches[1]
@@ -46,10 +56,13 @@ jobs:
           throw "next_major ($nextInt) must be greater than current major ($currentMajor)"
         }
 
-        git fetch --tags --force 2>$null
+        git fetch --tags --force origin
+        if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot validate sequential-major rule." }
+
         $latestStable = git tag --list --sort=-v:refname |
-            Where-Object { $_ -match '^(\d+)\.\d+\.\d+$' } |
+            Where-Object { $_ -match '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' } |
             Select-Object -First 1
+
         if ($latestStable) {
           if ($latestStable -notmatch '^(\d+)\.') {
             throw "Could not parse latest stable tag: '$latestStable'"
@@ -61,13 +74,20 @@ jobs:
           }
           Write-Host "OK: next_major ($nextInt) is exactly one greater than latest stable major ($latestStableMajor)."
         } else {
-          Write-Host "No stable tags found; skipping sequential-major check."
+          # Fail closed: if no stable tags exist, require next_major == currentMajor + 1 against version.json,
+          # so we still preserve the no-skipping invariant for fresh repos.
+          $expectedMajor = $currentMajor + 1
+          if ($nextInt -ne $expectedMajor) {
+            throw "No stable tags found; falling back to comparing against main's current major ($currentMajor). next_major ($nextInt) must be exactly $expectedMajor."
+          }
+          Write-Host "No stable tags found; next_major ($nextInt) matches currentMajor+1 ($expectedMajor)."
         }
 
         $newVersion = "$next.0-preview.{height}"
+        $runId = $env:GITHUB_RUN_ID
         Add-Content -Path $env:GITHUB_ENV -Value "NEW_VERSION=$newVersion"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAJOR=$next"
-        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-major-$next"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-major-$next-$runId"
 
     - name: Create bump branch
       run: git checkout -b "$BUMP_BRANCH"
@@ -75,32 +95,44 @@ jobs:
     - name: Bump version.json
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEW_VERSION`"")
-        [System.IO.File]::WriteAllText($path, $new)
+        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEW_VERSION`"")
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
+        [System.IO.File]::WriteAllText($path, $content)
 
     - name: Commit and push
+      shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
-        git commit -m "Bump main to $NEW_VERSION (next major preview line)"
-        git push -u origin "$BUMP_BRANCH"
+        git commit -m "Bump main to $env:NEW_VERSION (next major preview line)"
+        git push --force-with-lease -u origin "$env:BUMP_BRANCH"
 
     - name: Open PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        $nextMajor = $env:NEXT_MAJOR
         $body = @"
-        Bumps ``main`` from its current preview to ``$env:NEW_VERSION`` ahead of upcoming breaking changes for ``$env:NEXT_MAJOR.0``.
+        Bumps ``main`` from its current preview to ``$env:NEW_VERSION`` ahead of upcoming breaking changes for ``${nextMajor}.0``.
 
-        Merge this **before** any PR labeled ``breaking-change`` so the prereleases are correctly versioned as ``$env:NEXT_MAJOR.0.0-preview.N``.
+        Merge this **before** any PR labeled ``breaking-change`` so the prereleases are correctly versioned as ``${nextMajor}.0.0-preview.N``.
         "@
-        $url = gh pr create `
+        $url = (gh pr create `
           --base main `
           --head "$env:BUMP_BRANCH" `
           --title "Bump main to $env:NEW_VERSION (next major preview)" `
-          --body $body
+          --body $body | Select-Object -Last 1).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
+          throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
+        }
         Add-Content -Path $env:GITHUB_ENV -Value "PR_URL=$url"
 
     - name: Summary

--- a/.github/workflows/bump-major-preview.yml
+++ b/.github/workflows/bump-major-preview.yml
@@ -7,6 +7,11 @@ on:
         description: 'Next major version (e.g., 10) for the new preview line on main'
         required: true
         type: string
+      discard_current_preview:
+        description: 'Allow orphaning the current major''s preview work (no release branch will ever ship for it). Check this only when intentionally abandoning the current X.Y-preview line.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -21,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_MAJOR_INPUT: ${{ inputs.next_major }}
+      DISCARD_PREVIEW_INPUT: ${{ inputs.discard_current_preview }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -57,8 +63,40 @@ jobs:
           throw "main's version is '$ver' but should be '<major>.<minor>-preview.{height}'"
         }
         $currentMajor = [int]$matches[1]
+        $currentMinor = [int]$matches[2]
         if ($nextInt -le $currentMajor) {
           throw "next_major ($nextInt) must be greater than current major ($currentMajor)"
+        }
+
+        # Pre-flight: detect whether the current major's preview work would be orphaned.
+        # The only workflow that creates release branches is cut-major.yml, and it requires
+        # main to be on <major>.0-preview. If main has moved past .0-preview without the
+        # major ever being cut (or has accumulated minor work past the existing release
+        # branch's stable minor), bumping to the next major silently loses that work.
+        $discardOverride = $env:DISCARD_PREVIEW_INPUT -eq 'true'
+        $releaseBranch = "release/$currentMajor.x"
+        $releaseExists = git ls-remote --heads origin "refs/heads/$releaseBranch"
+        if ($LASTEXITCODE -ne 0) { throw "git ls-remote for $releaseBranch failed (exit $LASTEXITCODE); cannot verify orphan state." }
+
+        if (-not $releaseExists) {
+          $msg = "main is on $currentMajor.$currentMinor-preview but '$releaseBranch' does not exist. Bumping main to $nextInt would orphan ALL '$currentMajor.x' work (no stable '$currentMajor.*' would ever ship). To ship $currentMajor.0 stable first, run 'Cut major release' with major_version=$currentMajor and next_main_version=$nextInt.0. To intentionally discard the $currentMajor preview line, re-run this workflow with 'discard_current_preview' checked."
+          if (-not $discardOverride) { throw $msg }
+          Write-Host "WARNING (discard_current_preview=true): release/$currentMajor.x does not exist. All $currentMajor.x work is being orphaned."
+        } else {
+          $releaseVerJson = git show "origin/${releaseBranch}:version.json" | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0) { throw "Failed to read version.json from origin/$releaseBranch." }
+          $releaseVer = $releaseVerJson.version
+          if ($releaseVer -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+            throw "'$releaseBranch' version is '$releaseVer'; expected stable '<major>.<minor>' form. Cannot verify orphan state."
+          }
+          $releaseMinor = [int]$matches[2]
+          if ($currentMinor -gt $releaseMinor) {
+            $msg = "main is on $currentMajor.$currentMinor-preview but '$releaseBranch' is at $currentMajor.$releaseMinor stable. Bumping main to $nextInt would orphan the $currentMajor.$currentMinor preview work (never shipped as stable). To ship $currentMajor.$currentMinor stable first, run 'Promote main to stable minor' with target_release_branch=$releaseBranch and stable_version=$currentMajor.$currentMinor. To intentionally discard $currentMajor.$currentMinor preview, re-run this workflow with 'discard_current_preview' checked."
+            if (-not $discardOverride) { throw $msg }
+            Write-Host "WARNING (discard_current_preview=true): orphaning $currentMajor.$currentMinor preview work (release/$currentMajor.x is at $currentMajor.$releaseMinor)."
+          } else {
+            Write-Host "OK: $releaseBranch is at $currentMajor.$releaseMinor stable and main is on $currentMajor.$currentMinor-preview ($currentMinor <= $releaseMinor); no orphaning."
+          }
         }
 
         $latestStable = git tag --list --sort=-v:refname |

--- a/.github/workflows/bump-major-preview.yml
+++ b/.github/workflows/bump-major-preview.yml
@@ -43,7 +43,6 @@ jobs:
           throw "next_major must be a positive integer with no leading zeros (got: '$next')"
         }
         $nextInt = [int]$next
-        $next = [string]$nextInt
 
         git fetch --tags --force origin
         if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot validate sequential-major rule." }

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,13 +54,3 @@ jobs:
     - name: Run Tests
       run: dotnet test --no-restore --configuration Release DynamicData.sln
       working-directory: src
-
-    - name: Pack
-      run: dotnet pack --no-restore --configuration Release DynamicData.sln
-      working-directory: src
-
-    - name: Create NuGet Artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: nuget
-        path: 'src/**/bin/Release/*.nupkg'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [ main, release/** ]
+    branches: [ main, 'release/*.x' ]
 
 env:
   configuration: Release

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,7 +60,7 @@ jobs:
       working-directory: src
 
     - name: Create NuGet Artifacts
-      uses: actions/upload-artifact@v6.0.0
+      uses: actions/upload-artifact@v4.6.2
       with:
         name: nuget
         path: 'src/**/bin/Release/*.nupkg'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   configuration: Release
-  productNamespacePrefix: "DynamicData"
 
 jobs:
   build:
@@ -40,7 +39,7 @@ jobs:
 
     - name: NBGV
       id: nbgv
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@v0.5.1
       with:
         setAllVars: true
         
@@ -61,7 +60,7 @@ jobs:
       working-directory: src
 
     - name: Create NuGet Artifacts
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v7
       with:
         name: nuget
-        path: '**/*.nupkg'
+        path: 'src/**/bin/Release/*.nupkg'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,3 +54,13 @@ jobs:
     - name: Run Tests
       run: dotnet test --no-restore --configuration Release DynamicData.sln
       working-directory: src
+
+    - name: Pack
+      run: dotnet pack --no-restore --configuration Release DynamicData.sln
+      working-directory: src
+
+    - name: Create NuGet Artifacts
+      uses: actions/upload-artifact@v6.0.0
+      with:
+        name: nuget
+        path: 'src/**/bin/Release/*.nupkg'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/** ]
 
 env:
   configuration: Release

--- a/.github/workflows/cut-major.yml
+++ b/.github/workflows/cut-major.yml
@@ -57,6 +57,22 @@ jobs:
         if ($nextMain -notmatch '^(\d+)\.(\d+)$') {
           throw "next_main_version must be 'major.minor' (got: '$nextMain')"
         }
+        $nextMainMajor = [int]$matches[1]
+        $nextMainMinor = [int]$matches[2]
+        $cutMajor = [int]$major
+
+        if ($nextMainMajor -eq $cutMajor) {
+          if ($nextMainMinor -lt 1) {
+            throw "next_main_version ($nextMain) for the same major as the cut release must have minor >= 1. After cutting $major.0, the next main version should be $major.1 or later."
+          }
+        } elseif ($nextMainMajor -eq $cutMajor + 1) {
+          if ($nextMainMinor -ne 0) {
+            throw "next_main_version ($nextMain) for the next major must be $($cutMajor + 1).0. Use sequential major bumps (no skipping)."
+          }
+        } else {
+          throw "next_main_version ($nextMain) must be either '$major.<minor>' (continued minors of the cut major) or '$($cutMajor + 1).0' (next sequential major). To skip a major, edit version.json by hand."
+        }
+
         $nextPreview = "$nextMain-preview.{height}"
 
         Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_BRANCH=$releaseBranch"
@@ -75,8 +91,10 @@ jobs:
       run: |
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        [System.IO.File]::WriteAllText($path, $new)
+        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*\r?\n', '')
+        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
+        [System.IO.File]::WriteAllText($path, $content)
 
     - name: Commit and push release branch
       run: |

--- a/.github/workflows/cut-major.yml
+++ b/.github/workflows/cut-major.yml
@@ -1,0 +1,134 @@
+name: Cut major release
+
+on:
+  workflow_dispatch:
+    inputs:
+      major_version:
+        description: 'Major version to ship as stable (e.g., 10). Main must currently be on this major''s preview line.'
+        required: true
+        type: string
+      next_main_version:
+        description: 'Next preview version for main as major.minor (default: <major>.1). Use the next major if more breaking changes are queued.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Configure git
+      run: |
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+
+    - name: Validate inputs
+      shell: pwsh
+      run: |
+        $major = '${{ inputs.major_version }}'
+        if ($major -notmatch '^\d+$') {
+          throw "major_version must be a single integer (got: '$major')"
+        }
+
+        $releaseBranch = "release/$major.x"
+        $stableVersion = "$major.0"
+
+        $mainVersionJson = git show "origin/main:version.json" | ConvertFrom-Json
+        $mainVer = $mainVersionJson.version
+        if ($mainVer -notmatch "^$major\.0-preview") {
+          throw "main's version is '$mainVer' but should be '$major.0-preview.{height}' to cut $major.0 stable. Run 'Bump main to next major preview' first if needed."
+        }
+
+        $existing = git ls-remote --heads origin "refs/heads/$releaseBranch"
+        if ($existing) {
+          throw "Branch '$releaseBranch' already exists. Cannot cut a new major release branch that exists."
+        }
+
+        $nextMain = '${{ inputs.next_main_version }}'
+        if (-not $nextMain) { $nextMain = "$major.1" }
+        if ($nextMain -notmatch '^(\d+)\.(\d+)$') {
+          throw "next_main_version must be 'major.minor' (got: '$nextMain')"
+        }
+        $nextPreview = "$nextMain-preview.{height}"
+
+        Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_BRANCH=$releaseBranch"
+        Add-Content -Path $env:GITHUB_ENV -Value "STABLE_VERSION=$stableVersion"
+        Add-Content -Path $env:GITHUB_ENV -Value "NEXT_PREVIEW=$nextPreview"
+        Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAIN_VERSION=$nextMain"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$stableVersion"
+
+    - name: Create release branch from main
+      run: |
+        git checkout main
+        git checkout -b "$RELEASE_BRANCH"
+
+    - name: Set stable version on release branch
+      shell: pwsh
+      run: |
+        $path = 'version.json'
+        $content = [System.IO.File]::ReadAllText($path)
+        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
+        [System.IO.File]::WriteAllText($path, $new)
+
+    - name: Commit and push release branch
+      run: |
+        git add version.json
+        git commit -m "Cut $RELEASE_BRANCH at $STABLE_VERSION stable"
+        git push -u origin "$RELEASE_BRANCH"
+
+    - name: Create main bump branch
+      run: |
+        git checkout main
+        git checkout -b "$BUMP_BRANCH"
+
+    - name: Bump main to next preview
+      shell: pwsh
+      run: |
+        $path = 'version.json'
+        $content = [System.IO.File]::ReadAllText($path)
+        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
+        [System.IO.File]::WriteAllText($path, $new)
+
+    - name: Commit and push main bump branch
+      run: |
+        git add version.json
+        git commit -m "Bump main to $NEXT_PREVIEW after cutting $RELEASE_BRANCH"
+        git push -u origin "$BUMP_BRANCH"
+
+    - name: Open main bump PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: pwsh
+      run: |
+        $body = @"
+        Companion PR to cutting ``$env:RELEASE_BRANCH``.
+
+        The release branch ``$env:RELEASE_BRANCH`` has been pushed and will publish ``$env:STABLE_VERSION.0`` stable.
+
+        This PR advances ``main`` to ``$env:NEXT_PREVIEW`` so subsequent PRs publish that preview line.
+        "@
+        $url = gh pr create `
+          --base main `
+          --head "$env:BUMP_BRANCH" `
+          --title "Bump main to $env:NEXT_PREVIEW after $env:RELEASE_BRANCH cut" `
+          --body $body
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_PR_URL=$url"
+
+    - name: Summary
+      shell: pwsh
+      run: |
+        $summary = @"
+        ## Major release cut
+
+        - **New release branch**: ``$env:RELEASE_BRANCH`` (will publish ``$env:STABLE_VERSION.0`` stable on push).
+        - **Main bump PR** (merge to advance main to next preview): $env:BUMP_PR_URL
+        "@
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/cut-major.yml
+++ b/.github/workflows/cut-major.yml
@@ -18,7 +18,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: cut-major-${{ inputs.major_version }}
+  group: main-version-mutator
   cancel-in-progress: false
 
 jobs:
@@ -43,7 +43,6 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
 
         $major = $env:MAJOR_VERSION_INPUT
         if ($major -notmatch '^(0|[1-9]\d*)$') {
@@ -59,12 +58,16 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE); cannot proceed." }
 
         $mainHeadSha = (git rev-parse origin/main).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $mainHeadSha) { throw "git rev-parse origin/main failed (exit $LASTEXITCODE)." }
+
         $mainVersionJson = git show "${mainHeadSha}:version.json" | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0) { throw "Failed to read version.json from origin/main." }
         $mainVer = $mainVersionJson.version
         if ($mainVer -notmatch "^$major\.0-preview") {
           throw "main's version is '$mainVer' but should be '$major.0-preview.{height}' to cut $major.0 stable. Run 'Bump main to next major preview' first if needed."
         }
 
+        # Test branch existence without --exit-code (which throws on no-match under strict mode).
         $existing = git ls-remote --heads origin "refs/heads/$releaseBranch"
         if ($LASTEXITCODE -ne 0) { throw "git ls-remote failed (exit $LASTEXITCODE); cannot verify branch state." }
         if ($existing) {
@@ -88,27 +91,35 @@ jobs:
           if ($nextMainMinor -ne 0) {
             throw "next_main_version ($nextMain) for the next major must be $($cutMajor + 1).0. Use sequential major bumps (no skipping)."
           }
+          # When advancing to the next major, verify no stable tags already exist for it.
+          $existingNextStable = git tag --list "$nextMainMajor.*" | Where-Object { $_ -match "^$nextMainMajor\.\d+\.\d+$" }
+          if ($existingNextStable) {
+            $list = $existingNextStable -join ', '
+            throw "next_main_version ($nextMain) targets major $nextMainMajor, but stable tags already exist for it: $list. Advancing main to ${nextMain}-preview would conflict with already-shipped stables. Pick a higher version or investigate."
+          }
         } else {
           throw "next_main_version ($nextMain) must be either '$major.<minor>' (continued minors of the cut major) or '$($cutMajor + 1).0' (next sequential major). To skip a major, edit version.json by hand."
         }
 
         $nextPreview = "$nextMain-preview.{height}"
         $runId = $env:GITHUB_RUN_ID
+        $runAttempt = $env:GITHUB_RUN_ATTEMPT
 
         Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_BRANCH=$releaseBranch"
         Add-Content -Path $env:GITHUB_ENV -Value "STABLE_VERSION=$stableVersion"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_PREVIEW=$nextPreview"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAIN_VERSION=$nextMain"
-        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$stableVersion-$runId"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$stableVersion-$runId-$runAttempt"
         Add-Content -Path $env:GITHUB_ENV -Value "MAIN_HEAD_SHA=$mainHeadSha"
 
     - name: Create main bump branch (from validated main SHA)
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git checkout "$env:MAIN_HEAD_SHA"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout failed (exit $LASTEXITCODE)." }
         git checkout -b "$env:BUMP_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout -b failed (exit $LASTEXITCODE)." }
 
     - name: Bump main to next preview
       shell: pwsh
@@ -117,18 +128,38 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
+        # Verify removal worked (defends against regex misses on unusual formatting).
+        $obj = $content | ConvertFrom-Json
+        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
+          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        }
 
     - name: Commit and push main bump branch
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
+        if ($LASTEXITCODE -ne 0) { throw "git add failed (exit $LASTEXITCODE)." }
         git commit -m "Bump main to $env:NEXT_PREVIEW after cutting $env:RELEASE_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)." }
         git push --force-with-lease -u origin "$env:BUMP_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git push failed (exit $LASTEXITCODE)." }
+
+    - name: Verify main hasn't moved since validation
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        git fetch origin main --quiet
+        if ($LASTEXITCODE -ne 0) { throw "git fetch origin main failed (exit $LASTEXITCODE)." }
+        $currentMainSha = (git rev-parse origin/main).Trim()
+        if ($LASTEXITCODE -ne 0) { throw "git rev-parse failed (exit $LASTEXITCODE)." }
+        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
+          throw "main moved during cut-major run (was $env:MAIN_HEAD_SHA, now $currentMainSha). The bump branch was pushed but no PR was created and the release branch was NOT pushed. Delete the bump branch and re-run the workflow."
+        }
+        Write-Host "OK: main is still at $env:MAIN_HEAD_SHA."
 
     - name: Open main bump PR
       env:
@@ -136,7 +167,6 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         $body = @"
         Companion PR to cutting ``$env:RELEASE_BRANCH``.
 
@@ -144,35 +174,28 @@ jobs:
 
         This PR advances ``main`` to ``$env:NEXT_PREVIEW`` so subsequent PRs publish that preview line.
         "@
-        $url = (gh pr create `
-          --base main `
-          --head "$env:BUMP_BRANCH" `
-          --title "Bump main to $env:NEXT_PREVIEW after $env:RELEASE_BRANCH cut" `
-          --body $body | Select-Object -Last 1).Trim()
+        try {
+          $url = (gh pr create `
+            --base main `
+            --head "$env:BUMP_BRANCH" `
+            --title "Bump main to $env:NEXT_PREVIEW after $env:RELEASE_BRANCH cut" `
+            --body $body | Select-Object -Last 1).Trim()
+        } catch {
+          throw "gh pr create failed: $($_.Exception.Message)"
+        }
         if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
           throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
         }
         Add-Content -Path $env:GITHUB_ENV -Value "BUMP_PR_URL=$url"
 
-    - name: Verify main hasn't moved since validation
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
-        git fetch origin main --quiet
-        $currentMainSha = (git rev-parse origin/main).Trim()
-        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
-          throw "main moved during cut-major run (was $env:MAIN_HEAD_SHA, now $currentMainSha). The bump PR has been opened; the release branch was NOT pushed. Re-run the workflow after closing the bump PR."
-        }
-        Write-Host "OK: main is still at $env:MAIN_HEAD_SHA."
-
     - name: Create release branch from validated main SHA
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git checkout "$env:MAIN_HEAD_SHA"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout failed (exit $LASTEXITCODE)." }
         git checkout -b "$env:RELEASE_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout -b failed (exit $LASTEXITCODE)." }
 
     - name: Set stable version on release branch
       shell: pwsh
@@ -181,18 +204,24 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
+        $obj = $content | ConvertFrom-Json
+        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
+          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        }
 
     - name: Commit and push release branch
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
+        if ($LASTEXITCODE -ne 0) { throw "git add failed (exit $LASTEXITCODE)." }
         git commit -m "Cut $env:RELEASE_BRANCH at $env:STABLE_VERSION stable"
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)." }
         git push -u origin "$env:RELEASE_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git push failed (exit $LASTEXITCODE)." }
 
     - name: Trigger release workflow on new release branch
       env:
@@ -200,20 +229,42 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
-        gh workflow run release.yml --ref "$env:RELEASE_BRANCH"
-        if ($LASTEXITCODE -ne 0) {
-          throw "Failed to trigger release.yml on $env:RELEASE_BRANCH (exit $LASTEXITCODE). The release branch has been pushed but won't publish automatically (GITHUB_TOKEN pushes don't fire push triggers). Manually run release.yml against $env:RELEASE_BRANCH from the Actions tab."
+        # Wait briefly for GitHub to index the newly pushed branch so workflow_dispatch can find it.
+        $maxAttempts = 6
+        for ($i = 1; $i -le $maxAttempts; $i++) {
+          try {
+            gh workflow run release.yml --ref "$env:RELEASE_BRANCH" 2>$null
+          } catch {
+            # swallow; we check LASTEXITCODE
+          }
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "release.yml dispatched for $env:RELEASE_BRANCH on attempt $i."
+            break
+          }
+          if ($i -eq $maxAttempts) {
+            throw "Failed to trigger release.yml on $env:RELEASE_BRANCH after $maxAttempts attempts. The release branch is pushed but won't publish automatically. Manually run release.yml against $env:RELEASE_BRANCH from the Actions tab."
+          }
+          Start-Sleep -Seconds 5
         }
-        Write-Host "OK: release.yml dispatched for $env:RELEASE_BRANCH."
+        # Verify a run actually queued.
+        Start-Sleep -Seconds 5
+        $runs = gh run list --workflow=release.yml --branch="$env:RELEASE_BRANCH" --limit 1 --json databaseId,status,url 2>$null | ConvertFrom-Json
+        if (-not $runs -or $runs.Count -eq 0) {
+          Write-Warning "Dispatched release.yml but no run is visible yet. Check the Actions tab and verify a run starts; if not, dispatch manually."
+        } else {
+          $runUrl = $runs[0].url
+          Write-Host "Triggered run: $runUrl"
+          Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_RUN_URL=$runUrl"
+        }
 
     - name: Summary
       shell: pwsh
       run: |
+        $runLink = if ($env:RELEASE_RUN_URL) { "[release run]($env:RELEASE_RUN_URL)" } else { "the Actions tab (run not yet visible; check manually)" }
         $summary = @"
         ## Major release cut
 
-        - **New release branch**: ``$env:RELEASE_BRANCH`` (publishes the first ``$env:STABLE_VERSION.x`` stable build via release.yml, dispatched automatically).
+        - **New release branch**: ``$env:RELEASE_BRANCH`` publishing the first ``$env:STABLE_VERSION.x`` stable build (first patch is ``$env:STABLE_VERSION.1``). See $runLink.
         - **Main bump PR** (merge to advance main to next preview): $env:BUMP_PR_URL
         "@
         Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/cut-major.yml
+++ b/.github/workflows/cut-major.yml
@@ -202,11 +202,11 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
         if ($content -match '"versionHeightOffset"') {
           $content = [regex]::Replace($content, '"versionHeightOffset"\s*:\s*-?\d+', '"versionHeightOffset": -1')
+          $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
         } else {
-          $content = [regex]::Replace($content, '(?m)^(\s*)"version":\s*"[^"]+"\s*,?', "`$0`r`n`$1`"versionHeightOffset`": -1,", 1)
+          $content = [regex]::Replace($content, '(?m)^(\s*)"version":\s*"[^"]+"\s*,?', "`$1`"version`": `"$env:STABLE_VERSION`",`r`n`$1`"versionHeightOffset`": -1,", 1)
         }
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)

--- a/.github/workflows/cut-major.yml
+++ b/.github/workflows/cut-major.yml
@@ -15,14 +15,23 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
+
+concurrency:
+  group: cut-major-${{ inputs.major_version }}
+  cancel-in-progress: false
 
 jobs:
   cut:
     runs-on: ubuntu-latest
+    env:
+      MAJOR_VERSION_INPUT: ${{ inputs.major_version }}
+      NEXT_MAIN_VERSION_INPUT: ${{ inputs.next_main_version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
       with:
+        ref: main
         fetch-depth: 0
 
     - name: Configure git
@@ -33,33 +42,43 @@ jobs:
     - name: Validate inputs
       shell: pwsh
       run: |
-        $major = '${{ inputs.major_version }}'
-        if ($major -notmatch '^\d+$') {
-          throw "major_version must be a single integer (got: '$major')"
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
+        $major = $env:MAJOR_VERSION_INPUT
+        if ($major -notmatch '^(0|[1-9]\d*)$') {
+          throw "major_version must be a positive integer with no leading zeros (got: '$major')"
         }
+        $cutMajor = [int]$major
+        $major = [string]$cutMajor
 
         $releaseBranch = "release/$major.x"
         $stableVersion = "$major.0"
 
-        $mainVersionJson = git show "origin/main:version.json" | ConvertFrom-Json
+        git fetch --tags --force origin
+        if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE); cannot proceed." }
+
+        $mainHeadSha = (git rev-parse origin/main).Trim()
+        $mainVersionJson = git show "${mainHeadSha}:version.json" | ConvertFrom-Json
         $mainVer = $mainVersionJson.version
         if ($mainVer -notmatch "^$major\.0-preview") {
           throw "main's version is '$mainVer' but should be '$major.0-preview.{height}' to cut $major.0 stable. Run 'Bump main to next major preview' first if needed."
         }
 
         $existing = git ls-remote --heads origin "refs/heads/$releaseBranch"
+        if ($LASTEXITCODE -ne 0) { throw "git ls-remote failed (exit $LASTEXITCODE); cannot verify branch state." }
         if ($existing) {
           throw "Branch '$releaseBranch' already exists. Cannot cut a new major release branch that exists."
         }
 
-        $nextMain = '${{ inputs.next_main_version }}'
+        $nextMain = $env:NEXT_MAIN_VERSION_INPUT
         if (-not $nextMain) { $nextMain = "$major.1" }
-        if ($nextMain -notmatch '^(\d+)\.(\d+)$') {
-          throw "next_main_version must be 'major.minor' (got: '$nextMain')"
+        if ($nextMain -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+          throw "next_main_version must be 'major.minor' with no leading zeros (got: '$nextMain')"
         }
         $nextMainMajor = [int]$matches[1]
         $nextMainMinor = [int]$matches[2]
-        $cutMajor = [int]$major
+        $nextMain = "$nextMainMajor.$nextMainMinor"
 
         if ($nextMainMajor -eq $cutMajor) {
           if ($nextMainMinor -lt 1) {
@@ -74,71 +93,119 @@ jobs:
         }
 
         $nextPreview = "$nextMain-preview.{height}"
+        $runId = $env:GITHUB_RUN_ID
 
         Add-Content -Path $env:GITHUB_ENV -Value "RELEASE_BRANCH=$releaseBranch"
         Add-Content -Path $env:GITHUB_ENV -Value "STABLE_VERSION=$stableVersion"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_PREVIEW=$nextPreview"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_MAIN_VERSION=$nextMain"
-        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$stableVersion"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$stableVersion-$runId"
+        Add-Content -Path $env:GITHUB_ENV -Value "MAIN_HEAD_SHA=$mainHeadSha"
 
-    - name: Create release branch from main
-      run: |
-        git checkout main
-        git checkout -b "$RELEASE_BRANCH"
-
-    - name: Set stable version on release branch
+    - name: Create main bump branch (from validated main SHA)
       shell: pwsh
       run: |
-        $path = 'version.json'
-        $content = [System.IO.File]::ReadAllText($path)
-        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*\r?\n', '')
-        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
-        [System.IO.File]::WriteAllText($path, $content)
-
-    - name: Commit and push release branch
-      run: |
-        git add version.json
-        git commit -m "Cut $RELEASE_BRANCH at $STABLE_VERSION stable"
-        git push -u origin "$RELEASE_BRANCH"
-
-    - name: Create main bump branch
-      run: |
-        git checkout main
-        git checkout -b "$BUMP_BRANCH"
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git checkout "$env:MAIN_HEAD_SHA"
+        git checkout -b "$env:BUMP_BRANCH"
 
     - name: Bump main to next preview
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
-        [System.IO.File]::WriteAllText($path, $new)
+        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
+        [System.IO.File]::WriteAllText($path, $content)
 
     - name: Commit and push main bump branch
+      shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
-        git commit -m "Bump main to $NEXT_PREVIEW after cutting $RELEASE_BRANCH"
-        git push -u origin "$BUMP_BRANCH"
+        git commit -m "Bump main to $env:NEXT_PREVIEW after cutting $env:RELEASE_BRANCH"
+        git push --force-with-lease -u origin "$env:BUMP_BRANCH"
 
     - name: Open main bump PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         $body = @"
         Companion PR to cutting ``$env:RELEASE_BRANCH``.
 
-        The release branch ``$env:RELEASE_BRANCH`` has been pushed and will publish ``$env:STABLE_VERSION.0`` stable.
+        Once ``$env:RELEASE_BRANCH`` is pushed it will publish the first ``$env:STABLE_VERSION.x`` stable build (first patch is ``$env:STABLE_VERSION.1``).
 
         This PR advances ``main`` to ``$env:NEXT_PREVIEW`` so subsequent PRs publish that preview line.
         "@
-        $url = gh pr create `
+        $url = (gh pr create `
           --base main `
           --head "$env:BUMP_BRANCH" `
           --title "Bump main to $env:NEXT_PREVIEW after $env:RELEASE_BRANCH cut" `
-          --body $body
+          --body $body | Select-Object -Last 1).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
+          throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
+        }
         Add-Content -Path $env:GITHUB_ENV -Value "BUMP_PR_URL=$url"
+
+    - name: Verify main hasn't moved since validation
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git fetch origin main --quiet
+        $currentMainSha = (git rev-parse origin/main).Trim()
+        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
+          throw "main moved during cut-major run (was $env:MAIN_HEAD_SHA, now $currentMainSha). The bump PR has been opened; the release branch was NOT pushed. Re-run the workflow after closing the bump PR."
+        }
+        Write-Host "OK: main is still at $env:MAIN_HEAD_SHA."
+
+    - name: Create release branch from validated main SHA
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git checkout "$env:MAIN_HEAD_SHA"
+        git checkout -b "$env:RELEASE_BRANCH"
+
+    - name: Set stable version on release branch
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $path = 'version.json'
+        $content = [System.IO.File]::ReadAllText($path)
+        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
+        [System.IO.File]::WriteAllText($path, $content)
+
+    - name: Commit and push release branch
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git add version.json
+        git commit -m "Cut $env:RELEASE_BRANCH at $env:STABLE_VERSION stable"
+        git push -u origin "$env:RELEASE_BRANCH"
+
+    - name: Trigger release workflow on new release branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        gh workflow run release.yml --ref "$env:RELEASE_BRANCH"
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to trigger release.yml on $env:RELEASE_BRANCH (exit $LASTEXITCODE). The release branch has been pushed but won't publish automatically (GITHUB_TOKEN pushes don't fire push triggers). Manually run release.yml against $env:RELEASE_BRANCH from the Actions tab."
+        }
+        Write-Host "OK: release.yml dispatched for $env:RELEASE_BRANCH."
 
     - name: Summary
       shell: pwsh
@@ -146,7 +213,7 @@ jobs:
         $summary = @"
         ## Major release cut
 
-        - **New release branch**: ``$env:RELEASE_BRANCH`` (will publish ``$env:STABLE_VERSION.0`` stable on push).
+        - **New release branch**: ``$env:RELEASE_BRANCH`` (publishes the first ``$env:STABLE_VERSION.x`` stable build via release.yml, dispatched automatically).
         - **Main bump PR** (merge to advance main to next preview): $env:BUMP_PR_URL
         "@
         Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/cut-major.yml
+++ b/.github/workflows/cut-major.yml
@@ -49,7 +49,6 @@ jobs:
           throw "major_version must be a positive integer with no leading zeros (got: '$major')"
         }
         $cutMajor = [int]$major
-        $major = [string]$cutMajor
 
         $releaseBranch = "release/$major.x"
         $stableVersion = "$major.0"
@@ -204,12 +203,16 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
+        if ($content -match '"versionHeightOffset"') {
+          $content = [regex]::Replace($content, '"versionHeightOffset"\s*:\s*-?\d+', '"versionHeightOffset": -1')
+        } else {
+          $content = [regex]::Replace($content, '(?m)^(\s*)"version":\s*"[^"]+"\s*,?', "`$0`r`n`$1`"versionHeightOffset`": -1,", 1)
+        }
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
         $obj = $content | ConvertFrom-Json
-        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
-          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        if ($obj.versionHeightOffset -ne -1) {
+          throw "Failed to set versionHeightOffset to -1 (got: $($obj.versionHeightOffset)). Manual edit required."
         }
 
     - name: Commit and push release branch

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -25,33 +25,46 @@ jobs:
         BASE_REF: ${{ github.base_ref }}
         LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
-        $labels = $env:LABELS_JSON | ConvertFrom-Json
-        $isBreaking = ($labels -contains 'breaking-change') -or ($labels -contains 'semver:major')
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
 
-        if (-not $isBreaking) {
-          Write-Host "PR is not labeled 'breaking-change' or 'semver:major'; no major-bump check needed."
+        if ($env:BASE_REF -ne 'main') {
+          Write-Host "PR targets '$env:BASE_REF' (not main); breaking-change check only applies to PRs targeting main. Skipping."
           exit 0
         }
 
-        Write-Host "PR is labeled as breaking. Verifying main's version.json reflects a newer major than the latest stable release."
+        $labels = $env:LABELS_JSON | ConvertFrom-Json
+        $isBreaking = $labels -contains 'breaking-change'
 
-        git fetch origin $env:BASE_REF --depth=1 2>$null
-        $baseVersionJson = git show "origin/${env:BASE_REF}:version.json" | ConvertFrom-Json
-        $baseVer = $baseVersionJson.version
-        if ($baseVer -notmatch '^(\d+)\.') {
-          Write-Error "::error file=version.json::Could not parse major version from base version.json: '$baseVer'"
+        if (-not $isBreaking) {
+          Write-Host "PR is not labeled 'breaking-change'; no major-bump check needed."
+          exit 0
+        }
+
+        Write-Host "PR is labeled as breaking. Verifying the PR's version.json reflects a newer major than the latest stable release."
+
+        # Validate against the PR HEAD's version.json (which is the checked-out tree),
+        # not the base branch, so a PR that reverts main's version is also caught.
+        $headVersionJson = Get-Content version.json -Raw | ConvertFrom-Json
+        $headVer = $headVersionJson.version
+        if ($headVer -notmatch '^(0|[1-9]\d*)\.') {
+          Write-Error "::error file=version.json::Could not parse major version from PR head version.json: '$headVer'"
           exit 1
         }
-        $baseMajor = [int]$matches[1]
+        $headMajor = [int]$matches[1]
 
-        git fetch --tags --force 2>$null
+        git fetch --tags --force origin
+        if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot safely validate breaking-change label." }
+
         $latestStable = git tag --list --sort=-v:refname |
-            Where-Object { $_ -match '^(\d+)\.\d+\.\d+$' } |
+            Where-Object { $_ -match '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' } |
             Select-Object -First 1
 
         if (-not $latestStable) {
-          Write-Host "No stable tags found; cannot determine latest released major. Skipping check."
-          exit 0
+          # Fail closed: a breaking-change PR with no known stable history is suspicious.
+          # Don't silently allow it; require the label to be removed for genuinely new repos.
+          Write-Error "::error::No stable tags found; cannot validate sequential-major rule for a breaking-change PR. Either remove the 'breaking-change' label or verify git tag history is intact."
+          exit 1
         }
 
         if ($latestStable -notmatch '^(\d+)\.') {
@@ -60,17 +73,17 @@ jobs:
         }
         $latestMajor = [int]$matches[1]
 
-        Write-Host "Latest stable major: $latestMajor; current main major: $baseMajor"
+        Write-Host "Latest stable major: $latestMajor; PR head major: $headMajor"
 
         $expectedMajor = $latestMajor + 1
-        if ($baseMajor -ne $expectedMajor) {
-          if ($baseMajor -le $latestMajor) {
-            $msg = "PR is labeled breaking-change but main's major ($baseMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow with next_major=$expectedMajor first, then re-target this PR."
+        if ($headMajor -ne $expectedMajor) {
+          if ($headMajor -le $latestMajor) {
+            $msg = "PR is labeled breaking-change but its version.json major ($headMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow with next_major=$expectedMajor first, then re-target this PR. After the bump PR merges, push a new commit (or close+reopen this PR) to re-run this check."
           } else {
-            $msg = "PR is labeled breaking-change but main's major ($baseMajor) skips past major $expectedMajor. Main must be at exactly one greater than the latest stable major ($latestMajor + 1 = $expectedMajor). Major versions must be incremented sequentially. Reset main to $expectedMajor.0-preview.{height} before merging this PR."
+            $msg = "PR is labeled breaking-change but its version.json major ($headMajor) skips past major $expectedMajor. Main must be at exactly one greater than the latest stable major ($latestMajor + 1 = $expectedMajor). Major versions must be incremented sequentially. Reset main to $expectedMajor.0-preview.{height} before merging this PR."
           }
           Write-Error "::error file=version.json::$msg"
           exit 1
         }
 
-        Write-Host "OK: main major ($baseMajor) is exactly one greater than latest stable major ($latestMajor)."
+        Write-Host "OK: PR head major ($headMajor) is exactly one greater than latest stable major ($latestMajor)."

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -62,10 +62,15 @@ jobs:
 
         Write-Host "Latest stable major: $latestMajor; current main major: $baseMajor"
 
-        if ($baseMajor -le $latestMajor) {
-          $msg = "PR is labeled breaking-change but main's major ($baseMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow first, then re-target this PR."
+        $expectedMajor = $latestMajor + 1
+        if ($baseMajor -ne $expectedMajor) {
+          if ($baseMajor -le $latestMajor) {
+            $msg = "PR is labeled breaking-change but main's major ($baseMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow with next_major=$expectedMajor first, then re-target this PR."
+          } else {
+            $msg = "PR is labeled breaking-change but main's major ($baseMajor) skips past major $expectedMajor. Main must be at exactly one greater than the latest stable major ($latestMajor + 1 = $expectedMajor). Major versions must be incremented sequentially. Reset main to $expectedMajor.0-preview.{height} before merging this PR."
+          }
           Write-Error "::error file=version.json::$msg"
           exit 1
         }
 
-        Write-Host "OK: main major ($baseMajor) > latest stable major ($latestMajor)."
+        Write-Host "OK: main major ($baseMajor) is exactly one greater than latest stable major ($latestMajor)."

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -24,11 +24,23 @@ jobs:
       env:
         BASE_REF: ${{ github.base_ref }}
         LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         $ErrorActionPreference = 'Stop'
 
         if ($env:BASE_REF -ne 'main') {
           Write-Host "PR targets '$env:BASE_REF' (not main); breaking-change check only applies to PRs targeting main. Skipping."
+          exit 0
+        }
+
+        # The version-bump bot PRs (opened by GITHUB_TOKEN from the automation workflows)
+        # legitimately change the major in version.json. Don't trip the unconditional
+        # major-change check on them; their content is reviewed in the workflow that
+        # opened them.
+        $isBotBumpPr = ($env:PR_AUTHOR -eq 'github-actions[bot]') -and ($env:HEAD_REF -like 'bot/bump-*')
+        if ($isBotBumpPr) {
+          Write-Host "PR is an automation-authored version-bump branch ('$env:HEAD_REF'); skipping check."
           exit 0
         }
 
@@ -74,13 +86,14 @@ jobs:
             Select-Object -First 1
 
         if (-not $latestStable) {
-          # No prior stable releases. Use main's current major as the floor, so a brand-new
-          # project's first breaking PR is allowed when it advances main by exactly one.
-          if ($headMajor -eq $baseMajor + 1) {
-            Write-Host "No stable tags found; PR head major ($headMajor) is exactly one greater than main ($baseMajor). OK."
+          # No prior stable releases. Accept either the post-bump steady state
+          # (head == base, both already at the new major) or the rare case where
+          # the breaking PR itself does the bump (head == base + 1).
+          if ($headMajor -eq $baseMajor -or $headMajor -eq $baseMajor + 1) {
+            Write-Host "No stable tags found; PR head major ($headMajor) is consistent with main ($baseMajor). OK."
             exit 0
           }
-          throw "No stable tags found; PR head major ($headMajor) must be exactly one greater than main's current major ($baseMajor) for a breaking-change PR with no prior stable history."
+          throw "No stable tags found; PR head major ($headMajor) must equal or be exactly one greater than main's current major ($baseMajor) for a breaking-change PR with no prior stable history."
         }
 
         if ($latestStable -notmatch '^(\d+)\.') {

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -26,7 +26,6 @@ jobs:
         LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
 
         if ($env:BASE_REF -ne 'main') {
           Write-Host "PR targets '$env:BASE_REF' (not main); breaking-change check only applies to PRs targeting main. Skipping."
@@ -36,22 +35,36 @@ jobs:
         $labels = $env:LABELS_JSON | ConvertFrom-Json
         $isBreaking = $labels -contains 'breaking-change'
 
+        $headVersionJson = Get-Content version.json -Raw | ConvertFrom-Json
+        $headVer = $headVersionJson.version
+        if ($headVer -notmatch '^(0|[1-9]\d*)\.') {
+          throw "Could not parse major version from PR head version.json: '$headVer'"
+        }
+        $headMajor = [int]$matches[1]
+
+        git fetch origin main --quiet
+        if ($LASTEXITCODE -ne 0) { throw "git fetch origin main failed (exit $LASTEXITCODE)." }
+
+        $baseVersionJson = git show "origin/main:version.json" | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0) { throw "Failed to read version.json from origin/main." }
+        $baseVer = $baseVersionJson.version
+        if ($baseVer -notmatch '^(0|[1-9]\d*)\.') {
+          throw "Could not parse major version from main's version.json: '$baseVer'"
+        }
+        $baseMajor = [int]$matches[1]
+
+        # Unconditional check: if this PR changes the major in version.json, it MUST be
+        # labeled breaking-change. Catches unlabeled major-version edits.
+        if ($headMajor -ne $baseMajor -and -not $isBreaking) {
+          throw "This PR changes version.json's major from $baseMajor to $headMajor but is not labeled 'breaking-change'. Major-version changes must be tagged."
+        }
+
         if (-not $isBreaking) {
-          Write-Host "PR is not labeled 'breaking-change'; no major-bump check needed."
+          Write-Host "PR is not labeled 'breaking-change' and does not change the major; no further checks."
           exit 0
         }
 
         Write-Host "PR is labeled as breaking. Verifying the PR's version.json reflects a newer major than the latest stable release."
-
-        # Validate against the PR HEAD's version.json (which is the checked-out tree),
-        # not the base branch, so a PR that reverts main's version is also caught.
-        $headVersionJson = Get-Content version.json -Raw | ConvertFrom-Json
-        $headVer = $headVersionJson.version
-        if ($headVer -notmatch '^(0|[1-9]\d*)\.') {
-          Write-Error "::error file=version.json::Could not parse major version from PR head version.json: '$headVer'"
-          exit 1
-        }
-        $headMajor = [int]$matches[1]
 
         git fetch --tags --force origin
         if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot safely validate breaking-change label." }
@@ -61,15 +74,17 @@ jobs:
             Select-Object -First 1
 
         if (-not $latestStable) {
-          # Fail closed: a breaking-change PR with no known stable history is suspicious.
-          # Don't silently allow it; require the label to be removed for genuinely new repos.
-          Write-Error "::error::No stable tags found; cannot validate sequential-major rule for a breaking-change PR. Either remove the 'breaking-change' label or verify git tag history is intact."
-          exit 1
+          # No prior stable releases. Use main's current major as the floor, so a brand-new
+          # project's first breaking PR is allowed when it advances main by exactly one.
+          if ($headMajor -eq $baseMajor + 1) {
+            Write-Host "No stable tags found; PR head major ($headMajor) is exactly one greater than main ($baseMajor). OK."
+            exit 0
+          }
+          throw "No stable tags found; PR head major ($headMajor) must be exactly one greater than main's current major ($baseMajor) for a breaking-change PR with no prior stable history."
         }
 
         if ($latestStable -notmatch '^(\d+)\.') {
-          Write-Error "Could not parse latest stable tag: '$latestStable'"
-          exit 1
+          throw "Could not parse latest stable tag: '$latestStable'"
         }
         $latestMajor = [int]$matches[1]
 
@@ -78,12 +93,11 @@ jobs:
         $expectedMajor = $latestMajor + 1
         if ($headMajor -ne $expectedMajor) {
           if ($headMajor -le $latestMajor) {
-            $msg = "PR is labeled breaking-change but its version.json major ($headMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow with next_major=$expectedMajor first, then re-target this PR. After the bump PR merges, push a new commit (or close+reopen this PR) to re-run this check."
+            $msg = "PR is labeled breaking-change but its version.json major ($headMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow with next_major=$expectedMajor first, then rebase this PR onto the updated main."
           } else {
-            $msg = "PR is labeled breaking-change but its version.json major ($headMajor) skips past major $expectedMajor. Main must be at exactly one greater than the latest stable major ($latestMajor + 1 = $expectedMajor). Major versions must be incremented sequentially. Reset main to $expectedMajor.0-preview.{height} before merging this PR."
+            $msg = "PR is labeled breaking-change but its version.json major ($headMajor) skips past major $expectedMajor. Main must be at exactly latest_stable_major + 1 ($latestMajor + 1 = $expectedMajor). Reset main to $expectedMajor.0-preview.{height} before merging this PR."
           }
-          Write-Error "::error file=version.json::$msg"
-          exit 1
+          throw $msg
         }
 
         Write-Host "OK: PR head major ($headMajor) is exactly one greater than latest stable major ($latestMajor)."

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -29,23 +29,39 @@ jobs:
       run: |
         $ErrorActionPreference = 'Stop'
 
+        # The version-bump bot PRs (opened by GITHUB_TOKEN from the automation workflows)
+        # legitimately change version.json. Don't trip the manual-edit guard on them;
+        # their content is reviewed in the workflow that opened them.
+        $isBotBumpPr = ($env:PR_AUTHOR -eq 'github-actions[bot]') -and ($env:HEAD_REF -like 'bot/bump-*' -or $env:HEAD_REF -like 'bot/promote-*')
+
+        $labels = $env:LABELS_JSON | ConvertFrom-Json
+        $isBreaking = $labels -contains 'breaking-change'
+        $isManualEdit = $labels -contains 'manual-version-edit'
+
+        # Reject any human-authored PR that touches version.json unless explicitly
+        # labeled 'manual-version-edit'. version.json is owned by the automation
+        # workflows (cut-major, promote-minor, bump-major-preview); manual edits
+        # bypass the regression guards and should be a deliberate, labeled exception.
+        if (-not $isBotBumpPr) {
+          $base = "origin/$env:BASE_REF"
+          git fetch origin $env:BASE_REF --quiet
+          if ($LASTEXITCODE -ne 0) { throw "git fetch origin $env:BASE_REF failed (exit $LASTEXITCODE)." }
+          $diff = git diff --name-only "$base...HEAD"
+          if ($LASTEXITCODE -ne 0) { throw "git diff against $base failed (exit $LASTEXITCODE)." }
+          if (($diff -split "`r?`n") -contains 'version.json' -and -not $isManualEdit) {
+            throw "This PR modifies version.json but is not authored by the automation bot and is not labeled 'manual-version-edit'. version.json is managed by the workflows in .github/workflows/ (cut-major, promote-minor, bump-major-preview). To override (e.g. for the one-time cutover or a recovery operation), add the 'manual-version-edit' label."
+          }
+        }
+
         if ($env:BASE_REF -ne 'main') {
           Write-Host "PR targets '$env:BASE_REF' (not main); breaking-change check only applies to PRs targeting main. Skipping."
           exit 0
         }
 
-        # The version-bump bot PRs (opened by GITHUB_TOKEN from the automation workflows)
-        # legitimately change the major in version.json. Don't trip the unconditional
-        # major-change check on them; their content is reviewed in the workflow that
-        # opened them.
-        $isBotBumpPr = ($env:PR_AUTHOR -eq 'github-actions[bot]') -and ($env:HEAD_REF -like 'bot/bump-*')
         if ($isBotBumpPr) {
-          Write-Host "PR is an automation-authored version-bump branch ('$env:HEAD_REF'); skipping check."
+          Write-Host "PR is an automation-authored version-bump branch ('$env:HEAD_REF'); skipping breaking-change check."
           exit 0
         }
-
-        $labels = $env:LABELS_JSON | ConvertFrom-Json
-        $isBreaking = $labels -contains 'breaking-change'
 
         $headVersionJson = Get-Content version.json -Raw | ConvertFrom-Json
         $headVer = $headVersionJson.version

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -1,0 +1,71 @@
+name: PR version check
+
+on:
+  pull_request:
+    branches: [main, release/**]
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Validate version.json against PR labels and history
+      shell: pwsh
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+      run: |
+        $labels = $env:LABELS_JSON | ConvertFrom-Json
+        $isBreaking = ($labels -contains 'breaking-change') -or ($labels -contains 'semver:major')
+
+        if (-not $isBreaking) {
+          Write-Host "PR is not labeled 'breaking-change' or 'semver:major'; no major-bump check needed."
+          exit 0
+        }
+
+        Write-Host "PR is labeled as breaking. Verifying main's version.json reflects a newer major than the latest stable release."
+
+        git fetch origin $env:BASE_REF --depth=1 2>$null
+        $baseVersionJson = git show "origin/${env:BASE_REF}:version.json" | ConvertFrom-Json
+        $baseVer = $baseVersionJson.version
+        if ($baseVer -notmatch '^(\d+)\.') {
+          Write-Error "::error file=version.json::Could not parse major version from base version.json: '$baseVer'"
+          exit 1
+        }
+        $baseMajor = [int]$matches[1]
+
+        git fetch --tags --force 2>$null
+        $latestStable = git tag --list --sort=-v:refname |
+            Where-Object { $_ -match '^(\d+)\.\d+\.\d+$' } |
+            Select-Object -First 1
+
+        if (-not $latestStable) {
+          Write-Host "No stable tags found; cannot determine latest released major. Skipping check."
+          exit 0
+        }
+
+        if ($latestStable -notmatch '^(\d+)\.') {
+          Write-Error "Could not parse latest stable tag: '$latestStable'"
+          exit 1
+        }
+        $latestMajor = [int]$matches[1]
+
+        Write-Host "Latest stable major: $latestMajor; current main major: $baseMajor"
+
+        if ($baseMajor -le $latestMajor) {
+          $msg = "PR is labeled breaking-change but main's major ($baseMajor) is not greater than the latest stable release major ($latestMajor; tag '$latestStable'). Run the 'Bump main to next major preview' workflow first, then re-target this PR."
+          Write-Error "::error file=version.json::$msg"
+          exit 1
+        }
+
+        Write-Host "OK: main major ($baseMajor) > latest stable major ($latestMajor)."

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -2,7 +2,7 @@ name: PR version check
 
 on:
   pull_request:
-    branches: [main, release/**]
+    branches: [main, 'release/*.x']
     types: [opened, edited, labeled, unlabeled, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -128,6 +128,10 @@ jobs:
         $mergeExit = $LASTEXITCODE
         if ($mergeExit -ne 0) {
           $conflicts = (git diff --name-only --diff-filter=U) -split "`r?`n" | Where-Object { $_ }
+          if (-not $conflicts) {
+            git merge --abort 2>$null
+            throw "git merge failed (exit $mergeExit) with no conflicted files. Likely a transport or object error; check the runner log above."
+          }
           $unexpected = $conflicts | Where-Object { $_ -ne 'version.json' }
           if ($unexpected) {
             $list = $unexpected -join ', '
@@ -177,7 +181,9 @@ jobs:
         git fetch origin --quiet
         if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)." }
         $currentMainSha = (git rev-parse origin/main).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $currentMainSha) { throw "git rev-parse origin/main failed (exit $LASTEXITCODE)." }
         $currentBranchSha = (git rev-parse "origin/$env:TARGET_RELEASE_BRANCH").Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $currentBranchSha) { throw "git rev-parse origin/$env:TARGET_RELEASE_BRANCH failed (exit $LASTEXITCODE)." }
         if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
           throw "main moved during promotion (was $env:MAIN_HEAD_SHA, now $currentMainSha). The promotion branch was pushed but no PRs were created. Delete the promotion branch and re-run."
         }

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -16,9 +16,16 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: promote-minor-${{ inputs.target_release_branch }}-${{ inputs.stable_version }}
+  cancel-in-progress: false
+
 jobs:
   promote:
     runs-on: ubuntu-latest
+    env:
+      TARGET_RELEASE_BRANCH_INPUT: ${{ inputs.target_release_branch }}
+      STABLE_VERSION_INPUT: ${{ inputs.stable_version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -33,122 +40,177 @@ jobs:
     - name: Validate inputs and compute next preview
       shell: pwsh
       run: |
-        $branch = '${{ inputs.target_release_branch }}'
-        $version = '${{ inputs.stable_version }}'
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
 
-        if ($branch -notmatch '^release/(\d+)\.x$') {
-          throw "target_release_branch must match 'release/<major>.x' (got: '$branch')"
+        $branch = $env:TARGET_RELEASE_BRANCH_INPUT
+        $version = $env:STABLE_VERSION_INPUT
+
+        if ($branch -notmatch '^release/(0|[1-9]\d*)\.x$') {
+          throw "target_release_branch must match 'release/<major>.x' with no leading zeros (got: '$branch')"
         }
         $branchMajor = [int]$matches[1]
 
-        if ($version -notmatch '^(\d+)\.(\d+)$') {
-          throw "stable_version must be 'major.minor' (got: '$version')"
+        if ($version -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+          throw "stable_version must be 'major.minor' with no leading zeros (got: '$version')"
         }
         $versionMajor = [int]$matches[1]
         $versionMinor = [int]$matches[2]
+        $version = "$versionMajor.$versionMinor"
 
         if ($branchMajor -ne $versionMajor) {
           throw "stable_version major ($versionMajor) must match target_release_branch major ($branchMajor)"
         }
 
-        git fetch origin $branch 2>$null
-        if ($LASTEXITCODE -ne 0) { throw "Branch '$branch' does not exist on origin" }
+        $existing = git ls-remote --heads --exit-code origin "refs/heads/$branch"
+        $lsExit = $LASTEXITCODE
+        if ($lsExit -eq 2) {
+          throw "Branch '$branch' does not exist on origin"
+        }
+        if ($lsExit -ne 0) {
+          throw "git ls-remote failed (exit $lsExit); cannot verify branch state."
+        }
 
         $branchVersionJson = git show "origin/${branch}:version.json" | ConvertFrom-Json
         $branchVer = $branchVersionJson.version
-        if ($branchVer -notmatch '^(\d+)\.(\d+)') {
-          throw "Could not parse current version on '$branch': '$branchVer'"
+        if ($branchVer -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+          throw "version.json on '$branch' is '$branchVer', which is not a clean stable '<major>.<minor>' value. Refusing to promote on top of a non-stable release branch."
         }
         $branchCurrentMinor = [int]$matches[2]
         if ($versionMinor -le $branchCurrentMinor) {
           throw "stable_version ($version) must be greater than current version on '$branch' ($branchVer)"
         }
 
-        $mainVersionJson = git show "origin/main:version.json" | ConvertFrom-Json
+        $mainHeadSha = (git rev-parse origin/main).Trim()
+        $mainVersionJson = git show "${mainHeadSha}:version.json" | ConvertFrom-Json
         $mainVer = $mainVersionJson.version
-        if ($mainVer -notmatch '^(\d+)\.(\d+)-preview') {
+        if ($mainVer -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)-preview') {
           throw "main's version.json must be in '<major>.<minor>-preview.{height}' form (got: '$mainVer')"
         }
         $mainMajor = [int]$matches[1]
         $mainMinor = [int]$matches[2]
 
         if ($versionMajor -ne $mainMajor -or $versionMinor -ne $mainMinor) {
-          throw "stable_version ($version) must match main's current preview ($mainMajor.$mainMinor-preview.{height}). Promoting any other version would mislabel main's code as the wrong stable release. To ship a different version, run 'Bump main to next major preview' first or wait for main to be at the version you want to promote."
+          throw "stable_version ($version) must match main's current preview ($mainMajor.$mainMinor-preview.{height}). Promoting any other version would mislabel main's code as the wrong stable release."
         }
 
         $nextMain = "$mainMajor.$($mainMinor + 1)-preview.{height}"
+        $runId = $env:GITHUB_RUN_ID
 
         Add-Content -Path $env:GITHUB_ENV -Value "TARGET_RELEASE_BRANCH=$branch"
         Add-Content -Path $env:GITHUB_ENV -Value "STABLE_VERSION=$version"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_PREVIEW=$nextMain"
-        Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_BRANCH=bot/promote-$version"
-        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$version"
+        Add-Content -Path $env:GITHUB_ENV -Value "MAIN_HEAD_SHA=$mainHeadSha"
+        Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_BRANCH=bot/promote-$version-$runId"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$version-$runId"
 
     - name: Create promotion branch (merges main into release branch)
+      shell: pwsh
       run: |
-        git checkout "$TARGET_RELEASE_BRANCH"
-        git checkout -b "$PROMOTE_BRANCH"
-        git merge origin/main --no-edit
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git checkout "$env:TARGET_RELEASE_BRANCH"
+        git checkout -b "$env:PROMOTE_BRANCH"
+        # -X theirs: prefer main's content on conflict. The next step overwrites version.json
+        # to the stable value regardless, so version.json conflicts are mooted either way.
+        # We invoke through cmd to avoid PowerShell halting on git's non-zero exit when
+        # the merge succeeds with the chosen strategy.
+        git merge -X theirs origin/main --no-edit
+        if ($LASTEXITCODE -ne 0) {
+          throw "git merge of origin/main into $env:PROMOTE_BRANCH failed (exit $LASTEXITCODE). Resolve manually and re-run."
+        }
 
     - name: Set stable version on promotion branch
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*\r?\n', '')
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
 
     - name: Commit and push promotion branch
+      shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
-        git commit -m "Set version to $STABLE_VERSION (stable)"
-        git push -u origin "$PROMOTE_BRANCH"
+        git commit -m "Set version to $env:STABLE_VERSION (stable)"
+        git push --force-with-lease -u origin "$env:PROMOTE_BRANCH"
 
     - name: Open promotion PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         $body = @"
         Promotes ``main`` into ``$env:TARGET_RELEASE_BRANCH`` and sets ``version.json`` to ``$env:STABLE_VERSION`` stable.
 
+        > This PR is NOT mechanical: it contains the full diff of ``main`` since the last promotion. Review accordingly. Because it is bot-authored, GitHub does not run CI on it by default; close and reopen the PR to trigger CI.
+
         Merge this PR **first**, then merge the companion PR that bumps ``main`` to ``$env:NEXT_PREVIEW``.
         "@
-        $url = gh pr create `
+        $url = (gh pr create `
           --base "$env:TARGET_RELEASE_BRANCH" `
           --head "$env:PROMOTE_BRANCH" `
-          --title "Promote main to $env:STABLE_VERSION.0 stable" `
-          --body $body
+          --title "Promote main to $env:STABLE_VERSION stable" `
+          --body $body | Select-Object -Last 1).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
+          throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
+        }
         Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_PR_URL=$url"
 
-    - name: Create main bump branch
+    - name: Verify main hasn't moved since validation
+      shell: pwsh
       run: |
-        git fetch origin main
-        git checkout main
-        git pull --ff-only origin main
-        git checkout -b "$BUMP_BRANCH"
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git fetch origin main --quiet
+        $currentMainSha = (git rev-parse origin/main).Trim()
+        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
+          throw "main moved during promotion run (was $env:MAIN_HEAD_SHA, now $currentMainSha). The promotion PR has been opened against the validated SHA, but the bump-main PR was NOT created because the computed NEXT_PREVIEW may now be stale. Re-run the workflow after merging the promotion PR."
+        }
+        Write-Host "OK: main is still at $env:MAIN_HEAD_SHA."
+
+    - name: Create main bump branch (from validated main SHA)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        git checkout "$env:MAIN_HEAD_SHA"
+        git checkout -b "$env:BUMP_BRANCH"
 
     - name: Bump main to next preview
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
-        [System.IO.File]::WriteAllText($path, $new)
+        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
+        [System.IO.File]::WriteAllText($path, $content)
 
     - name: Commit and push main bump branch
+      shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
-        git commit -m "Bump main to $NEXT_PREVIEW after $STABLE_VERSION promotion"
-        git push -u origin "$BUMP_BRANCH"
+        git commit -m "Bump main to $env:NEXT_PREVIEW after $env:STABLE_VERSION promotion"
+        git push --force-with-lease -u origin "$env:BUMP_BRANCH"
 
     - name: Open main bump PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         $body = @"
         Companion PR to the ``$env:STABLE_VERSION`` promotion.
 
@@ -156,11 +218,14 @@ jobs:
 
         Merge this PR **after** the promotion PR: $env:PROMOTE_PR_URL
         "@
-        $url = gh pr create `
+        $url = (gh pr create `
           --base main `
           --head "$env:BUMP_BRANCH" `
           --title "Bump main to $env:NEXT_PREVIEW after $env:STABLE_VERSION promotion" `
-          --body $body
+          --body $body | Select-Object -Last 1).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
+          throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
+        }
         Add-Content -Path $env:GITHUB_ENV -Value "BUMP_PR_URL=$url"
 
     - name: Summary
@@ -171,7 +236,7 @@ jobs:
 
         | Order | PR | Purpose |
         | :-: | --- | --- |
-        | 1 | $env:PROMOTE_PR_URL | Merge first. Promotes main to ``$env:STABLE_VERSION``.0 stable on ``$env:TARGET_RELEASE_BRANCH``. |
+        | 1 | $env:PROMOTE_PR_URL | Merge first. Promotes main to ``$env:STABLE_VERSION`` stable on ``$env:TARGET_RELEASE_BRANCH``. First published patch is ``$env:STABLE_VERSION.1``. |
         | 2 | $env:BUMP_PR_URL | Merge second. Bumps main to ``$env:NEXT_PREVIEW``. |
         "@
         Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -155,12 +155,16 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
+        if ($content -match '"versionHeightOffset"') {
+          $content = [regex]::Replace($content, '"versionHeightOffset"\s*:\s*-?\d+', '"versionHeightOffset": -1')
+        } else {
+          $content = [regex]::Replace($content, '(?m)^(\s*)"version":\s*"[^"]+"\s*,?', "`$0`r`n`$1`"versionHeightOffset`": -1,", 1)
+        }
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
         $obj = $content | ConvertFrom-Json
-        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
-          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        if ($obj.versionHeightOffset -ne -1) {
+          throw "Failed to set versionHeightOffset to -1 (got: $($obj.versionHeightOffset)). Manual edit required."
         }
 
     - name: Commit and push promotion branch

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -72,6 +72,10 @@ jobs:
         $mainMajor = [int]$matches[1]
         $mainMinor = [int]$matches[2]
 
+        if ($versionMajor -ne $mainMajor -or $versionMinor -ne $mainMinor) {
+          throw "stable_version ($version) must match main's current preview ($mainMajor.$mainMinor-preview.{height}). Promoting any other version would mislabel main's code as the wrong stable release. To ship a different version, run 'Bump main to next major preview' first or wait for main to be at the version you want to promote."
+        }
+
         $nextMain = "$mainMajor.$($mainMinor + 1)-preview.{height}"
 
         Add-Content -Path $env:GITHUB_ENV -Value "TARGET_RELEASE_BRANCH=$branch"
@@ -91,8 +95,10 @@ jobs:
       run: |
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        [System.IO.File]::WriteAllText($path, $new)
+        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*\r?\n', '')
+        $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
+        [System.IO.File]::WriteAllText($path, $content)
 
     - name: Commit and push promotion branch
       run: |

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -1,0 +1,171 @@
+name: Promote main to stable minor
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_release_branch:
+        description: 'Existing release branch to promote into (e.g., release/9.x)'
+        required: true
+        type: string
+      stable_version:
+        description: 'Stable version to ship as major.minor (e.g., 9.5)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Configure git
+      run: |
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+
+    - name: Validate inputs and compute next preview
+      shell: pwsh
+      run: |
+        $branch = '${{ inputs.target_release_branch }}'
+        $version = '${{ inputs.stable_version }}'
+
+        if ($branch -notmatch '^release/(\d+)\.x$') {
+          throw "target_release_branch must match 'release/<major>.x' (got: '$branch')"
+        }
+        $branchMajor = [int]$matches[1]
+
+        if ($version -notmatch '^(\d+)\.(\d+)$') {
+          throw "stable_version must be 'major.minor' (got: '$version')"
+        }
+        $versionMajor = [int]$matches[1]
+        $versionMinor = [int]$matches[2]
+
+        if ($branchMajor -ne $versionMajor) {
+          throw "stable_version major ($versionMajor) must match target_release_branch major ($branchMajor)"
+        }
+
+        git fetch origin $branch 2>$null
+        if ($LASTEXITCODE -ne 0) { throw "Branch '$branch' does not exist on origin" }
+
+        $branchVersionJson = git show "origin/${branch}:version.json" | ConvertFrom-Json
+        $branchVer = $branchVersionJson.version
+        if ($branchVer -notmatch '^(\d+)\.(\d+)') {
+          throw "Could not parse current version on '$branch': '$branchVer'"
+        }
+        $branchCurrentMinor = [int]$matches[2]
+        if ($versionMinor -le $branchCurrentMinor) {
+          throw "stable_version ($version) must be greater than current version on '$branch' ($branchVer)"
+        }
+
+        $mainVersionJson = git show "origin/main:version.json" | ConvertFrom-Json
+        $mainVer = $mainVersionJson.version
+        if ($mainVer -notmatch '^(\d+)\.(\d+)-preview') {
+          throw "main's version.json must be in '<major>.<minor>-preview.{height}' form (got: '$mainVer')"
+        }
+        $mainMajor = [int]$matches[1]
+        $mainMinor = [int]$matches[2]
+
+        $nextMain = "$mainMajor.$($mainMinor + 1)-preview.{height}"
+
+        Add-Content -Path $env:GITHUB_ENV -Value "TARGET_RELEASE_BRANCH=$branch"
+        Add-Content -Path $env:GITHUB_ENV -Value "STABLE_VERSION=$version"
+        Add-Content -Path $env:GITHUB_ENV -Value "NEXT_PREVIEW=$nextMain"
+        Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_BRANCH=bot/promote-$version"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$version"
+
+    - name: Create promotion branch (merges main into release branch)
+      run: |
+        git checkout "$TARGET_RELEASE_BRANCH"
+        git checkout -b "$PROMOTE_BRANCH"
+        git merge origin/main --no-edit
+
+    - name: Set stable version on promotion branch
+      shell: pwsh
+      run: |
+        $path = 'version.json'
+        $content = [System.IO.File]::ReadAllText($path)
+        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
+        [System.IO.File]::WriteAllText($path, $new)
+
+    - name: Commit and push promotion branch
+      run: |
+        git add version.json
+        git commit -m "Set version to $STABLE_VERSION (stable)"
+        git push -u origin "$PROMOTE_BRANCH"
+
+    - name: Open promotion PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: pwsh
+      run: |
+        $body = @"
+        Promotes ``main`` into ``$env:TARGET_RELEASE_BRANCH`` and sets ``version.json`` to ``$env:STABLE_VERSION`` stable.
+
+        Merge this PR **first**, then merge the companion PR that bumps ``main`` to ``$env:NEXT_PREVIEW``.
+        "@
+        $url = gh pr create `
+          --base "$env:TARGET_RELEASE_BRANCH" `
+          --head "$env:PROMOTE_BRANCH" `
+          --title "Promote main to $env:STABLE_VERSION.0 stable" `
+          --body $body
+        Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_PR_URL=$url"
+
+    - name: Create main bump branch
+      run: |
+        git fetch origin main
+        git checkout main
+        git pull --ff-only origin main
+        git checkout -b "$BUMP_BRANCH"
+
+    - name: Bump main to next preview
+      shell: pwsh
+      run: |
+        $path = 'version.json'
+        $content = [System.IO.File]::ReadAllText($path)
+        $new = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
+        [System.IO.File]::WriteAllText($path, $new)
+
+    - name: Commit and push main bump branch
+      run: |
+        git add version.json
+        git commit -m "Bump main to $NEXT_PREVIEW after $STABLE_VERSION promotion"
+        git push -u origin "$BUMP_BRANCH"
+
+    - name: Open main bump PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: pwsh
+      run: |
+        $body = @"
+        Companion PR to the ``$env:STABLE_VERSION`` promotion.
+
+        Bumps ``main`` to ``$env:NEXT_PREVIEW`` so subsequent PRs publish the next preview line.
+
+        Merge this PR **after** the promotion PR: $env:PROMOTE_PR_URL
+        "@
+        $url = gh pr create `
+          --base main `
+          --head "$env:BUMP_BRANCH" `
+          --title "Bump main to $env:NEXT_PREVIEW after $env:STABLE_VERSION promotion" `
+          --body $body
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_PR_URL=$url"
+
+    - name: Summary
+      shell: pwsh
+      run: |
+        $summary = @"
+        ## Promotion PRs created
+
+        | Order | PR | Purpose |
+        | :-: | --- | --- |
+        | 1 | $env:PROMOTE_PR_URL | Merge first. Promotes main to ``$env:STABLE_VERSION``.0 stable on ``$env:TARGET_RELEASE_BRANCH``. |
+        | 2 | $env:BUMP_PR_URL | Merge second. Bumps main to ``$env:NEXT_PREVIEW``. |
+        "@
+        Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: promote-minor-${{ inputs.target_release_branch }}-${{ inputs.stable_version }}
+  group: main-version-mutator
   cancel-in-progress: false
 
 jobs:
@@ -41,7 +41,6 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
 
         $branch = $env:TARGET_RELEASE_BRANCH_INPUT
         $version = $env:STABLE_VERSION_INPUT
@@ -62,16 +61,19 @@ jobs:
           throw "stable_version major ($versionMajor) must match target_release_branch major ($branchMajor)"
         }
 
-        $existing = git ls-remote --heads --exit-code origin "refs/heads/$branch"
-        $lsExit = $LASTEXITCODE
-        if ($lsExit -eq 2) {
-          throw "Branch '$branch' does not exist on origin"
-        }
-        if ($lsExit -ne 0) {
-          throw "git ls-remote failed (exit $lsExit); cannot verify branch state."
-        }
+        # Fetch latest refs explicitly so we don't rely on checkout-time state.
+        git fetch origin --quiet
+        if ($LASTEXITCODE -ne 0) { throw "git fetch origin failed (exit $LASTEXITCODE); cannot proceed." }
 
-        $branchVersionJson = git show "origin/${branch}:version.json" | ConvertFrom-Json
+        $existing = git ls-remote --heads origin "refs/heads/$branch"
+        if ($LASTEXITCODE -ne 0) { throw "git ls-remote failed (exit $LASTEXITCODE); cannot verify branch state." }
+        if (-not $existing) { throw "Branch '$branch' does not exist on origin." }
+
+        $branchHeadSha = (git rev-parse "origin/$branch").Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $branchHeadSha) { throw "git rev-parse origin/$branch failed (exit $LASTEXITCODE)." }
+
+        $branchVersionJson = git show "${branchHeadSha}:version.json" | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0) { throw "Failed to read version.json from origin/$branch." }
         $branchVer = $branchVersionJson.version
         if ($branchVer -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
           throw "version.json on '$branch' is '$branchVer', which is not a clean stable '<major>.<minor>' value. Refusing to promote on top of a non-stable release branch."
@@ -82,7 +84,10 @@ jobs:
         }
 
         $mainHeadSha = (git rev-parse origin/main).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $mainHeadSha) { throw "git rev-parse origin/main failed (exit $LASTEXITCODE)." }
+
         $mainVersionJson = git show "${mainHeadSha}:version.json" | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0) { throw "Failed to read version.json from origin/main." }
         $mainVer = $mainVersionJson.version
         if ($mainVer -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)-preview') {
           throw "main's version.json must be in '<major>.<minor>-preview.{height}' form (got: '$mainVer')"
@@ -96,29 +101,48 @@ jobs:
 
         $nextMain = "$mainMajor.$($mainMinor + 1)-preview.{height}"
         $runId = $env:GITHUB_RUN_ID
+        $runAttempt = $env:GITHUB_RUN_ATTEMPT
 
         Add-Content -Path $env:GITHUB_ENV -Value "TARGET_RELEASE_BRANCH=$branch"
         Add-Content -Path $env:GITHUB_ENV -Value "STABLE_VERSION=$version"
         Add-Content -Path $env:GITHUB_ENV -Value "NEXT_PREVIEW=$nextMain"
         Add-Content -Path $env:GITHUB_ENV -Value "MAIN_HEAD_SHA=$mainHeadSha"
-        Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_BRANCH=bot/promote-$version-$runId"
-        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$version-$runId"
+        Add-Content -Path $env:GITHUB_ENV -Value "BRANCH_HEAD_SHA=$branchHeadSha"
+        Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_BRANCH=bot/promote-$version-$runId-$runAttempt"
+        Add-Content -Path $env:GITHUB_ENV -Value "BUMP_BRANCH=bot/bump-main-after-$version-$runId-$runAttempt"
 
     - name: Create promotion branch (merges main into release branch)
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
-        git checkout "$env:TARGET_RELEASE_BRANCH"
+        git checkout "$env:BRANCH_HEAD_SHA"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout of release branch SHA failed (exit $LASTEXITCODE)." }
         git checkout -b "$env:PROMOTE_BRANCH"
-        # -X theirs: prefer main's content on conflict. The next step overwrites version.json
-        # to the stable value regardless, so version.json conflicts are mooted either way.
-        # We invoke through cmd to avoid PowerShell halting on git's non-zero exit when
-        # the merge succeeds with the chosen strategy.
-        git merge -X theirs origin/main --no-edit
-        if ($LASTEXITCODE -ne 0) {
-          throw "git merge of origin/main into $env:PROMOTE_BRANCH failed (exit $LASTEXITCODE). Resolve manually and re-run."
+        if ($LASTEXITCODE -ne 0) { throw "git checkout -b failed (exit $LASTEXITCODE)." }
+
+        # Plain merge first, so any unexpected conflict is surfaced loudly.
+        # The known-conflict case is version.json (both sides edit it). Resolve only that
+        # one path automatically; abort on anything else so a forgotten hotfix on the
+        # release branch is never silently overwritten by main.
+        git merge --no-commit --no-ff "$env:MAIN_HEAD_SHA"
+        $mergeExit = $LASTEXITCODE
+        if ($mergeExit -ne 0) {
+          $conflicts = (git diff --name-only --diff-filter=U) -split "`r?`n" | Where-Object { $_ }
+          $unexpected = $conflicts | Where-Object { $_ -ne 'version.json' }
+          if ($unexpected) {
+            $list = $unexpected -join ', '
+            git merge --abort 2>$null
+            throw "Merge of main into $env:TARGET_RELEASE_BRANCH produced conflicts in non-version.json files: $list. This usually means a release-branch-only change conflicts with main; resolve manually."
+          }
+          # Only version.json conflicted. The next step overwrites it anyway, so take main's
+          # side here to keep the merge moving (the stable version is written immediately after).
+          git checkout --theirs version.json
+          if ($LASTEXITCODE -ne 0) { throw "git checkout --theirs version.json failed (exit $LASTEXITCODE)." }
+          git add version.json
+          if ($LASTEXITCODE -ne 0) { throw "git add version.json failed (exit $LASTEXITCODE)." }
         }
+        git commit --no-edit -m "Merge main into $env:TARGET_RELEASE_BRANCH for $env:STABLE_VERSION promotion"
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed after merge (exit $LASTEXITCODE)." }
 
     - name: Set stable version on promotion branch
       shell: pwsh
@@ -127,18 +151,40 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
+        $obj = $content | ConvertFrom-Json
+        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
+          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        }
 
     - name: Commit and push promotion branch
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
+        if ($LASTEXITCODE -ne 0) { throw "git add failed (exit $LASTEXITCODE)." }
         git commit -m "Set version to $env:STABLE_VERSION (stable)"
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)." }
         git push --force-with-lease -u origin "$env:PROMOTE_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git push failed (exit $LASTEXITCODE)." }
+
+    - name: Verify branch and main still at validated SHAs
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        git fetch origin --quiet
+        if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)." }
+        $currentMainSha = (git rev-parse origin/main).Trim()
+        $currentBranchSha = (git rev-parse "origin/$env:TARGET_RELEASE_BRANCH").Trim()
+        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
+          throw "main moved during promotion (was $env:MAIN_HEAD_SHA, now $currentMainSha). The promotion branch was pushed but no PRs were created. Delete the promotion branch and re-run."
+        }
+        if ($currentBranchSha -ne $env:BRANCH_HEAD_SHA) {
+          throw "$env:TARGET_RELEASE_BRANCH moved during promotion (was $env:BRANCH_HEAD_SHA, now $currentBranchSha). The promotion branch was pushed but no PRs were created. Delete the promotion branch and re-run."
+        }
+        Write-Host "OK: refs are stable."
 
     - name: Open promotion PR
       env:
@@ -146,7 +192,6 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         $body = @"
         Promotes ``main`` into ``$env:TARGET_RELEASE_BRANCH`` and sets ``version.json`` to ``$env:STABLE_VERSION`` stable.
 
@@ -154,35 +199,28 @@ jobs:
 
         Merge this PR **first**, then merge the companion PR that bumps ``main`` to ``$env:NEXT_PREVIEW``.
         "@
-        $url = (gh pr create `
-          --base "$env:TARGET_RELEASE_BRANCH" `
-          --head "$env:PROMOTE_BRANCH" `
-          --title "Promote main to $env:STABLE_VERSION stable" `
-          --body $body | Select-Object -Last 1).Trim()
+        try {
+          $url = (gh pr create `
+            --base "$env:TARGET_RELEASE_BRANCH" `
+            --head "$env:PROMOTE_BRANCH" `
+            --title "Promote main to $env:STABLE_VERSION stable" `
+            --body $body | Select-Object -Last 1).Trim()
+        } catch {
+          throw "gh pr create failed: $($_.Exception.Message)"
+        }
         if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
           throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
         }
         Add-Content -Path $env:GITHUB_ENV -Value "PROMOTE_PR_URL=$url"
 
-    - name: Verify main hasn't moved since validation
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
-        git fetch origin main --quiet
-        $currentMainSha = (git rev-parse origin/main).Trim()
-        if ($currentMainSha -ne $env:MAIN_HEAD_SHA) {
-          throw "main moved during promotion run (was $env:MAIN_HEAD_SHA, now $currentMainSha). The promotion PR has been opened against the validated SHA, but the bump-main PR was NOT created because the computed NEXT_PREVIEW may now be stale. Re-run the workflow after merging the promotion PR."
-        }
-        Write-Host "OK: main is still at $env:MAIN_HEAD_SHA."
-
     - name: Create main bump branch (from validated main SHA)
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git checkout "$env:MAIN_HEAD_SHA"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout failed (exit $LASTEXITCODE)." }
         git checkout -b "$env:BUMP_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git checkout -b failed (exit $LASTEXITCODE)." }
 
     - name: Bump main to next preview
       shell: pwsh
@@ -191,18 +229,24 @@ jobs:
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
         $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:NEXT_PREVIEW`"")
-        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(\r?\n|$)', '')
+        $content = [regex]::Replace($content, '(?m)^\s*"versionHeightOffset"\s*:\s*-?\d+\s*,?\s*(//[^\r\n]*)?\s*(\r?\n|$)', '')
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)
+        $obj = $content | ConvertFrom-Json
+        if ($obj.PSObject.Properties.Name -contains 'versionHeightOffset') {
+          throw "Failed to strip versionHeightOffset from version.json. Manual edit required."
+        }
 
     - name: Commit and push main bump branch
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         git add version.json
+        if ($LASTEXITCODE -ne 0) { throw "git add failed (exit $LASTEXITCODE)." }
         git commit -m "Bump main to $env:NEXT_PREVIEW after $env:STABLE_VERSION promotion"
+        if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)." }
         git push --force-with-lease -u origin "$env:BUMP_BRANCH"
+        if ($LASTEXITCODE -ne 0) { throw "git push failed (exit $LASTEXITCODE)." }
 
     - name: Open main bump PR
       env:
@@ -210,7 +254,6 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
         $body = @"
         Companion PR to the ``$env:STABLE_VERSION`` promotion.
 
@@ -218,11 +261,15 @@ jobs:
 
         Merge this PR **after** the promotion PR: $env:PROMOTE_PR_URL
         "@
-        $url = (gh pr create `
-          --base main `
-          --head "$env:BUMP_BRANCH" `
-          --title "Bump main to $env:NEXT_PREVIEW after $env:STABLE_VERSION promotion" `
-          --body $body | Select-Object -Last 1).Trim()
+        try {
+          $url = (gh pr create `
+            --base main `
+            --head "$env:BUMP_BRANCH" `
+            --title "Bump main to $env:NEXT_PREVIEW after $env:STABLE_VERSION promotion" `
+            --body $body | Select-Object -Last 1).Trim()
+        } catch {
+          throw "gh pr create failed: $($_.Exception.Message)"
+        }
         if ($LASTEXITCODE -ne 0 -or -not $url -or $url -notmatch '^https?://') {
           throw "gh pr create did not return a valid URL (exit $LASTEXITCODE; got: '$url')"
         }
@@ -238,5 +285,7 @@ jobs:
         | :-: | --- | --- |
         | 1 | $env:PROMOTE_PR_URL | Merge first. Promotes main to ``$env:STABLE_VERSION`` stable on ``$env:TARGET_RELEASE_BRANCH``. First published patch is ``$env:STABLE_VERSION.1``. |
         | 2 | $env:BUMP_PR_URL | Merge second. Bumps main to ``$env:NEXT_PREVIEW``. |
+
+        > Merge the bump PR (row 2) AS SOON AS the promotion PR (row 1) merges. Otherwise, the next push to main will fail the prerelease-regression guard because a stable ``$env:STABLE_VERSION.*`` tag now exists.
         "@
         Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/.github/workflows/promote-minor.yml
+++ b/.github/workflows/promote-minor.yml
@@ -154,11 +154,11 @@ jobs:
         $ErrorActionPreference = 'Stop'
         $path = 'version.json'
         $content = [System.IO.File]::ReadAllText($path)
-        $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
         if ($content -match '"versionHeightOffset"') {
           $content = [regex]::Replace($content, '"versionHeightOffset"\s*:\s*-?\d+', '"versionHeightOffset": -1')
+          $content = [regex]::Replace($content, '"version":\s*"[^"]+"', "`"version`": `"$env:STABLE_VERSION`"")
         } else {
-          $content = [regex]::Replace($content, '(?m)^(\s*)"version":\s*"[^"]+"\s*,?', "`$0`r`n`$1`"versionHeightOffset`": -1,", 1)
+          $content = [regex]::Replace($content, '(?m)^(\s*)"version":\s*"[^"]+"\s*,?', "`$1`"version`": `"$env:STABLE_VERSION`",`r`n`$1`"versionHeightOffset`": -1,", 1)
         }
         $content = [regex]::Replace($content, ',(\s*[}\]])', '$1')
         [System.IO.File]::WriteAllText($path, $content)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,15 @@ on:
 
 env:
   configuration: Release
-  productNamespacePrefix: "ReactiveMarbles"
+  productNamespacePrefix: "DynamicData"
 
 jobs:
   release:
     runs-on: windows-latest
     environment:
       name: release
+    permissions:
+      contents: write
     outputs:
       nbgv: ${{ steps.nbgv.outputs.SemVer2 }}
     steps:
@@ -83,12 +85,10 @@ jobs:
       id: changelog
 
     - name: Create Release
-      uses: actions/create-release@v1.1.4
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      uses: softprops/action-gh-release@v2
       with:
           tag_name: ${{ steps.nbgv.outputs.SemVer2 }}
-          release_name: ${{ steps.nbgv.outputs.SemVer2 }}
+          name: ${{ steps.nbgv.outputs.SemVer2 }}
           prerelease: ${{ steps.nbgv.outputs.PrereleaseVersion != '' }}
           body: |
             ${{ steps.changelog.outputs.commitLog }}
@@ -98,4 +98,4 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
         SOURCE_URL: https://api.nuget.org/v3/index.json
       run: |
-        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} **/*.nupkg
+        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} --skip-duplicate **/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,14 @@ name: Build and Release
 on:
   push:
     branches: [ main, 'release/*.x' ]
+  workflow_dispatch:
 
 env:
   configuration: Release
-  productNamespacePrefix: "DynamicData"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -29,7 +33,8 @@ jobs:
       env:
         REF_NAME: ${{ github.ref_name }}
       run: |
-        if ($env:REF_NAME -ne 'main' -and $env:REF_NAME -notmatch '^release/\d+\.x$') {
+        $ErrorActionPreference = 'Stop'
+        if ($env:REF_NAME -ne 'main' -and $env:REF_NAME -notmatch '^release/(0|[1-9]\d*)\.x$') {
           throw "release.yml triggered on '$env:REF_NAME' which is neither 'main' nor 'release/<major>.x'. Refusing to publish."
         }
         Write-Host "OK: publishing from '$env:REF_NAME'."
@@ -53,7 +58,7 @@ jobs:
 
     - name: NBGV
       id: nbgv
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@v0.5.1
       with:
         setAllVars: true
 
@@ -62,7 +67,15 @@ jobs:
       env:
         SEMVER2: ${{ steps.nbgv.outputs.SemVer2 }}
         PRERELEASE: ${{ steps.nbgv.outputs.PrereleaseVersion }}
+        REF_NAME: ${{ github.ref_name }}
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
+        if ($env:PRERELEASE -and $env:REF_NAME -match '^release/(0|[1-9]\d*)\.x$') {
+          throw "Refusing to publish prerelease '$env:SEMVER2' from a release branch ('$env:REF_NAME'). Release branches must only publish stable versions."
+        }
+
         if (-not $env:PRERELEASE) {
           Write-Host "Stable release ($env:SEMVER2); skipping prerelease regression check."
           exit 0
@@ -72,8 +85,12 @@ jobs:
         }
         $major = $matches[1]
         $minor = $matches[2]
-        git fetch --tags --force 2>$null
-        $stableTags = git tag --list "$major.$minor.*" | Where-Object { $_ -match "^$major\.$minor\.\d+$" }
+        git fetch --tags --force origin
+        if ($LASTEXITCODE -ne 0) { throw "git fetch --tags failed (exit $LASTEXITCODE); cannot validate prerelease regression." }
+
+        $majorEsc = [regex]::Escape($major)
+        $minorEsc = [regex]::Escape($minor)
+        $stableTags = git tag --list "$major.$minor.*" | Where-Object { $_ -match "^${majorEsc}\.${minorEsc}\.\d+$" }
         if ($stableTags) {
           $list = $stableTags -join ', '
           $msg = "Stable for $major.$minor has already shipped (tags: $list); cannot publish prerelease '$env:SEMVER2'. Bump main's version.json to the next minor or major preview line."
@@ -86,26 +103,26 @@ jobs:
       run: dotnet restore DynamicData.sln
       working-directory: src
       
-    - name: Build
+    - name: Pack
       run: dotnet pack --no-restore --configuration Release DynamicData.sln
       working-directory: src
+
+    - name: NuGet Push
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+        SOURCE_URL: https://api.nuget.org/v3/index.json
+      run: |
+        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} --skip-duplicate src/**/bin/Release/*.nupkg
 
     - name: Changelog
       uses: glennawatson/ChangeLog@v1
       id: changelog
 
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2.6.2
       with:
           tag_name: ${{ steps.nbgv.outputs.SemVer2 }}
           name: ${{ steps.nbgv.outputs.SemVer2 }}
           prerelease: ${{ steps.nbgv.outputs.PrereleaseVersion != '' }}
           body: |
             ${{ steps.changelog.outputs.commitLog }}
-            
-    - name: NuGet Push
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
-        SOURCE_URL: https://api.nuget.org/v3/index.json
-      run: |
-        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} --skip-duplicate **/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         setAllVars: true
 
-    - name: Verify prerelease does not regress past stable
+    - name: Verify version matches branch policy
       shell: pwsh
       env:
         SEMVER2: ${{ steps.nbgv.outputs.SemVer2 }}
@@ -70,7 +70,10 @@ jobs:
         REF_NAME: ${{ github.ref_name }}
       run: |
         $ErrorActionPreference = 'Stop'
-        $PSNativeCommandUseErrorActionPreference = $true
+
+        if ($env:REF_NAME -eq 'main' -and -not $env:PRERELEASE) {
+          throw "Refusing to publish stable '$env:SEMVER2' from main. main must always publish prereleases. Check version.json for an accidental switch to a non-prerelease form."
+        }
 
         if ($env:PRERELEASE -and $env:REF_NAME -match '^release/(0|[1-9]\d*)\.x$') {
           throw "Refusing to publish prerelease '$env:SEMVER2' from a release branch ('$env:REF_NAME'). Release branches must only publish stable versions."
@@ -80,7 +83,7 @@ jobs:
           Write-Host "Stable release ($env:SEMVER2); skipping prerelease regression check."
           exit 0
         }
-        if ($env:SEMVER2 -notmatch '^(\d+)\.(\d+)\.\d+-') {
+        if ($env:SEMVER2 -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-') {
           throw "Could not parse SemVer2 '$env:SEMVER2'"
         }
         $major = $matches[1]
@@ -93,29 +96,38 @@ jobs:
         $stableTags = git tag --list "$major.$minor.*" | Where-Object { $_ -match "^${majorEsc}\.${minorEsc}\.\d+$" }
         if ($stableTags) {
           $list = $stableTags -join ', '
-          $msg = "Stable for $major.$minor has already shipped (tags: $list); cannot publish prerelease '$env:SEMVER2'. Bump main's version.json to the next minor or major preview line."
-          Write-Error "::error::$msg"
-          exit 1
+          throw "Stable for $major.$minor has already shipped (tags: $list); cannot publish prerelease '$env:SEMVER2'. Bump main's version.json to the next minor or major preview line."
         }
         Write-Host "OK: no stable $major.$minor.* tag exists; '$env:SEMVER2' is safe to publish."
 
     - name: NuGet Restore
       run: dotnet restore DynamicData.sln
       working-directory: src
-      
+
+    - name: Run Tests
+      run: dotnet test --no-restore --configuration Release DynamicData.sln
+      working-directory: src
+
     - name: Pack
-      run: dotnet pack --no-restore --configuration Release DynamicData.sln
+      run: dotnet pack --no-restore --no-build --configuration Release DynamicData.sln
       working-directory: src
 
     - name: NuGet Push
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
         SOURCE_URL: https://api.nuget.org/v3/index.json
+      shell: pwsh
       run: |
-        dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} --skip-duplicate src/**/bin/Release/*.nupkg
+        $ErrorActionPreference = 'Stop'
+        $packages = Get-ChildItem -Path src -Recurse -Filter '*.nupkg' | Where-Object { $_.FullName -like '*\bin\Release\*' }
+        if (-not $packages) { throw "No .nupkg files found under src/**/bin/Release/." }
+        foreach ($pkg in $packages) {
+          dotnet nuget push -s $env:SOURCE_URL -k $env:NUGET_AUTH_TOKEN --skip-duplicate $pkg.FullName
+          if ($LASTEXITCODE -ne 0) { throw "dotnet nuget push failed for $($pkg.Name) (exit $LASTEXITCODE)." }
+        }
 
     - name: Changelog
-      uses: glennawatson/ChangeLog@v1
+      uses: glennawatson/ChangeLog@0464dd89b26f61fecf24b41d675f8ffdb11c4c3f # v1
       id: changelog
 
     - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build and Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/** ]
 
 env:
   configuration: Release
@@ -64,6 +64,7 @@ jobs:
       with:
           tag_name: ${{ steps.nbgv.outputs.SemVer2 }}
           release_name: ${{ steps.nbgv.outputs.SemVer2 }}
+          prerelease: ${{ steps.nbgv.outputs.PrereleaseVersion != '' }}
           body: |
             ${{ steps.changelog.outputs.commitLog }}
             

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build and Release
 
 on:
   push:
-    branches: [ main, release/** ]
+    branches: [ main, 'release/*.x' ]
 
 env:
   configuration: Release
@@ -23,6 +23,16 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+
+    - name: Validate publish branch
+      shell: pwsh
+      env:
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        if ($env:REF_NAME -ne 'main' -and $env:REF_NAME -notmatch '^release/\d+\.x$') {
+          throw "release.yml triggered on '$env:REF_NAME' which is neither 'main' nor 'release/<major>.x'. Refusing to publish."
+        }
+        Write-Host "OK: publishing from '$env:REF_NAME'."
 
     - name: Setup .NET (With cache)
       uses: actions/setup-dotnet@v5.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,32 @@ jobs:
       uses: dotnet/nbgv@master
       with:
         setAllVars: true
-        
+
+    - name: Verify prerelease does not regress past stable
+      shell: pwsh
+      env:
+        SEMVER2: ${{ steps.nbgv.outputs.SemVer2 }}
+        PRERELEASE: ${{ steps.nbgv.outputs.PrereleaseVersion }}
+      run: |
+        if (-not $env:PRERELEASE) {
+          Write-Host "Stable release ($env:SEMVER2); skipping prerelease regression check."
+          exit 0
+        }
+        if ($env:SEMVER2 -notmatch '^(\d+)\.(\d+)\.\d+-') {
+          throw "Could not parse SemVer2 '$env:SEMVER2'"
+        }
+        $major = $matches[1]
+        $minor = $matches[2]
+        git fetch --tags --force 2>$null
+        $stableTags = git tag --list "$major.$minor.*" | Where-Object { $_ -match "^$major\.$minor\.\d+$" }
+        if ($stableTags) {
+          $list = $stableTags -join ', '
+          $msg = "Stable for $major.$minor has already shipped (tags: $list); cannot publish prerelease '$env:SEMVER2'. Bump main's version.json to the next minor or major preview line."
+          Write-Error "::error::$msg"
+          exit 1
+        }
+        Write-Host "OK: no stable $major.$minor.* tag exists; '$env:SEMVER2' is safe to publish."
+
     - name: NuGet Restore
       run: dotnet restore DynamicData.sln
       working-directory: src

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,8 +15,8 @@ Every PR merged to either branch publishes a NuGet package automatically via `.g
 
 NBGV walks the first-parent history from `HEAD` back to the commit where `version.json`'s `version` field last changed. The count of commits is the "height". `{height}` in `version.json` is replaced with that count.
 
-- Two PRs merging the same day get distinct heights — no collisions.
-- A `version.json` change resets height to 1.
+- Two PRs merging the same day get distinct heights, no collisions.
+- A `version.json` change resets height to 1 (so the commit that sets the version is published as `X.Y.1`, not `X.Y.0`).
 - `fetch-depth: 0` in CI is required for height to be correct.
 
 ## Automation workflows
@@ -25,16 +25,20 @@ All `version.json` edits and release-branch creation are scripted via `workflow_
 
 | Workflow | When to run | What it does |
 |---|---|---|
-| **Promote main to stable minor** (`promote-minor.yml`) | Ready to ship the next minor (e.g. `9.5.0`) from `main` to an existing release branch. | Opens two PRs: (1) merges `main` into `release/<major>.x` and sets stable version; (2) bumps `main` to the next preview minor. |
-| **Cut major release** (`cut-major.yml`) | Ready to ship a new major as stable from `main` (e.g. `10.0.0`). | Creates a new `release/<major>.x` branch with stable version, then opens a PR to advance `main` to the next preview. |
+| **Promote main to stable minor** (`promote-minor.yml`) | Ready to ship the next minor (first published patch is `X.Y.1`) from `main` to an existing release branch. | Opens two PRs: (1) merges `main` into `release/<major>.x` and sets stable version (contains the full diff, NOT mechanical); (2) bumps `main` to the next preview minor (mechanical). |
+| **Cut major release** (`cut-major.yml`) | Ready to ship a new major as stable from `main` (first published patch is `X.0.1`). | Opens a main-bump PR first, then creates `release/<major>.x` with the stable version, then dispatches `release.yml` to publish the first patch. |
 | **Bump main to next major preview** (`bump-major-preview.yml`) | First breaking change is about to land on `main`. | Opens a PR bumping `main` from `<X>.Y-preview.{height}` to `<X+1>.0-preview.{height}`. |
 
 Two passive guards run on every PR / release:
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/**`. | If the PR is labeled `breaking-change` or `semver:major`, fails the check unless `main`'s major is **exactly one greater** than the latest stable tag's major (no skipping). |
-| **Prerelease regression guard** (in `release.yml`) | Every push to `main`. | Fails the publish step if a stable `X.Y.*` tag already exists for the major.minor being prereleased. |
+| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/*.x`. | For PRs to `main` labeled `breaking-change`, fails the check unless the PR's `version.json` major is **exactly one greater** than the latest stable tag's major (no skipping). For PRs to `release/*.x`, the check is skipped (breaking changes are a main-only concern). |
+| **Prerelease regression guard** (in `release.yml`) | Every push to `main` and dispatched run on `release/*.x`. | Refuses to publish a prerelease from a `release/*.x` branch (those must be stable only). Refuses to publish a prerelease for `X.Y` if a stable `X.Y.*` tag already exists. |
+
+### Recommended branch protection
+
+To make the **PR version check** binding (not advisory), add `PR version check / check` as a required status check on `main` in branch protection settings.
 
 ## Day-to-day flows
 
@@ -44,40 +48,54 @@ Open a PR targeting `release/9.x`. Merge. `release.yml` publishes `9.4.N` to NuG
 ### Preview of the next minor (e.g. `9.5.0-preview.42`)
 Open a PR targeting `main`. Merge. `release.yml` publishes `9.5.0-preview.N`. The GitHub Release is automatically marked as a pre-release. **No manual version edits.**
 
-### Promoting `main` → next stable minor (e.g. shipping `9.5.0`)
+### Promoting `main` → next stable minor (e.g. shipping the first `9.5.x` stable)
 1. Run the **Promote main to stable minor** workflow from the GitHub Actions tab. Inputs: `target_release_branch=release/9.x`, `stable_version=9.5`.
-2. Review and merge the two PRs it creates (promotion PR first, main-bump PR second).
-3. `release.yml` ships `9.5.0` stable on the release branch; `main` continues at `9.6-preview.{height}`.
+2. Review and merge the two PRs it creates. **The promotion PR is NOT mechanical**: it contains the full diff of `main` since the last promotion. Review it carefully.
+3. Merge the promotion PR first, then the main-bump PR.
+4. `release.yml` ships the first `9.5.x` patch (i.e. `9.5.1`) on the release branch; `main` continues at `9.6-preview.{height}`.
 
 ### Breaking change landing on `main`
 1. Run the **Bump main to next major preview** workflow before merging the first breaking change. Inputs: `next_major=10` (must be exactly one greater than the latest stable major; the workflow refuses skips like `next_major=11` when stable is `9.x`).
 2. Merge the PR it creates. `main` now publishes `10.0.0-preview.N`.
-3. Label the breaking-change PR with `breaking-change`. The **PR version check** workflow will block it until step 2 has merged.
+3. Label the breaking-change PR with `breaking-change`. The **PR version check** workflow will block it until step 2 has merged. After step 2 merges, push an empty commit to the breaking-change PR (or close+reopen it) to re-trigger the check.
 
-### Cutting a new major release (e.g. shipping `10.0.0`)
+### Cutting a new major release (e.g. shipping the first `10.x` stable)
 1. Run the **Cut major release** workflow. Inputs: `major_version=10`. Optional: `next_main_version=11.0` if more breaking changes are queued.
-2. The workflow creates `release/10.x` directly (publishes `10.0.0` stable) and opens a PR to advance `main`.
+2. The workflow opens a main-bump PR, creates `release/10.x` directly, and dispatches `release.yml` against `release/10.x` to publish the first `10.0.x` patch.
 3. Merge the main-bump PR.
 
 ### Manual escape hatch
-The automation workflows are thin wrappers around `version.json` edits. If something goes wrong, you can always perform the equivalent edits by hand. See the workflow YAML files for the exact operations.
+The automation workflows are thin wrappers around `version.json` edits. If something goes wrong, you can always perform the equivalent edits by hand. See the workflow YAML files for the exact operations. Recovery scenarios:
+
+- **`cut-major` failed after pushing the release branch but before dispatching `release.yml`**: manually run `release.yml` against the new `release/<major>.x` branch from the Actions tab.
+- **`promote-minor` failed mid-flight**: the bot branches `bot/promote-<version>-<run_id>` and `bot/bump-main-after-<version>-<run_id>` carry the run ID, so a retry produces fresh branches. Delete any stale bot branches or PRs from the failed run before re-running.
 
 ## Initial cutover (one-time, when introducing this infrastructure)
 
-This is **the only time manual steps are required**, because release/9.x does not yet exist when this PR merges.
+This is **the only time manual steps are required**, because `release/9.x` does not yet exist when this PR merges.
 
 After this PR merges to `main`:
 
 1. `main` will start publishing `9.5.0-preview.N` (the version bump in this PR took effect).
-2. Cut `release/9.x` from main HEAD:
+2. Cut `release/9.x` from `main` HEAD:
     ```sh
     git fetch origin
     git checkout -b release/9.x origin/main
     ```
 3. On `release/9.x`, edit `version.json`:
-    - Set `"version"` back to `"9.4"`.
-    - Add `"versionHeightOffset": 37` (the height of the latest published stable tag `9.4.37`, so the next build doesn't collide with it).
-4. Commit and push `release/9.x`. The next build produces `9.4.38` stable.
+    - Change `"version"` from `"9.5-preview.{height}"` back to `"9.4"`.
+    - Add `"versionHeightOffset": <N>` where `<N>` is the patch number of the latest stable `9.4.x` tag at cutover time. Verify with `git tag --list '9.4.*' | sort -V | tail -1`. The next stable build will be `9.4.<N+1>`. (At PR author time this was `37`; verify before pushing.)
+    - The full file should look like:
+        ```jsonc
+        {
+            "version": "9.4",
+            "versionHeightOffset": 37,
+            "publicReleaseRefSpec": [ /* unchanged */ ],
+            "nugetPackageVersion": { /* unchanged */ },
+            "cloudBuild": { /* unchanged */ }
+        }
+        ```
+4. Commit and push `release/9.x`. The next build produces `9.4.<N+1>` stable.
 
 From this point on, all subsequent releases use the automation workflows above. No more manual `version.json` edits.
 
@@ -85,5 +103,4 @@ From this point on, all subsequent releases use the automation workflows above. 
 
 PRs opened by the automation workflows are authored by `GITHUB_TOKEN`. GitHub deliberately suppresses workflow runs triggered by this token to prevent recursive workflows, so `ci-build.yml` and `pr-version-check.yml` will **not** run on these bot-authored PRs by default.
 
-The version-bump PRs are mechanical (single-line `version.json` edits with no code impact), so this is usually fine. If you want CI checks to run on them, close and reopen the PR once, or push an empty commit, or wire the workflows to use a personal access token (PAT) stored as a repository secret.
-
+The main-bump PRs are mechanical (single-line `version.json` edits with no code impact). The promotion PRs from `promote-minor` carry the full diff of `main` and SHOULD be reviewed carefully, and CI should be run on them. To trigger CI on a bot PR, close and reopen it, push an empty commit, or wire the workflows to use a personal access token (PAT) stored as a repository secret.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,68 @@
+# Releasing DynamicData
+
+DynamicData uses [Nerdbank.GitVersioning (NBGV)](https://github.com/dotnet/Nerdbank.GitVersioning) to compute package versions from git history. Versions are deterministic: the patch number is git height (commit count since `version.json`'s `version` field last changed).
+
+## Branching model
+
+| Branch | Purpose | Package version |
+|---|---|---|
+| `main` | Active development for the next minor (or major). | Pre-release: `X.Y.0-preview.N` |
+| `release/<major>.x` | Lifetime branch for an entire major version (e.g. `release/9.x` hosts all 9.x minors). | Stable: `X.Y.N` |
+
+Every PR merged to either branch publishes a NuGet package automatically via `.github/workflows/release.yml`.
+
+## How patch numbers are computed
+
+NBGV walks the first-parent history from `HEAD` back to the commit where `version.json`'s `version` field last changed. The count of commits is the "height". `{height}` in `version.json` is replaced with that count.
+
+- Two PRs merging the same day get distinct heights — no collisions.
+- A `version.json` change resets height to 1.
+- `fetch-depth: 0` in CI is required for height to be correct.
+
+## Day-to-day flows
+
+### Shipping a patch on the current stable line (e.g. `9.4.36`)
+1. Open a PR targeting `release/9.x`.
+2. Merge. `release.yml` publishes `9.4.N` to NuGet automatically.
+
+### Shipping a pre-release of the next minor (e.g. `9.5.0-preview.42`)
+1. Open a PR targeting `main`.
+2. Merge. `release.yml` publishes `9.5.0-preview.N` to NuGet automatically. The GitHub Release is marked as a pre-release.
+
+### Promoting `main` → stable on the existing release branch (e.g. 9.5)
+1. Open a PR from `main` into `release/9.x`.
+2. In the same PR, edit `version.json` on `release/9.x` to bump the version field from `"9.4"` → `"9.5"` (no `-preview` suffix).
+3. Merge. `release.yml` publishes `9.5.0` stable.
+4. On `main`, open a follow-up PR bumping `version.json` from `"9.5-preview.{height}"` to `"9.6-preview.{height}"` (or `"10.0-preview.{height}"` if breaking changes are planned next).
+
+### Bumping the major version (breaking changes)
+When the first breaking change PR for the next major is merging to `main`, include a `version.json` bump from `"9.5-preview.{height}"` to `"10.0-preview.{height}"`. From that commit forward, `main` publishes `10.0.0-preview.N`.
+
+### Cutting a new release branch for a new major (e.g. `release/10.x`)
+1. Create `release/10.x` from `main` at the commit you want to ship as 10.0.0.
+2. Edit `version.json` on `release/10.x`: change `"version"` from `"10.0-preview.{height}"` to `"10.0"`.
+3. Push. `release.yml` publishes `10.0.0` stable.
+4. On `main`, open a PR bumping to the next dev version (`"10.1-preview.{height}"` or `"11.0-preview.{height}"`).
+
+## Cutting `release/9.x` for the first time
+
+This needs to happen **once**, alongside introducing this prerelease infrastructure. The recommended sequence is **two PRs** so the cutover requires no cherry-picks or version height offsets:
+
+### Recommended cutover sequence
+
+1. **PR1 — workflow + docs only** (this commit): updates `.github/workflows/*.yml` to trigger on `main` and `release/**`, adds `RELEASING.md`. Leaves `version.json` at `"9.4"`.
+2. **Merge PR1** to main. Main is now publishing `9.4.N` stable (height continues from before).
+3. **Cut `release/9.x`** from the post-PR1 main HEAD: `git checkout -b release/9.x main && git push -u origin release/9.x`. `release/9.x` now has the new workflows and `version.json = "9.4"` — it will publish `9.4.N` stable on every merge.
+4. **PR2 — version bump only**: changes `version.json` from `"9.4"` to `"9.5-preview.{height}"`. Target: `main`.
+5. **Merge PR2** to main. Main starts publishing `9.5.0-preview.N` pre-releases.
+
+### Alternative: single PR + versionHeightOffset
+
+If you prefer one PR for everything (workflow + version bump), the cutover requires a manual `versionHeightOffset` on `release/9.x` to avoid colliding with existing tags:
+
+1. Merge the combined PR to main. Main starts publishing `9.5.0-preview.N`.
+2. Cut `release/9.x` from post-merge main HEAD.
+3. On `release/9.x`, edit `version.json`:
+    - Set `"version"` back to `"9.4"`.
+    - Add `"versionHeightOffset": <N>` where `<N>` is the height of the last published `9.4.N` tag (currently `9.4.35` → offset `35`).
+4. Commit and push `release/9.x`. Next build produces `9.4.{1 + N + further_height}`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,7 +38,7 @@ Two passive guards run on every PR / release:
 
 ## Day-to-day flows
 
-### Patch on the current stable line (e.g. `9.4.36`)
+### Patch on the current stable line (e.g. `9.4.38`)
 Open a PR targeting `release/9.x`. Merge. `release.yml` publishes `9.4.N` to NuGet automatically. **No manual version edits.**
 
 ### Preview of the next minor (e.g. `9.5.0-preview.42`)
@@ -76,8 +76,8 @@ After this PR merges to `main`:
     ```
 3. On `release/9.x`, edit `version.json`:
     - Set `"version"` back to `"9.4"`.
-    - Add `"versionHeightOffset": 36` (the height main was at just before this PR merged — needed so the next build doesn't collide with the existing `9.4.35` tag).
-4. Commit and push `release/9.x`. The next build produces `9.4.37` stable.
+    - Add `"versionHeightOffset": 37` (the height of the latest published stable tag `9.4.37`, so the next build doesn't collide with it).
+4. Commit and push `release/9.x`. The next build produces `9.4.38` stable.
 
 From this point on, all subsequent releases use the automation workflows above. No more manual `version.json` edits.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@ Every PR merged to either branch publishes a NuGet package automatically via `.g
 NBGV walks the first-parent history from `HEAD` back to the commit where `version.json`'s `version` field last changed. The count of commits is the "height". `{height}` in `version.json` is replaced with that count.
 
 - Two PRs merging the same day get distinct heights, no collisions.
-- A `version.json` change resets height to 1 (so the commit that sets the version is published as `X.Y.1`, not `X.Y.0`).
+- A `version.json` change resets height to 1. Combined with `"versionHeightOffset": -1` (written by the automation workflows on stable branches), the commit that sets a new stable version publishes as `X.Y.0` (per semver convention; previews stay at `X.Y.0-preview.1` because main does not use the offset).
 - `fetch-depth: 0` in CI is required for height to be correct.
 
 ## Automation workflows
@@ -25,8 +25,8 @@ All `version.json` edits and release-branch creation are scripted via `workflow_
 
 | Workflow | When to run | What it does |
 |---|---|---|
-| **Promote main to stable minor** (`promote-minor.yml`) | Ready to ship the next minor (first published patch is `X.Y.1`) from `main` to an existing release branch. | Opens two PRs: (1) merges `main` into `release/<major>.x` and sets stable version (contains the full diff, NOT mechanical); (2) bumps `main` to the next preview minor (mechanical). |
-| **Cut major release** (`cut-major.yml`) | Ready to ship a new major as stable from `main` (first published patch is `X.0.1`). | Opens a main-bump PR first, then creates `release/<major>.x` with the stable version, then dispatches `release.yml` to publish the first patch. |
+| **Promote main to stable minor** (`promote-minor.yml`) | Ready to ship the next minor (first published patch is `X.Y.0`) from `main` to an existing release branch. | Opens two PRs: (1) merges `main` into `release/<major>.x` and sets stable version (contains the full diff, NOT mechanical); (2) bumps `main` to the next preview minor (mechanical). |
+| **Cut major release** (`cut-major.yml`) | Ready to ship a new major as stable from `main` (first published patch is `X.0.0`). | Opens a main-bump PR first, then creates `release/<major>.x` with the stable version, then dispatches `release.yml` to publish the first patch. |
 | **Bump main to next major preview** (`bump-major-preview.yml`) | First breaking change is about to land on `main`. | Opens a PR bumping `main` from `<X>.Y-preview.{height}` to `<X+1>.0-preview.{height}`. |
 
 Two passive guards run on every PR / release:
@@ -36,10 +36,6 @@ Two passive guards run on every PR / release:
 | **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/*.x`. | For PRs to `main` labeled `breaking-change`, fails the check unless the PR's `version.json` major is **exactly one greater** than the latest stable tag's major (no skipping). For PRs to `release/*.x`, the check is skipped (breaking changes are a main-only concern). |
 | **Prerelease regression guard** (in `release.yml`) | Every push to `main` and dispatched run on `release/*.x`. | Refuses to publish a prerelease from a `release/*.x` branch (those must be stable only). Refuses to publish a prerelease for `X.Y` if a stable `X.Y.*` tag already exists. |
 
-### Recommended branch protection
-
-To make the **PR version check** binding (not advisory), add `PR version check / check` as a required status check on `main` in branch protection settings.
-
 ## Day-to-day flows
 
 ### Patch on the current stable line (e.g. `9.4.38`)
@@ -47,6 +43,13 @@ Open a PR targeting `release/9.x`. Merge. `release.yml` publishes `9.4.N` to NuG
 
 ### Preview of the next minor (e.g. `9.5.0-preview.42`)
 Open a PR targeting `main`. Merge. `release.yml` publishes `9.5.0-preview.N`. The GitHub Release is automatically marked as a pre-release. **No manual version edits.**
+
+### Cherry-picking a fix from `main` to a release branch
+The promote workflow merges all of `main` into the release branch. For backporting just one (or a few) commits without promoting everything:
+1. `git checkout release/9.x && git pull`
+2. `git checkout -b fix/backport-XYZ release/9.x`
+3. `git cherry-pick <sha-on-main>` (repeat for each commit)
+4. Push and open a PR targeting `release/9.x`. Merging publishes the next patch via `release.yml`. **No manual version edits.**
 
 ### Promoting `main` → next stable minor (e.g. shipping the first `9.5.x` stable)
 1. Run the **Promote main to stable minor** workflow from the GitHub Actions tab. Inputs: `target_release_branch=release/9.x`, `stable_version=9.5`.
@@ -69,35 +72,6 @@ The automation workflows are thin wrappers around `version.json` edits. If somet
 
 - **`cut-major` failed after pushing the release branch but before dispatching `release.yml`**: manually run `release.yml` against the new `release/<major>.x` branch from the Actions tab.
 - **`promote-minor` failed mid-flight**: the bot branches `bot/promote-<version>-<run_id>` and `bot/bump-main-after-<version>-<run_id>` carry the run ID, so a retry produces fresh branches. Delete any stale bot branches or PRs from the failed run before re-running.
-
-## Initial cutover (one-time, when introducing this infrastructure)
-
-This is **the only time manual steps are required**, because `release/9.x` does not yet exist when this PR merges.
-
-After this PR merges to `main`:
-
-1. `main` will start publishing `9.5.0-preview.N` (the version bump in this PR took effect).
-2. Cut `release/9.x` from `main` HEAD:
-    ```sh
-    git fetch origin
-    git checkout -b release/9.x origin/main
-    ```
-3. On `release/9.x`, edit `version.json`:
-    - Change `"version"` from `"9.5-preview.{height}"` back to `"9.4"`.
-    - Add `"versionHeightOffset": <N>` where `<N>` is the patch number of the latest stable `9.4.x` tag at cutover time. Verify with `git tag --list '9.4.*' | sort -V | tail -1`. The next stable build will be `9.4.<N+1>`. (At PR author time this was `37`; verify before pushing.)
-    - The full file should look like:
-        ```jsonc
-        {
-            "version": "9.4",
-            "versionHeightOffset": 37,
-            "publicReleaseRefSpec": [ /* unchanged */ ],
-            "nugetPackageVersion": { /* unchanged */ },
-            "cloudBuild": { /* unchanged */ }
-        }
-        ```
-4. Commit and push `release/9.x`. The next build produces `9.4.<N+1>` stable.
-
-From this point on, all subsequent releases use the automation workflows above. No more manual `version.json` edits.
 
 ## Known limitation: bot PRs and downstream CI
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,18 +51,18 @@ Open a PR targeting `main`. Merge. `release.yml` publishes `9.5.0-preview.N`. Th
 ### Promoting `main` → next stable minor (e.g. shipping the first `9.5.x` stable)
 1. Run the **Promote main to stable minor** workflow from the GitHub Actions tab. Inputs: `target_release_branch=release/9.x`, `stable_version=9.5`.
 2. Review and merge the two PRs it creates. **The promotion PR is NOT mechanical**: it contains the full diff of `main` since the last promotion. Review it carefully.
-3. Merge the promotion PR first, then the main-bump PR.
-4. `release.yml` ships the first `9.5.x` patch (i.e. `9.5.1`) on the release branch; `main` continues at `9.6-preview.{height}`.
+3. Merge the promotion PR first, then **immediately** merge the main-bump PR. Don't leave the bump PR sitting: every push to `main` between the stable ship and the bump merge fails the prerelease-regression guard.
+4. `release.yml` ships the first `9.5.x` patch (i.e. `9.5.1`) on the release branch; `main` resumes at `9.6-preview.{height}`.
 
 ### Breaking change landing on `main`
 1. Run the **Bump main to next major preview** workflow before merging the first breaking change. Inputs: `next_major=10` (must be exactly one greater than the latest stable major; the workflow refuses skips like `next_major=11` when stable is `9.x`).
 2. Merge the PR it creates. `main` now publishes `10.0.0-preview.N`.
-3. Label the breaking-change PR with `breaking-change`. The **PR version check** workflow will block it until step 2 has merged. After step 2 merges, push an empty commit to the breaking-change PR (or close+reopen it) to re-trigger the check.
+3. Label the breaking-change PR with `breaking-change`. The **PR version check** workflow will block it until step 2 has merged. After step 2 merges, rebase the breaking-change PR onto the updated `main` (or merge `main` into it) so the PR head includes the bumped `version.json`. Pushing an empty commit alone is not enough: the check reads `version.json` from the PR head, which is unchanged until the bump lands in the PR's branch.
 
 ### Cutting a new major release (e.g. shipping the first `10.x` stable)
-1. Run the **Cut major release** workflow. Inputs: `major_version=10`. Optional: `next_main_version=11.0` if more breaking changes are queued.
-2. The workflow opens a main-bump PR, creates `release/10.x` directly, and dispatches `release.yml` against `release/10.x` to publish the first `10.0.x` patch.
-3. Merge the main-bump PR.
+1. Run the **Cut major release** workflow. Inputs: `major_version=10`. Optional: `next_main_version=11.0` if more breaking changes are queued (the workflow refuses values that aren't `10.<minor>` or exactly `11.0`).
+2. The workflow opens a main-bump PR, creates `release/10.x`, and dispatches `release.yml` against the new branch to publish the first `10.0.x` patch. The dispatched run URL is in the workflow summary.
+3. Merge the main-bump PR. Don't wait: every push to `main` after the new stable ships will fail the prerelease-regression guard until this PR merges.
 
 ### Manual escape hatch
 The automation workflows are thin wrappers around `version.json` edits. If something goes wrong, you can always perform the equivalent edits by hand. See the workflow YAML files for the exact operations. Recovery scenarios:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,50 +19,71 @@ NBGV walks the first-parent history from `HEAD` back to the commit where `versio
 - A `version.json` change resets height to 1.
 - `fetch-depth: 0` in CI is required for height to be correct.
 
+## Automation workflows
+
+All `version.json` edits and release-branch creation are scripted via `workflow_dispatch` actions in the GitHub Actions UI. Maintainers should not edit `version.json` by hand.
+
+| Workflow | When to run | What it does |
+|---|---|---|
+| **Promote main to stable minor** (`promote-minor.yml`) | Ready to ship the next minor (e.g. `9.5.0`) from `main` to an existing release branch. | Opens two PRs: (1) merges `main` into `release/<major>.x` and sets stable version; (2) bumps `main` to the next preview minor. |
+| **Cut major release** (`cut-major.yml`) | Ready to ship a new major as stable from `main` (e.g. `10.0.0`). | Creates a new `release/<major>.x` branch with stable version, then opens a PR to advance `main` to the next preview. |
+| **Bump main to next major preview** (`bump-major-preview.yml`) | First breaking change is about to land on `main`. | Opens a PR bumping `main` from `<X>.Y-preview.{height}` to `<X+1>.0-preview.{height}`. |
+
+Two passive guards run on every PR / release:
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/**`. | If the PR is labeled `breaking-change` or `semver:major`, fails the check unless `main`'s major is already greater than the latest stable tag. |
+| **Prerelease regression guard** (in `release.yml`) | Every push to `main`. | Fails the publish step if a stable `X.Y.*` tag already exists for the major.minor being prereleased. |
+
 ## Day-to-day flows
 
-### Shipping a patch on the current stable line (e.g. `9.4.36`)
-1. Open a PR targeting `release/9.x`.
-2. Merge. `release.yml` publishes `9.4.N` to NuGet automatically.
+### Patch on the current stable line (e.g. `9.4.36`)
+Open a PR targeting `release/9.x`. Merge. `release.yml` publishes `9.4.N` to NuGet automatically. **No manual version edits.**
 
-### Shipping a pre-release of the next minor (e.g. `9.5.0-preview.42`)
-1. Open a PR targeting `main`.
-2. Merge. `release.yml` publishes `9.5.0-preview.N` to NuGet automatically. The GitHub Release is marked as a pre-release.
+### Preview of the next minor (e.g. `9.5.0-preview.42`)
+Open a PR targeting `main`. Merge. `release.yml` publishes `9.5.0-preview.N`. The GitHub Release is automatically marked as a pre-release. **No manual version edits.**
 
-### Promoting `main` → stable on the existing release branch (e.g. 9.5)
-1. Open a PR from `main` into `release/9.x`.
-2. In the same PR, edit `version.json` on `release/9.x` to bump the version field from `"9.4"` → `"9.5"` (no `-preview` suffix).
-3. Merge. `release.yml` publishes `9.5.0` stable.
-4. On `main`, open a follow-up PR bumping `version.json` from `"9.5-preview.{height}"` to `"9.6-preview.{height}"` (or `"10.0-preview.{height}"` if breaking changes are planned next).
+### Promoting `main` → next stable minor (e.g. shipping `9.5.0`)
+1. Run the **Promote main to stable minor** workflow from the GitHub Actions tab. Inputs: `target_release_branch=release/9.x`, `stable_version=9.5`.
+2. Review and merge the two PRs it creates (promotion PR first, main-bump PR second).
+3. `release.yml` ships `9.5.0` stable on the release branch; `main` continues at `9.6-preview.{height}`.
 
-### Bumping the major version (breaking changes)
-When the first breaking change PR for the next major is merging to `main`, include a `version.json` bump from `"9.5-preview.{height}"` to `"10.0-preview.{height}"`. From that commit forward, `main` publishes `10.0.0-preview.N`.
+### Breaking change landing on `main`
+1. Run the **Bump main to next major preview** workflow before merging the first breaking change. Inputs: `next_major=10`.
+2. Merge the PR it creates. `main` now publishes `10.0.0-preview.N`.
+3. Label the breaking-change PR with `breaking-change`. The **PR version check** workflow will block it until step 2 has merged.
 
-### Cutting a new release branch for a new major (e.g. `release/10.x`)
-1. Create `release/10.x` from `main` at the commit you want to ship as 10.0.0.
-2. Edit `version.json` on `release/10.x`: change `"version"` from `"10.0-preview.{height}"` to `"10.0"`.
-3. Push. `release.yml` publishes `10.0.0` stable.
-4. On `main`, open a PR bumping to the next dev version (`"10.1-preview.{height}"` or `"11.0-preview.{height}"`).
+### Cutting a new major release (e.g. shipping `10.0.0`)
+1. Run the **Cut major release** workflow. Inputs: `major_version=10`. Optional: `next_main_version=11.0` if more breaking changes are queued.
+2. The workflow creates `release/10.x` directly (publishes `10.0.0` stable) and opens a PR to advance `main`.
+3. Merge the main-bump PR.
 
-## Cutting `release/9.x` for the first time
+### Manual escape hatch
+The automation workflows are thin wrappers around `version.json` edits. If something goes wrong, you can always perform the equivalent edits by hand. See the workflow YAML files for the exact operations.
 
-This needs to happen **once**, alongside introducing this prerelease infrastructure. The recommended sequence is **two PRs** so the cutover requires no cherry-picks or version height offsets:
+## Initial cutover (one-time, when introducing this infrastructure)
 
-### Recommended cutover sequence
+This is **the only time manual steps are required**, because release/9.x does not yet exist when this PR merges.
 
-1. **PR1 — workflow + docs only** (this commit): updates `.github/workflows/*.yml` to trigger on `main` and `release/**`, adds `RELEASING.md`. Leaves `version.json` at `"9.4"`.
-2. **Merge PR1** to main. Main is now publishing `9.4.N` stable (height continues from before).
-3. **Cut `release/9.x`** from the post-PR1 main HEAD: `git checkout -b release/9.x main && git push -u origin release/9.x`. `release/9.x` now has the new workflows and `version.json = "9.4"` — it will publish `9.4.N` stable on every merge.
-4. **PR2 — version bump only**: changes `version.json` from `"9.4"` to `"9.5-preview.{height}"`. Target: `main`.
-5. **Merge PR2** to main. Main starts publishing `9.5.0-preview.N` pre-releases.
+After this PR merges to `main`:
 
-### Alternative: single PR + versionHeightOffset
-
-If you prefer one PR for everything (workflow + version bump), the cutover requires a manual `versionHeightOffset` on `release/9.x` to avoid colliding with existing tags:
-
-1. Merge the combined PR to main. Main starts publishing `9.5.0-preview.N`.
-2. Cut `release/9.x` from post-merge main HEAD.
+1. `main` will start publishing `9.5.0-preview.N` (the version bump in this PR took effect).
+2. Cut `release/9.x` from main HEAD:
+    ```sh
+    git fetch origin
+    git checkout -b release/9.x origin/main
+    ```
 3. On `release/9.x`, edit `version.json`:
     - Set `"version"` back to `"9.4"`.
-    - Add `"versionHeightOffset": <N>` where `<N>` is the height of the last published `9.4.N` tag (currently `9.4.35` → offset `35`).
-4. Commit and push `release/9.x`. Next build produces `9.4.{1 + N + further_height}`.
+    - Add `"versionHeightOffset": 36` (the height main was at just before this PR merged — needed so the next build doesn't collide with the existing `9.4.35` tag).
+4. Commit and push `release/9.x`. The next build produces `9.4.37` stable.
+
+From this point on, all subsequent releases use the automation workflows above. No more manual `version.json` edits.
+
+## Known limitation: bot PRs and downstream CI
+
+PRs opened by the automation workflows are authored by `GITHUB_TOKEN`. GitHub deliberately suppresses workflow runs triggered by this token to prevent recursive workflows, so `ci-build.yml` and `pr-version-check.yml` will **not** run on these bot-authored PRs by default.
+
+The version-bump PRs are mechanical (single-line `version.json` edits with no code impact), so this is usually fine. If you want CI checks to run on them, close and reopen the PR once, or push an empty commit, or wire the workflows to use a personal access token (PAT) stored as a repository secret.
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,7 @@ Two passive guards run on every PR / release:
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/**`. | If the PR is labeled `breaking-change` or `semver:major`, fails the check unless `main`'s major is already greater than the latest stable tag. |
+| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/**`. | If the PR is labeled `breaking-change` or `semver:major`, fails the check unless `main`'s major is **exactly one greater** than the latest stable tag's major (no skipping). |
 | **Prerelease regression guard** (in `release.yml`) | Every push to `main`. | Fails the publish step if a stable `X.Y.*` tag already exists for the major.minor being prereleased. |
 
 ## Day-to-day flows
@@ -50,7 +50,7 @@ Open a PR targeting `main`. Merge. `release.yml` publishes `9.5.0-preview.N`. Th
 3. `release.yml` ships `9.5.0` stable on the release branch; `main` continues at `9.6-preview.{height}`.
 
 ### Breaking change landing on `main`
-1. Run the **Bump main to next major preview** workflow before merging the first breaking change. Inputs: `next_major=10`.
+1. Run the **Bump main to next major preview** workflow before merging the first breaking change. Inputs: `next_major=10` (must be exactly one greater than the latest stable major; the workflow refuses skips like `next_major=11` when stable is `9.x`).
 2. Merge the PR it creates. `main` now publishes `10.0.0-preview.N`.
 3. Label the breaking-change PR with `breaking-change`. The **PR version check** workflow will block it until step 2 has merged.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,17 +23,31 @@ NBGV walks the first-parent history from `HEAD` back to the commit where `versio
 
 All `version.json` edits and release-branch creation are scripted via `workflow_dispatch` actions in the GitHub Actions UI. Maintainers should not edit `version.json` by hand.
 
-| Workflow | When to run | What it does |
-|---|---|---|
-| **Promote main to stable minor** (`promote-minor.yml`) | Ready to ship the next minor (first published patch is `X.Y.0`) from `main` to an existing release branch. | Opens two PRs: (1) merges `main` into `release/<major>.x` and sets stable version (contains the full diff, NOT mechanical); (2) bumps `main` to the next preview minor (mechanical). |
-| **Cut major release** (`cut-major.yml`) | Ready to ship a new major as stable from `main` (first published patch is `X.0.0`). | Opens a main-bump PR first, then creates `release/<major>.x` with the stable version, then dispatches `release.yml` to publish the first patch. |
-| **Bump main to next major preview** (`bump-major-preview.yml`) | First breaking change is about to land on `main`. | Opens a PR bumping `main` from `<X>.Y-preview.{height}` to `<X+1>.0-preview.{height}`. |
+### Which workflow do I run?
+
+| Situation | Run |
+|---|---|
+| Ship a stable patch (e.g. `9.4.42`) | No workflow. Just PR to `release/<major>.x` and merge. |
+| Cherry-pick a fix from main to a release branch | No workflow. Cherry-pick locally and PR to `release/<major>.x`. |
+| Ship a preview | No workflow. Just PR to `main` and merge. |
+| Next minor stable on an existing release branch (e.g. `9.5` after `9.4` line) | **Promote main to stable minor** |
+| First stable of a new major (main has been parked on `X.0-preview`) | **Cut major release** |
+| First breaking change for the next major is about to land | **Bump main to next major preview** |
+| Hand-edit `version.json` (rare; recovery, manual cutover) | No workflow. Add the `manual-version-edit` label to your PR. |
+
+### Workflow reference
+
+| Workflow | Inputs | Prereq on main | Prereq on release branch | What it produces |
+|---|---|---|---|---|
+| **Promote main to stable minor** (`promote-minor.yml`) | `target_release_branch` (e.g. `release/9.x`); `stable_version` (e.g. `9.5`) | Main is on `<X>.<Y>-preview` where X.Y matches `stable_version` | Branch must EXIST; current `version` must be stable `<major>.<minor>` form; `stable_version` major must match; minor must be greater | Two PRs: (1) promotion PR with the full diff of main, sets version to `stable_version` + `versionHeightOffset: -1`; (2) companion main-bump PR moving main to `<X>.<Y+1>-preview`. **Merge promotion first, then bump immediately.** |
+| **Cut major release** (`cut-major.yml`) | `major_version` (required); `next_main_version` (optional; default `<major>.1`, may also be `<major+1>.0`) | Main is on `<major_version>.0-preview` **strictly** (the `.0`, not `.5`) | `release/<major>.x` must NOT exist | Two artifacts: (1) main-bump PR to `<next_main_version>-preview`; (2) new `release/<major>.x` at `<major>.0` + `versionHeightOffset: -1`, with `release.yml` dispatched to publish `<major>.0.0`. |
+| **Bump main to next major preview** (`bump-major-preview.yml`) | `next_major` (required); `discard_current_preview` (optional, default false) | Main is on `<X>.<Y>-preview`. `next_major` must equal `latest_stable_major + 1` (no skipping). Pre-flight orphan check: refuses to run if any current `<X>` preview work hasn't been cut/promoted to stable, unless `discard_current_preview` is checked | n/a | One PR: bumps main to `<next_major>.0-preview.{height}`. **Merge before landing the first breaking-change PR.** |
 
 Two passive guards run on every PR / release:
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/*.x`. | For PRs to `main` labeled `breaking-change`, fails the check unless the PR's `version.json` major is **exactly one greater** than the latest stable tag's major (no skipping). For PRs to `release/*.x`, the check is skipped (breaking changes are a main-only concern). |
+| **PR version check** (`pr-version-check.yml`) | Pull request to `main` / `release/*.x`. | Rejects any human-authored PR that modifies `version.json` unless labeled `manual-version-edit` (bot PRs from `bot/bump-*` and `bot/promote-*` are exempt). For PRs to `main` labeled `breaking-change`, also enforces that main's major is exactly one greater than the latest stable tag's major (no skipping). Any PR (labeled or not) that changes the major must carry the `breaking-change` label. |
 | **Prerelease regression guard** (in `release.yml`) | Every push to `main` and dispatched run on `release/*.x`. | Refuses to publish a prerelease from a `release/*.x` branch (those must be stable only). Refuses to publish a prerelease for `X.Y` if a stable `X.Y.*` tag already exists. |
 
 ## Day-to-day flows

--- a/version.json
+++ b/version.json
@@ -1,9 +1,8 @@
 {
-    "version": "9.4",
+    "version": "9.5-preview.{height}",
     "publicReleaseRefSpec": [
-        "^refs/heads/main$", // we release out of master
-        "^refs/heads/preview/.*", // we release previews
-        "^refs/heads/rel/\\d+\\.\\d+\\.\\d+" // we also release branches starting with rel/N.N.N
+        "^refs/heads/main$", // main publishes pre-release packages
+        "^refs/heads/release/.+" // release/<major>.x branches publish stable packages
     ],
     "nugetPackageVersion": {
         "semVer": 2

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": "9.5-preview.{height}",
     "publicReleaseRefSpec": [
         "^refs/heads/main$", // main publishes pre-release packages
-        "^refs/heads/release/.+" // release/<major>.x branches publish stable packages
+        "^refs/heads/release/\\d+\\.x$" // release/<major>.x branches publish stable packages
     ],
     "nugetPackageVersion": {
         "semVer": 2


### PR DESCRIPTION
Adds pre-release publishing built on NBGV, plus three workflow_dispatch actions that handle every `version.json` edit so we don't have to touch it by hand.

## How versions work

| Branch | `version.json` | Publishes |
|---|---|---|
| `main` | `"X.Y-preview.{height}"` | `X.Y.0-preview.N` on every PR merge |
| `release/<major>.x` | `"X.Y"` + `"versionHeightOffset": -1` | `X.Y.N` stable on every PR merge (first published patch is `X.Y.0`, per semver convention; previews stay at `preview.1` per .NET ecosystem convention) |

NBGV's `{height}` is the first-parent commit count since the `version` field in `version.json` last changed. Two PRs merged the same day get distinct heights. No NuGet querying, no race conditions, no manual patch increments.

## Automation workflows

All run from the Actions tab.

| Workflow | When | What it does |
|---|---|---|
| Promote main to stable minor | Ready to ship the next minor stable | Opens two PRs: (1) merges main into `release/<major>.x` and sets the stable version (this one has the full diff, review it carefully); (2) bumps main to the next preview |
| Cut major release | Ready to ship a new major stable | Opens a main-bump PR, creates `release/<major>.x`, dispatches `release.yml` against the new branch |
| Bump main to next major preview | First breaking change is about to land | Opens a PR bumping main from `X.Y-preview` to `(X+1).0-preview`. Rejects skips |

Passive guards:

| Workflow | What it guards |
|---|---|
| `pr-version-check.yml` | Rejects any human-authored PR that modifies `version.json` unless labeled `manual-version-edit` (bot PRs from `bot/bump-*` and `bot/promote-*` are exempt). For PRs labeled `breaking-change`, also enforces that main's major is exactly `latest_stable_major + 1`. Any PR (labeled or not) that changes the major must carry the `breaking-change` label |
| Prerelease regression guard (in `release.yml`) | Refuses to publish stable from main, refuses to publish prerelease from `release/*.x`, refuses prerelease for `X.Y` if a stable `X.Y.*` tag already exists |

## Day-to-day

| Want to | Do this |
|---|---|
| Ship a stable patch | PR to `release/<major>.x`, merge |
| Cherry-pick a fix from main to a release branch | `git cherry-pick` onto a branch off `release/<major>.x`, PR, merge |
| Ship a preview | PR to `main`, merge |
| Ship the next stable minor | Run "Promote main to stable minor", merge both PRs (promotion first, then bump immediately) |
| Land a breaking change | Run "Bump main to next major preview", merge, then label and merge the breaking PR |
| Ship a new stable major | Run "Cut major release", merge the main-bump PR right after |

## One-time setup after this PR merges

### 1. Cut `release/9.x` by hand (the only manual `version.json` edit ever)

`release/9.x` doesn't exist yet, and it needs to continue the existing `9.4.x` tag history (currently at `9.4.37`). The `pr-version-check` guard requires the `manual-version-edit` label on any PR that edits `version.json`, but the cutover is a direct push to a new branch (no PR), so the label isn't needed.

```sh
git fetch origin
git checkout -b release/9.x origin/main
# Edit version.json:
#   - Change "version" from "9.5-preview.{height}" back to "9.4"
#   - Set "versionHeightOffset" to <N> where N is the latest stable 9.4.x patch number
#     Verify: git tag --list '9.4.*' | sort -V | tail -1  (e.g. 37 -> set to 37; next publish = 9.4.38)
git add version.json
git commit -m "Cut release/9.x continuing 9.4.<N+1>"
git push -u origin release/9.x
```

The next build on `release/9.x` produces `9.4.<N+1>`. After this, every release goes through the automation. The `manual-version-edit` label exists for recovery cases (a failed automation run that needs hand-cleanup); regular work never touches `version.json`.

### 2. Make `PR version check` a required status check

In repo settings -> Branches -> branch protection rule for `main` (and `release/*.x`), add `PR version check / check` as a required status check. This converts the guard from advisory to binding.

## Process

The basic infra was straightforward. The automation went through three rounds of adversarial multi-agent review (six reviewers in round 1, then four in round 2, then two in round 3 to verify the round-2 fixes). The reviewers found ~50 unique issues across the rounds, most of which got fixed: PowerShell injection through inputs, the second-promotion always-conflicts merge, `cut-major` race conditions and ordering bugs, error handling that swallowed git failures silently, a few subtle off-by-ones in the version checks, supply-chain risk from floating action versions, and the prerelease-regresses-past-stable case. The commit history walks through all of it if you want details.

## Known limitation

Bot PRs are authored by `GITHUB_TOKEN`. GitHub deliberately suppresses workflows triggered by that token to prevent recursion, so `ci-build.yml` and `pr-version-check.yml` won't run on auto-generated PRs unless you close and reopen them (or wire up a PAT). The main-bump PRs are one-line `version.json` edits so this is usually fine. The promotion PRs from `promote-minor` carry the full diff of main and should be reviewed and have CI run before merging.