### PR TITLE
ci: adopt GitReleaseNoteGenerator and nbgv CLI tool

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,12 +37,20 @@ jobs:
             **/global.json
             **/nuget.config
 
-    - name: NBGV
+    - name: Install (or update) nbgv tool
+      run: dotnet tool update --global nbgv
+
+    - name: Set NBGV cloud variables
+      run: nbgv cloud -a
+
+    - name: Expose NBGV version as step outputs
       id: nbgv
-      uses: dotnet/nbgv@v0.5.2
-      with:
-        setAllVars: true
-        
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        "SemVer2=$env:NBGV_SemVer2" >> $env:GITHUB_OUTPUT
+        "PrereleaseVersion=$env:NBGV_PrereleaseVersion" >> $env:GITHUB_OUTPUT
+
     - name: NuGet Restore
       run: dotnet restore DynamicData.sln
       working-directory: src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,19 @@ jobs:
             **/global.json
             **/nuget.config
 
-    - name: NBGV
+    - name: Install (or update) nbgv tool
+      run: dotnet tool update --global nbgv
+
+    - name: Set NBGV cloud variables
+      run: nbgv cloud -a
+
+    - name: Expose NBGV version as step outputs
       id: nbgv
-      uses: dotnet/nbgv@v0.5.2
-      with:
-        setAllVars: true
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        "SemVer2=$env:NBGV_SemVer2" >> $env:GITHUB_OUTPUT
+        "PrereleaseVersion=$env:NBGV_PrereleaseVersion" >> $env:GITHUB_OUTPUT
 
     - name: Verify version matches branch policy
       shell: pwsh
@@ -126,21 +134,24 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "dotnet nuget push failed for $($pkg.Name) (exit $LASTEXITCODE)." }
         }
 
-    - name: Changelog
-      uses: glennawatson/ChangeLog@0464dd89b26f61fecf24b41d675f8ffdb11c4c3f # v1
-      id: changelog
+    - name: Install GitReleaseNoteGenerator
+      run: dotnet tool install -g GitReleaseNoteGenerator
+
+    - name: Generate release notes
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        RELEASE_VERSION: ${{ steps.nbgv.outputs.SemVer2 }}
+      shell: pwsh
+      run: git-release-notes --release-version "$env:RELEASE_VERSION" --output-file release-notes.md
 
     - name: Create GitHub Release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.nbgv.outputs.SemVer2 }}
         IS_PRERELEASE: ${{ steps.nbgv.outputs.PrereleaseVersion != '' }}
-        BODY: ${{ steps.changelog.outputs.commitLog }}
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        $notesPath = Join-Path $env:RUNNER_TEMP 'release-notes.md'
-        Set-Content -Path $notesPath -Value $env:BODY -Encoding utf8 -NoNewline
-        $cmd = @('release', 'create', $env:TAG, '--title', $env:TAG, '--notes-file', $notesPath, '--target', $env:GITHUB_SHA)
+        $cmd = @('release', 'create', $env:TAG, '--title', $env:TAG, '--notes-file', 'release-notes.md', '--target', $env:GITHUB_SHA)
         if ($env:IS_PRERELEASE -eq 'true') { $cmd += '--prerelease' }
         gh @cmd


### PR DESCRIPTION
Resolves #1093.

## What

Move the release pipeline's note generation and version stamping off two stale GitHub Actions and onto the same dotnet global tools the reactiveui pipeline uses, while keeping Nerdbank.GitVersioning as the version source. (@JakenVeina mentioned that as a preference)

## Changes

- Release notes: replace the `glennawatson/ChangeLog` action with the `GitReleaseNoteGenerator` global tool (`git-release-notes`), generating a `release-notes.md` that is passed to `gh release create`. This matches the reactiveui/actions-common approach referenced in #1093.
- Versioning: replace the `dotnet/nbgv@v0.5.2` JS action (outdated, old Node runtime issues) with the `nbgv` dotnet global tool. `nbgv cloud -a` stamps the `NBGV_*` cloud variables (preserving the old `setAllVars` behaviour) and a follow-up step exposes `SemVer2`/`PrereleaseVersion` as step outputs.
- Applied the nbgv tool swap to both `release.yml` and `ci-build.yml`.

## Not changed

- Still on Nerdbank.GitVersioning (`version.json`); the version selection is unchanged.
- All branch/version policy validation steps are untouched.

## Notes

* Closes #1093
* The GitReleaseNoteGenerator is a newer version of ChangeLog, written in C# instead with some newer features. I stopped supporting the old ChangeLog in favour of the global tool.