### PR TITLE
Restore stable 9.4 versioning on release/9.x

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
-    "version": "9.5-preview.{height}",
+    "version": "9.4",
+    "versionHeightOffset": 31,
     "publicReleaseRefSpec": [
         "^refs/heads/main$", // main publishes pre-release packages
         "^refs/heads/release/\\d+\\.x$" // release/<major>.x branches publish stable packages


### PR DESCRIPTION
## Problem

`release/9.x` cannot publish. PR #1088 overwrote this branch''s `version.json` with main''s preview line, so HEAD declares `"version": "9.5-preview.{height}"`. NBGV computes `9.5.0-preview.2`, and the policy step in `release.yml` refuses to publish a prerelease from a `release/*.x` branch, so the branch is stuck.

## Fix

Restore the stable form. This branch ships stable `9.4.x`, and the latest published version (the tag on this repo and the package on NuGet.org) is `9.4.31`:

```json
"version": "9.4",
"versionHeightOffset": 31,
```

The base-version flip `9.4 -> 9.5 -> 9.4` resets NBGV''s git height to 1 on the commit that re-introduces `9.4`, so the offset is required to keep the patch number continuous.

## Verification

`nbgv get-version`, evaluated on the post-merge topology (one commit on the current HEAD, on a `release/9.x` ref):

| Field | Value |
| --- | --- |
| SemVer2 | 9.4.32 |
| PrereleaseVersion | (empty) |
| PublicRelease | True |

Next publish is a clean stable `9.4.32`, continuing from `9.4.31`. Offset 31 is the minimum safe value; 30 would compute `9.4.31` and collide with the existing release.

## Label

Labeled `manual-version-edit` so `pr-version-check.yml` permits the hand edit. This is the recovery case the label is documented for.
