### PR TITLE
Fixed that the Build and Release action defined in release.yml was attempting to publish a bogus "empty.nupkg" file…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $packages = Get-ChildItem -Path src -Recurse -Filter '*.nupkg' | Where-Object { $_.FullName -like '*\bin\Release\*' }
+        $packages = Get-ChildItem -Path src -Recurse -Filter 'DynamicData.*.nupkg' | Where-Object { $_.FullName -like '*\bin\Release\*' }
         if (-not $packages) { throw "No .nupkg files found under src/**/bin/Release/." }
         foreach ($pkg in $packages) {
           dotnet nuget push -s $env:SOURCE_URL -k $env:NUGET_AUTH_TOKEN --skip-duplicate $pkg.FullName


### PR DESCRIPTION
… that exists in the normal build output of the DynamicData.Tests project, as a part of the EmptyFiles package, since the job was written to search for "*.nupkg".

The job has been adjusted to only look for "DynamicData.*.nupkg" files.