### PR TITLE
Replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,8 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $cmd = @('release', 'create', $env:TAG, '--title', $env:TAG, '--notes', $env:BODY, '--target', $env:GITHUB_SHA)
+        $notesPath = Join-Path $env:RUNNER_TEMP 'release-notes.md'
+        Set-Content -Path $notesPath -Value $env:BODY -Encoding utf8 -NoNewline
+        $cmd = @('release', 'create', $env:TAG, '--title', $env:TAG, '--notes-file', $notesPath, '--target', $env:GITHUB_SHA)
         if ($env:IS_PRERELEASE -eq 'true') { $cmd += '--prerelease' }
         gh @cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,14 @@ jobs:
       id: changelog
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2.6.2
-      with:
-          tag_name: ${{ steps.nbgv.outputs.SemVer2 }}
-          name: ${{ steps.nbgv.outputs.SemVer2 }}
-          prerelease: ${{ steps.nbgv.outputs.PrereleaseVersion != '' }}
-          body: |
-            ${{ steps.changelog.outputs.commitLog }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ steps.nbgv.outputs.SemVer2 }}
+        IS_PRERELEASE: ${{ steps.nbgv.outputs.PrereleaseVersion != '' }}
+        BODY: ${{ steps.changelog.outputs.commitLog }}
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $cmd = @('release', 'create', $env:TAG, '--title', $env:TAG, '--notes', $env:BODY, '--target', $env:GITHUB_SHA)
+        if ($env:IS_PRERELEASE -eq 'true') { $cmd += '--prerelease' }
+        gh @cmd


### PR DESCRIPTION
## Problem

`release.yml` fails with `startup_failure` on every push to `main` and `release/*.x` because `softprops/action-gh-release@v2.6.2` is not on this repository's allowed-actions list.

Repro: https://github.com/reactivemarbles/DynamicData/actions/runs/26430799048

## Fix

Replace the action with `gh release create` from the GitHub CLI (pre-installed on the windows runner). Same inputs (tag, title, notes, prerelease flag), no third-party dependency, no policy change required.