### PR TITLE
Make SizeLimit tests deterministic by deduplicating generator output

### DIFF
--- a/src/DynamicData.Tests/Cache/SizeLimitFixture.cs
+++ b/src/DynamicData.Tests/Cache/SizeLimitFixture.cs
@@ -72,8 +72,13 @@ public class SizeLimitFixture : IDisposable
     [Fact]
     public void AddMoreThanLimitInBatched()
     {
-        _source.AddOrUpdate(_generator.Take(10).ToArray());
-        _source.AddOrUpdate(_generator.Take(10).ToArray());
+        // _generator.Take(N) draws random Person rows from a finite name pool; a second
+        // Take(10) call can produce keys that collide with the first batch, turning an
+        // Add into an Update and breaking the per-message Adds count. Draw a larger pool
+        // up front, dedupe by Key, then split into two non-overlapping batches of 10.
+        var people = _generator.Take(60).DistinctBy(p => p.Key).Take(20).ToArray();
+        _source.AddOrUpdate(people.Take(10).ToArray());
+        _source.AddOrUpdate(people.Skip(10).Take(10).ToArray());
 
         _scheduler.Start();
 
@@ -96,12 +101,17 @@ public class SizeLimitFixture : IDisposable
         var removesTriggered = false;
         var subscriber = _source.LimitSizeTo(10, _scheduler).Subscribe(removes => { removesTriggered = true; });
 
-        _source.AddOrUpdate(_generator.Take(10).ToArray());
+        // _generator.Take(N) draws random Person rows from a finite name pool; a second
+        // Take(10) call can produce keys that collide with the first batch, turning an
+        // Add into an Update and breaking the per-message Adds count. Draw a larger pool
+        // up front, dedupe by Key, then split into two non-overlapping batches of 10.
+        var people = _generator.Take(60).DistinctBy(p => p.Key).Take(20).ToArray();
+        _source.AddOrUpdate(people.Take(10).ToArray());
         _scheduler.AdvanceBy(TimeSpan.FromMilliseconds(150).Ticks);
 
         removesTriggered.Should().BeFalse();
 
-        _source.AddOrUpdate(_generator.Take(10).ToArray());
+        _source.AddOrUpdate(people.Skip(10).Take(10).ToArray());
 
         _scheduler.AdvanceBy(TimeSpan.FromMilliseconds(150).Ticks);
 


### PR DESCRIPTION
## Problem

`SizeLimitFixture.InvokeLimitSizeToWhenOverLimit` and `SizeLimitFixture.AddMoreThanLimitInBatched` fail intermittently in CI with errors of the form:

> Expected _results.Messages[1].Adds to be 10 because Should be 10 adds in the second update, but found 9 (difference of -1).

Both tests build a 10-item batch, then build a second 10-item batch, and assert that the two `AddOrUpdate` calls produced exactly 10 Adds each.

`RandomPersonGenerator.Take(N)` draws random `Person` rows from a finite name pool (~21 first names for girls + ~30 first names for boys, each cross-joined with 24 lastnames squared). `Person.Key` is `Person.Name`. Two independent `.Take(10)` calls can return rows that share the same generated `Name`, so the second batch's `AddOrUpdate` sees one of its rows as an existing key and emits 9 Adds + 1 Update instead of 10 Adds + 0 Updates.

The probability is small per row, but two `Take(10)` calls draw 20 rows into the same key space; birthday-paradox math puts the collision rate at roughly 0.3%. That matches the observed CI failure frequency for these two tests.

## Fix

Draw a larger candidate pool (60 rows), dedupe by `Key`, take the first 20 distinct, and split into two non-overlapping batches of 10. No production code changes.

## Verification

50 consecutive runs of `SizeLimitFixture` on the branch, zero failures. Targeted command:

```pwsh
for ($i=1; $i -le 50; $i++) {
  dotnet test ... --filter "FullyQualifiedName~SizeLimitFixture"
}
```