### PR TITLE
Fixed that `.Edit()` operations would not defer notifications for new subscriptions occurring during the edit.

### DIFF
--- a/src/DynamicData.Benchmarks/Miscellaneous/LockImplementations.cs
+++ b/src/DynamicData.Benchmarks/Miscellaneous/LockImplementations.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace DynamicData.Benchmarks.Miscellaneous;
+
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class LockImplementations
+{
+    public LockImplementations()
+    {
+        _objectGate     = new();
+        _threadingGate  = new();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int NoLock()
+    {
+        return 0;
+    }
+
+    [Benchmark]
+    public int ObjectLock()
+    {
+        lock (_objectGate)
+        {
+            return 0;
+        }
+    }
+
+    [Benchmark]
+    public int ThreadingLock()
+    {
+        lock (_threadingGate)
+        {
+            return 0;
+        }
+    }
+
+    private readonly object _objectGate;
+    private readonly Lock   _threadingGate;
+}

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -163,8 +163,6 @@ public class SourceCacheFixture : IDisposable
         change!.Count.Should().Be(0);
     }
 
-
-
     [Fact]
     public void StaticFilterRemove()
     {
@@ -191,7 +189,6 @@ public class SourceCacheFixture : IDisposable
     }
 
     public record class SomeObject(int Id, int Value);
-
 
     [Fact]
     public async Task MultiCacheFanInDoesNotDeadlock()
@@ -403,6 +400,23 @@ public class SourceCacheFixture : IDisposable
             "all items in the source should have propagated downstream");
 
         results.HasCompleted.Should().BeFalse("the source has not yet completed");
+    }
+
+    [Fact]
+    public void ConnectContinuesToWorkNormallyAfterAFailedEdit()
+    {
+        using var source = new SourceCache<int, int>(static item => item);
+    
+        source.AddOrUpdate(1);
+
+        source.Invoking(source => source.Edit(_ => throw new Exception("Test")))
+            .Should().Throw<Exception>()
+            .WithMessage("Test");
+
+        using var subscription = source.Connect().RecordCacheItems(out var results);
+
+        results.Error.Should().BeNull("new subscribers should not receive previous errors");
+        results.RecordedChangeSets.Should().ContainSingle("an initial changeset should have been published.");
     }
 
     private sealed record TestItem(string Key, string Value);

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -354,7 +354,7 @@ public class SourceCacheFixture : IDisposable
 
     // Covers https://github.com/reactivemarbles/DynamicData/issues/1129
     [Fact]
-    public void ConnectDuringEditDoesNotDuplicate()
+    public void ConnectDuringEditsDoesNotDuplicate()
     {
         using var items = new SourceCache<int, int>(static item => item);
         
@@ -385,17 +385,20 @@ public class SourceCacheFixture : IDisposable
 
             results.Error.Should().BeNull("no errors should have occurred");
             results.RecordedChangeSets.Should().BeEmpty("no changes should be published in the middle of an edit");
+
+            // Explicitly doing a nested edit, as that system is closely intertwined with the edit-tracking system that
+            // .Connect() uses.
+            items.Remove(item: 1);
+
+            results.Error.Should().BeNull("no errors should have occurred");
+            results.RecordedChangeSets.Should().BeEmpty("no changes should be published in the middle of an edit");
         });
         
         results.Should().NotBeNull("the edit delegate should have been invoked");
         results.Error.Should().BeNull("no errors should have occurred");
         results.RecordedChangeSets.Should().ContainSingle("subscribers should only receive a single initial changeset");
         results.RecordedItemsByKey.Should().BeEquivalentTo(
-            new Dictionary<int, int>()
-            {
-                [1] = 1,
-                [2] = 2
-            },
+            new Dictionary<int, int>() { [2] = 2 },
             options => options.WithoutStrictOrdering(),
             "all items in the source should have propagated downstream");
 

--- a/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
+++ b/src/DynamicData.Tests/Cache/SourceCacheFixture.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using DynamicData.Tests.Domain;
-
+using DynamicData.Tests.Utilities;
 using FluentAssertions;
 
 using Xunit;
@@ -352,6 +353,56 @@ public class SourceCacheFixture : IDisposable
         // Each key should appear exactly once in the new subscriber's view
         addCounts.GetValueOrDefault("k1").Should().Be(1, "k1 should appear once (snapshot only)");
         addCounts.GetValueOrDefault("k2").Should().Be(1, "k2 should appear once, not duplicated from snapshot + queued delivery");
+    }
+
+    // Covers https://github.com/reactivemarbles/DynamicData/issues/1129
+    [Fact]
+    public void ConnectDuringEditDoesNotDuplicate()
+    {
+        using var items = new SourceCache<int, int>(static item => item);
+        
+        using var subscriptions = new CompositeDisposable();
+        
+        // An initial subscription is required to initiate internal buffering of changes, during the upcoming .Edit().
+        // That is, we want there to be changes buffered, internally, when the mid-edit subscription comes in, to
+        // ensure that they don't get duplicated. This is the scenario that came in up #1129. 
+        subscriptions.Add(items
+            .Connect()
+            .Subscribe());
+            
+        CacheItemRecordingObserver<int, int>? results = null;
+            
+        items.Edit(inner =>
+        {
+            inner.AddOrUpdate(1);
+
+            subscriptions.Add(items
+                .Connect()
+                .ValidateChangeSets(static item => item)
+                .RecordCacheItems(out results));
+        
+            results.Error.Should().BeNull("no errors should have occurred");
+            results.RecordedChangeSets.Should().BeEmpty("no changes should be published in the middle of an edit");
+        
+            inner.AddOrUpdate(2);
+
+            results.Error.Should().BeNull("no errors should have occurred");
+            results.RecordedChangeSets.Should().BeEmpty("no changes should be published in the middle of an edit");
+        });
+        
+        results.Should().NotBeNull("the edit delegate should have been invoked");
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedChangeSets.Should().ContainSingle("subscribers should only receive a single initial changeset");
+        results.RecordedItemsByKey.Should().BeEquivalentTo(
+            new Dictionary<int, int>()
+            {
+                [1] = 1,
+                [2] = 2
+            },
+            options => options.WithoutStrictOrdering(),
+            "all items in the source should have propagated downstream");
+
+        results.HasCompleted.Should().BeFalse("the source has not yet completed");
     }
 
     private sealed record TestItem(string Key, string Value);

--- a/src/DynamicData.Tests/List/SourceListFixture.cs
+++ b/src/DynamicData.Tests/List/SourceListFixture.cs
@@ -71,4 +71,21 @@ public class SourceListFixture
         changeSets[0].First().Type.Should().Be(ChangeType.Range);
         changeSets[0].First().Range.Index.Should().Be(0);
     }
+
+    [Fact]
+    public void ConnectContinuesToWorkNormallyAfterAFailedEdit()
+    {
+        using var source = new SourceList<int>();
+    
+        source.Add(1);
+
+        source.Invoking(source => source.Edit(_ => throw new Exception("Test")))
+            .Should().Throw<Exception>()
+            .WithMessage("Test");
+
+        using var subscription = source.Connect().RecordListItems(out var results);
+
+        results.Error.Should().BeNull("new subscribers should not receive previous errors");
+        results.RecordedChangeSets.Should().ContainSingle("an initial changeset should have been published.");
+    }
 }

--- a/src/DynamicData.Tests/List/SourceListFixture.cs
+++ b/src/DynamicData.Tests/List/SourceListFixture.cs
@@ -1,13 +1,63 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
+
 using FluentAssertions;
 using Xunit;
+
+using DynamicData.Tests.Utilities;
 
 namespace DynamicData.Tests.List;
 
 public class SourceListFixture
 {
+    // Covers https://github.com/reactivemarbles/DynamicData/issues/1129
+    [Fact]
+    public void ConnectDuringEditDoesNotDuplicate()
+    {
+        using var items = new SourceList<int>();
+        
+        using var subscriptions = new CompositeDisposable();
+        
+        // An initial subscription is required to initiate internal buffering of changes, during the upcoming .Edit().
+        // That is, we want there to be changes buffered, internally, when the mid-edit subscription comes in, to
+        // ensure that they don't get duplicated. This is the scenario that came in up #1129. 
+        subscriptions.Add(items
+            .Connect()
+            .Subscribe());
+            
+        ListItemRecordingObserver<int>? results = null;
+            
+        items.Edit(inner =>
+        {
+            inner.Add(1);
+
+            subscriptions.Add(items
+                .Connect()
+                .ValidateChangeSets()
+                .RecordListItems(out results));
+        
+            results.Error.Should().BeNull("no errors should have occurred");
+            results.RecordedChangeSets.Should().BeEmpty("no changes should be published in the middle of an edit");
+        
+            inner.Add(2);
+
+            results.Error.Should().BeNull("no errors should have occurred");
+            results.RecordedChangeSets.Should().BeEmpty("no changes should be published in the middle of an edit");
+        });
+        
+        results.Should().NotBeNull("the edit delegate should have been invoked");
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedChangeSets.Should().ContainSingle("subscribers should only receive a single initial changeset");
+        results.RecordedItems.Should().BeEquivalentTo(
+            new[] { 1, 2, },
+            options => options.WithStrictOrdering(),
+            "all items in the source should have propagated downstream");
+
+        results.HasCompleted.Should().BeFalse("the source has not yet completed");
+    }
+
     [Fact]
     public void InitialChangeIsRange()
     {

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -198,24 +198,29 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         _editLevel++;
         _isEditInProgress.OnNext(_editLevel is not 0);
-        if (_editLevel == 1)
+        try
         {
-            var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
-            changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
+            if (_editLevel == 1)
+            {
+                var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
+                changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
+            }
+            else
+            {
+                _readerWriter.WriteNested(updateAction);
+            }
         }
-        else
+        finally
         {
-            _readerWriter.WriteNested(updateAction);
+            _editLevel--;
+
+            if (changes is not null && _editLevel == 0)
+            {
+                notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
+            }
+
+            _isEditInProgress.OnNext(_editLevel is not 0);
         }
-
-        _editLevel--;
-
-        if (changes is not null && _editLevel == 0)
-        {
-            notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
-        }
-
-        _isEditInProgress.OnNext(_editLevel is not 0);
     }
 
     internal void UpdateFromSource(Action<ISourceUpdater<TObject, TKey>> updateAction)
@@ -228,24 +233,29 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
         _editLevel++;
         _isEditInProgress.OnNext(_editLevel is not 0);
-        if (_editLevel == 1)
+        try
         {
-            var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
-            changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
+            if (_editLevel == 1)
+            {
+                var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
+                changes = _readerWriter.Write(updateAction, previewHandler, _changes.HasObservers);
+            }
+            else
+            {
+                _readerWriter.WriteNested(updateAction);
+            }
         }
-        else
+        finally
         {
-            _readerWriter.WriteNested(updateAction);
+            _editLevel--;
+
+            if (changes is not null && _editLevel == 0)
+            {
+                notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
+            }
+
+            _isEditInProgress.OnNext(_editLevel is not 0);
         }
-
-        _editLevel--;
-
-        if (changes is not null && _editLevel == 0)
-        {
-            notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
-        }
-
-        _isEditInProgress.OnNext(_editLevel is not 0);
     }
 
     private IObservable<IChangeSet<TObject, TKey>> CreateConnectObservable(Func<TObject, bool>? predicate, bool suppressEmptyChangeSets) =>

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -119,22 +119,41 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             lock (_locker)
             {
-                var observable = ((!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
-                        && (!_isEditInProgress.Value))
+                var observable = (
+                        _suspensionTracker.IsValueCreated,
+                        _isEditInProgress.Value)
+                    switch
+                    {
+                        // No suspensions or edits active, create the connection immediately.
+                        (false, false) => CreateConnectObservable(predicate, suppressEmptyChangeSets),
 
-                    // Create the Connection Observable
-                    ? CreateConnectObservable(predicate, suppressEmptyChangeSets)
+                        // Edit in progress, but suspension system is inactive
+                        // Need to avoid activating the suspension system if we don't absolutely need to, as it adds
+                        // locking overhead to edit operations. But then when the edit is done, we need to check if a
+                        // suspension came in. If so, do a followup wait with the full logic for both systems. It
+                        // needs to be the full logic, in case an edit comes in during the suspension, and so on.
+                        (false, true) => _isEditInProgress
+                            .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
+                            .Take(1)
+                            .Select(_ => CreateFullyDeferredConnection())
+                            .Switch(),
 
-                    // Defer until notifications are no longer suspended
-                    : Observable.CombineLatest(
+                        // If the suspension system is already active, we can monitor both systems simultaneously, and
+                        // make the connection as soon as both are idle at the same time.
+                        _ => CreateFullyDeferredConnection()
+                    };
+
+                return observable.SubscribeSafe(observer);
+
+                IObservable<IChangeSet<TObject, TKey>> CreateFullyDeferredConnection()
+                    => Observable.CombineLatest(
                             _suspensionTracker.Value.NotificationsSuspendedObservable,
                             _isEditInProgress,
                             static (areNotificationsSuspended, isEditInProgress) => areNotificationsSuspended || isEditInProgress)
+                        .Do(static _ => { }, observer.OnCompleted)
                         .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
                         .Take(1)
                         .SelectMany(_ => CreateConnectObservable(predicate, suppressEmptyChangeSets));
-
-                return observable.SubscribeSafe(observer);
             }
         });
 

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -42,7 +42,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     private readonly DeliveryQueue<CacheUpdate> _notifications;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed with _cleanUp")]
-    private readonly BehaviorSubject<bool> _isEditInProgress;
+    private readonly Lazy<BehaviorSubject<bool>> _isEditInProgress;
 
     private int _editLevel; // The level of recursion in editing.
 
@@ -55,7 +55,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         _readerWriter = new ReaderWriter<TObject, TKey>();
         _notifications = new DeliveryQueue<CacheUpdate>(_locker, new CacheUpdateObserver(this));
         _suspensionTracker = new(() => new SuspensionTracker());
-        _isEditInProgress = new(false);
+        _isEditInProgress = new(() => new(_editLevel is not 0));
 
         var loader = source.Subscribe(
             changeSet =>
@@ -86,7 +86,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         _readerWriter = new ReaderWriter<TObject, TKey>(keySelector);
         _notifications = new DeliveryQueue<CacheUpdate>(_locker, new CacheUpdateObserver(this));
         _suspensionTracker = new(() => new SuspensionTracker());
-        _isEditInProgress = new(false);
+        _isEditInProgress = new(() => new(_editLevel is not 0));
 
         _cleanUp = Disposable.Create(NotifyCompleted);
     }
@@ -114,48 +114,10 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     public IReadOnlyDictionary<TKey, TObject> KeyValues => _readerWriter.KeyValues;
 
-    public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool>? predicate = null, bool suppressEmptyChangeSets = true) =>
-        Observable.Create<IChangeSet<TObject, TKey>>(observer =>
-        {
-            lock (_locker)
-            {
-                var observable = (
-                        _suspensionTracker.IsValueCreated,
-                        _isEditInProgress.Value)
-                    switch
-                    {
-                        // No suspensions or edits active, create the connection immediately.
-                        (false, false) => CreateConnectObservable(predicate, suppressEmptyChangeSets),
-
-                        // Edit in progress, but suspension system is inactive
-                        // Need to avoid activating the suspension system if we don't absolutely need to, as it adds
-                        // locking overhead to edit operations. But then when the edit is done, we need to check if a
-                        // suspension came in. If so, do a followup wait with the full logic for both systems. It
-                        // needs to be the full logic, in case an edit comes in during the suspension, and so on.
-                        (false, true) => _isEditInProgress
-                            .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
-                            .Take(1)
-                            .Select(_ => CreateFullyDeferredConnection())
-                            .Switch(),
-
-                        // If the suspension system is already active, we can monitor both systems simultaneously, and
-                        // make the connection as soon as both are idle at the same time.
-                        _ => CreateFullyDeferredConnection()
-                    };
-
-                return observable.SubscribeSafe(observer);
-
-                IObservable<IChangeSet<TObject, TKey>> CreateFullyDeferredConnection()
-                    => Observable.CombineLatest(
-                            _suspensionTracker.Value.NotificationsSuspendedObservable,
-                            _isEditInProgress,
-                            static (areNotificationsSuspended, isEditInProgress) => areNotificationsSuspended || isEditInProgress)
-                        .Do(static _ => { }, observer.OnCompleted)
-                        .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
-                        .Take(1)
-                        .SelectMany(_ => CreateConnectObservable(predicate, suppressEmptyChangeSets));
-            }
-        });
+    public IObservable<IChangeSet<TObject, TKey>> Connect(
+            Func<TObject, bool>? predicate = null,
+            bool suppressEmptyChangeSets = true)
+        => CreateDeferredNotificationObservable(() => CreateConnectObservable(predicate, suppressEmptyChangeSets));
 
     public void Dispose() => _cleanUp.Dispose();
 
@@ -163,29 +125,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
     public IObservable<IChangeSet<TObject, TKey>> Preview(Func<TObject, bool>? predicate = null) => predicate is null ? _changesPreview : _changesPreview.Filter(predicate);
 
-    public IObservable<Change<TObject, TKey>> Watch(TKey key) =>
-        Observable.Create<Change<TObject, TKey>>(observer =>
-        {
-            lock (_locker)
-            {
-                var observable = ((!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
-                        && (!_isEditInProgress.Value))
-
-                    // Create the Watch Observable
-                    ? CreateWatchObservable(key)
-
-                    // Defer until notifications are no longer suspended
-                    : Observable.CombineLatest(
-                            _suspensionTracker.Value.NotificationsSuspendedObservable,
-                            _isEditInProgress,
-                            static (areNotificationsSuspended, isEditInProgress) => areNotificationsSuspended || isEditInProgress)
-                        .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
-                        .Take(1)
-                        .SelectMany(_ => CreateWatchObservable(key));
-
-                return observable.SubscribeSafe(observer);
-            }
-        });
+    public IObservable<Change<TObject, TKey>> Watch(TKey key)
+        => CreateDeferredNotificationObservable(() => CreateWatchObservable(key));
 
     public IDisposable SuspendCount()
     {
@@ -216,7 +157,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         ChangeSet<TObject, TKey>? changes = null;
 
         _editLevel++;
-        _isEditInProgress.OnNext(_editLevel is not 0);
+        if (_isEditInProgress.IsValueCreated)
+            _isEditInProgress.Value.OnNext(_editLevel is not 0);
         try
         {
             if (_editLevel == 1)
@@ -238,7 +180,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
             }
 
-            _isEditInProgress.OnNext(_editLevel is not 0);
+            if (_isEditInProgress.IsValueCreated)
+                _isEditInProgress.Value.OnNext(_editLevel is not 0);
         }
     }
 
@@ -251,7 +194,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         ChangeSet<TObject, TKey>? changes = null;
 
         _editLevel++;
-        _isEditInProgress.OnNext(_editLevel is not 0);
+        if (_isEditInProgress.IsValueCreated)
+            _isEditInProgress.Value.OnNext(_editLevel is not 0);
         try
         {
             if (_editLevel == 1)
@@ -273,7 +217,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
             }
 
-            _isEditInProgress.OnNext(_editLevel is not 0);
+            if (_isEditInProgress.IsValueCreated)
+                _isEditInProgress.Value.OnNext(_editLevel is not 0);
         }
     }
 
@@ -306,6 +251,65 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
                 return changes.SubscribeSafe(observer);
             });
+
+    private IObservable<T> CreateDeferredNotificationObservable<T>(Func<IObservable<T>> factory)
+        => Observable.Create<T>(observer =>
+        {
+            lock (_locker)
+            {
+                var observable = (
+                        // A suspension can't be in-progress if the suspension system hasn't been activated.
+                        _suspensionTracker.IsValueCreated,
+                        // An edit can be in-progress before the edit-tracking notification system is activated, so this
+                        // one needs an extra check.
+                        _isEditInProgress.IsValueCreated || (_editLevel is not 0))
+                    switch
+                    {
+                        // Neither the suspension system nor the edit system is active, create the connection
+                        // immediately.
+                        (false, false) => factory.Invoke(),
+
+                        // Edit system is active, suspension system isn't
+                        // Need to avoid activating the suspension system if we don't absolutely need to, as it adds
+                        // locking overhead to edit operations. But then when the edit is done, we need to check if a
+                        // suspension came in. If so, do a followup wait with the full logic for both systems. It
+                        // needs to be the full logic, in case an edit comes in during the suspension, and so on.
+                        (false, true) => _isEditInProgress.Value
+                            .Where(static isEditInProgress => !isEditInProgress)
+                            .Take(1)
+                            .SelectMany(_ => (_suspensionTracker.IsValueCreated && _suspensionTracker.Value.AreNotificationsSuspended)
+                                ? CreateFullyDeferredConnection()
+                                : factory.Invoke()),
+
+                        // Suspension system is active, edit system isn't
+                        // Same case as above, but reversed. Just wait on the suspension system, but then do a followup
+                        // wait if needed.
+                        (true, false) => _suspensionTracker.Value.NotificationsSuspendedObservable
+                            .Where(static isSuspensionInProgress => !isSuspensionInProgress)
+                            .Take(1)
+                            .SelectMany(_ => (_isEditInProgress.IsValueCreated && _isEditInProgress.Value.Value)
+                                ? CreateFullyDeferredConnection()
+                                : factory.Invoke()),
+
+                        // If both systems are already active, we can monitor both systems simultaneously, and make the
+                        // connection as soon as both are idle at the same time.
+                        _ => CreateFullyDeferredConnection()
+                    };
+
+                return observable.SubscribeSafe(observer);
+
+                IObservable<T> CreateFullyDeferredConnection()
+                    => Observable.CombineLatest(
+                            _suspensionTracker.Value.NotificationsSuspendedObservable,
+                            _isEditInProgress.Value,
+                            static (areNotificationsSuspended, isEditInProgress) => areNotificationsSuspended || isEditInProgress)
+                        .Do(static _ => { }, observer.OnCompleted)
+                        .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
+                        .Take(1)
+                        .Select(_ => factory.Invoke())
+                        .Switch();
+            }
+        });
 
     private IObservable<Change<TObject, TKey>> CreateWatchObservable(TKey key) =>
         Observable.Create<Change<TObject, TKey>>(
@@ -437,7 +441,11 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             cache._changesPreview.OnError(error);
             cache._changes.OnError(error);
-            cache._isEditInProgress.OnError(error);
+
+            if (cache._isEditInProgress.IsValueCreated)
+            {
+                cache._isEditInProgress.Value.OnError(error);
+            }
 
             if (cache._countChanged.IsValueCreated)
             {
@@ -454,7 +462,11 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             cache._changes.OnCompleted();
             cache._changesPreview.OnCompleted();
-            cache._isEditInProgress.OnCompleted();
+
+            if (cache._isEditInProgress.IsValueCreated)
+            {
+                cache._isEditInProgress.Value.OnCompleted();
+            }
 
             if (cache._countChanged.IsValueCreated)
             {

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -6,9 +6,8 @@ using System.Diagnostics;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Threading;
+
 using DynamicData.Binding;
-using DynamicData.Cache;
 using DynamicData.Cache.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -42,6 +41,9 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Terminated via NotifyCompleted in _cleanUp")]
     private readonly DeliveryQueue<CacheUpdate> _notifications;
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed with _cleanUp")]
+    private readonly BehaviorSubject<bool> _isEditInProgress;
+
     private int _editLevel; // The level of recursion in editing.
 
     private long _currentVersion; // Monotonic counter incremented under lock for each enqueued change notification.
@@ -53,6 +55,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         _readerWriter = new ReaderWriter<TObject, TKey>();
         _notifications = new DeliveryQueue<CacheUpdate>(_locker, new CacheUpdateObserver(this));
         _suspensionTracker = new(() => new SuspensionTracker());
+        _isEditInProgress = new(false);
 
         var loader = source.Subscribe(
             changeSet =>
@@ -83,6 +86,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         _readerWriter = new ReaderWriter<TObject, TKey>(keySelector);
         _notifications = new DeliveryQueue<CacheUpdate>(_locker, new CacheUpdateObserver(this));
         _suspensionTracker = new(() => new SuspensionTracker());
+        _isEditInProgress = new(false);
 
         _cleanUp = Disposable.Create(NotifyCompleted);
     }
@@ -115,17 +119,18 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             lock (_locker)
             {
-                var observable = (!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
+                var observable = ((!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
+                        && (!_isEditInProgress.Value))
 
                     // Create the Connection Observable
                     ? CreateConnectObservable(predicate, suppressEmptyChangeSets)
 
-                    // Defer until notifications are no longer suspended. Take(1) means there is only
-                    // ever one inner sequence, so SelectMany carries the terminal event of the gate
-                    // through on its own: the connection ends when the cache does, and fails when it
-                    // fails, rather than reporting a failure as a successful completion.
-                    : _suspensionTracker.Value.NotificationsSuspendedObservable
-                        .Where(static areNotificationsSuspended => !areNotificationsSuspended)
+                    // Defer until notifications are no longer suspended
+                    : Observable.CombineLatest(
+                            _suspensionTracker.Value.NotificationsSuspendedObservable,
+                            _isEditInProgress,
+                            static (areNotificationsSuspended, isEditInProgress) => areNotificationsSuspended || isEditInProgress)
+                        .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
                         .Take(1)
                         .SelectMany(_ => CreateConnectObservable(predicate, suppressEmptyChangeSets));
 
@@ -144,15 +149,18 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             lock (_locker)
             {
-                var observable = (!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
+                var observable = ((!_suspensionTracker.IsValueCreated || !_suspensionTracker.Value.AreNotificationsSuspended)
+                        && (!_isEditInProgress.Value))
 
                     // Create the Watch Observable
                     ? CreateWatchObservable(key)
 
-                    // Defer until notifications are no longer suspended. See Connect() for why
-                    // SelectMany is used here.
-                    : _suspensionTracker.Value.NotificationsSuspendedObservable
-                        .Where(static areNotificationsSuspended => !areNotificationsSuspended)
+                    // Defer until notifications are no longer suspended
+                    : Observable.CombineLatest(
+                            _suspensionTracker.Value.NotificationsSuspendedObservable,
+                            _isEditInProgress,
+                            static (areNotificationsSuspended, isEditInProgress) => areNotificationsSuspended || isEditInProgress)
+                        .Where(static shouldConnectionBeDeferred => !shouldConnectionBeDeferred)
                         .Take(1)
                         .SelectMany(_ => CreateWatchObservable(key));
 
@@ -189,6 +197,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         ChangeSet<TObject, TKey>? changes = null;
 
         _editLevel++;
+        _isEditInProgress.OnNext(_editLevel is not 0);
         if (_editLevel == 1)
         {
             var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
@@ -205,6 +214,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
         }
+
+        _isEditInProgress.OnNext(_editLevel is not 0);
     }
 
     internal void UpdateFromSource(Action<ISourceUpdater<TObject, TKey>> updateAction)
@@ -216,6 +227,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         ChangeSet<TObject, TKey>? changes = null;
 
         _editLevel++;
+        _isEditInProgress.OnNext(_editLevel is not 0);
         if (_editLevel == 1)
         {
             var previewHandler = _changesPreview.HasObservers ? (Action<ChangeSet<TObject, TKey>>)InvokePreview : null;
@@ -232,6 +244,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
         }
+
+        _isEditInProgress.OnNext(_editLevel is not 0);
     }
 
     private IObservable<IChangeSet<TObject, TKey>> CreateConnectObservable(Func<TObject, bool>? predicate, bool suppressEmptyChangeSets) =>
@@ -394,6 +408,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             cache._changesPreview.OnError(error);
             cache._changes.OnError(error);
+            cache._isEditInProgress.OnError(error);
 
             if (cache._countChanged.IsValueCreated)
             {
@@ -410,6 +425,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         {
             cache._changes.OnCompleted();
             cache._changesPreview.OnCompleted();
+            cache._isEditInProgress.OnCompleted();
 
             if (cache._countChanged.IsValueCreated)
             {

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -157,8 +157,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         ChangeSet<TObject, TKey>? changes = null;
 
         _editLevel++;
-        if (_isEditInProgress.IsValueCreated)
-            _isEditInProgress.Value.OnNext(_editLevel is not 0);
+        if (_isEditInProgress.IsValueCreated && (_editLevel is 1))
+            _isEditInProgress.Value.OnNext(true);
         try
         {
             if (_editLevel == 1)
@@ -180,8 +180,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
             }
 
-            if (_isEditInProgress.IsValueCreated)
-                _isEditInProgress.Value.OnNext(_editLevel is not 0);
+            if (_isEditInProgress.IsValueCreated && (_editLevel is 0))
+                _isEditInProgress.Value.OnNext(false);
         }
     }
 
@@ -194,8 +194,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
         ChangeSet<TObject, TKey>? changes = null;
 
         _editLevel++;
-        if (_isEditInProgress.IsValueCreated)
-            _isEditInProgress.Value.OnNext(_editLevel is not 0);
+        if (_isEditInProgress.IsValueCreated && (_editLevel is 1))
+            _isEditInProgress.Value.OnNext(true);
         try
         {
             if (_editLevel == 1)
@@ -217,8 +217,8 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                 notifications.EnqueueNext(new CacheUpdate(changes, _readerWriter.Count, ++_currentVersion));
             }
 
-            if (_isEditInProgress.IsValueCreated)
-                _isEditInProgress.Value.OnNext(_editLevel is not 0);
+            if (_isEditInProgress.IsValueCreated && (_editLevel is 0))
+                _isEditInProgress.Value.OnNext(false);
         }
     }
 

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -121,24 +121,33 @@ public sealed class SourceList<T> : ISourceList<T>
 
             _editLevel++;
             _isEditInProgress.OnNext(_editLevel is not 0);
-
-            if (_editLevel == 1)
+            try
             {
-                changes = _changesPreview.HasObservers ? _readerWriter.WriteWithPreview(updateAction, InvokeNextPreview) : _readerWriter.Write(updateAction);
+                try
+                {
+                    if (_editLevel == 1)
+                    {
+                        changes = _changesPreview.HasObservers ? _readerWriter.WriteWithPreview(updateAction, InvokeNextPreview) : _readerWriter.Write(updateAction);
+                    }
+                    else
+                    {
+                        _readerWriter.WriteNested(updateAction);
+                    }
+                }
+                finally
+                {
+                    _editLevel--;
+                }
+
+                if (changes is not null && (_editLevel is 0))
+                {
+                    InvokeNext(changes);
+                }
             }
-            else
+            finally
             {
-                _readerWriter.WriteNested(updateAction);
+                _isEditInProgress.OnNext(_editLevel is not 0);
             }
-
-            _editLevel--;
-
-            if (changes is not null && _editLevel == 0)
-            {
-                InvokeNext(changes);
-            }
-
-            _isEditInProgress.OnNext(_editLevel is not 0);
         }
     }
 

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -37,7 +37,7 @@ public sealed class SourceList<T> : ISourceList<T>
     private readonly ReaderWriter<T> _readerWriter = new();
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposal is superfluous after completion, and causes a bunch of test failures")]
-    private readonly BehaviorSubject<bool> _isEditInProgress;
+    private readonly Lazy<BehaviorSubject<bool>> _isEditInProgress;
 
     private int _editLevel;
 
@@ -47,7 +47,7 @@ public sealed class SourceList<T> : ISourceList<T>
     /// <param name="source">The source.</param>
     public SourceList(IObservable<IChangeSet<T>>? source = null)
     {
-        _isEditInProgress = new(false);
+        _isEditInProgress = new(() => new(_editLevel is not 0));
 
         var loader = source is null ? Disposable.Empty : LoadFromSource(source);
 
@@ -87,16 +87,16 @@ public sealed class SourceList<T> : ISourceList<T>
         {
             lock (_locker)
             {
-                var observable = !_isEditInProgress.Value
+                var observable = _isEditInProgress.IsValueCreated || (_editLevel is not 0)
 
-                    // Create the Connection Observable
-                    ? CreateConnectObservable(predicate)
-
-                    // Defer until notifications are no longer suspended
-                    : _isEditInProgress
+                    // Defer connection until there is no longer an in-progress edit.
+                    ? _isEditInProgress.Value
                         .Where(static isEditInProgress => !isEditInProgress)
                         .Take(1)
-                        .SelectMany(_ => CreateConnectObservable(predicate));
+                        .SelectMany(_ => CreateConnectObservable(predicate))
+
+                    // Otherwise, just connect immediately, and avoid forcing the edit-tracking system to initialize.
+                    : CreateConnectObservable(predicate);
 
                 return observable.SubscribeSafe(observer);
             }
@@ -123,7 +123,8 @@ public sealed class SourceList<T> : ISourceList<T>
             IChangeSet<T>? changes = null;
 
             _editLevel++;
-            _isEditInProgress.OnNext(_editLevel is not 0);
+            if (_isEditInProgress.IsValueCreated && (_editLevel is 1))
+                _isEditInProgress.Value.OnNext(true);
             try
             {
                 try
@@ -149,7 +150,8 @@ public sealed class SourceList<T> : ISourceList<T>
             }
             finally
             {
-                _isEditInProgress.OnNext(_editLevel is not 0);
+                if (_isEditInProgress.IsValueCreated && (_editLevel is 0))
+                    _isEditInProgress.Value.OnNext(false);
             }
         }
     }
@@ -236,7 +238,8 @@ public sealed class SourceList<T> : ISourceList<T>
         {
             _changesPreview.OnCompleted();
             _changes.OnCompleted();
-            _isEditInProgress.OnCompleted();
+            if (_isEditInProgress.IsValueCreated)
+                _isEditInProgress.Value.OnCompleted();
         }
     }
 
@@ -246,7 +249,8 @@ public sealed class SourceList<T> : ISourceList<T>
         {
             _changesPreview.OnError(exception);
             _changes.OnError(exception);
-            _isEditInProgress.OnError(exception);
+            if (_isEditInProgress.IsValueCreated)
+                _isEditInProgress.Value.OnError(exception);
         }
     }
 }

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -36,6 +36,9 @@ public sealed class SourceList<T> : ISourceList<T>
 
     private readonly ReaderWriter<T> _readerWriter = new();
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposal is superfluous after completion, and causes a bunch of test failures")]
+    private readonly BehaviorSubject<bool> _isEditInProgress;
+
     private int _editLevel;
 
     /// <summary>
@@ -44,6 +47,8 @@ public sealed class SourceList<T> : ISourceList<T>
     /// <param name="source">The source.</param>
     public SourceList(IObservable<IChangeSet<T>>? source = null)
     {
+        _isEditInProgress = new(false);
+
         var loader = source is null ? Disposable.Empty : LoadFromSource(source);
 
         _cleanUp = Disposable.Create(
@@ -78,6 +83,79 @@ public sealed class SourceList<T> : ISourceList<T>
 
     /// <inheritdoc />
     public IObservable<IChangeSet<T>> Connect(Func<T, bool>? predicate = null)
+        => Observable.Create<IChangeSet<T>>(observer =>
+        {
+            lock (_locker)
+            {
+                var observable = !_isEditInProgress.Value
+
+                    // Create the Connection Observable
+                    ? CreateConnectObservable(predicate)
+
+                    // Defer until notifications are no longer suspended
+                    : _isEditInProgress
+                        .Where(static isEditInProgress => !isEditInProgress)
+                        .Take(1)
+                        .SelectMany(_ => CreateConnectObservable(predicate));
+
+                return observable.SubscribeSafe(observer);
+            }
+        });
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cleanUp.Dispose();
+        _changesPreview.Dispose();
+        _isEditInProgress.OnCompleted();
+    }
+
+    /// <inheritdoc />
+    public void Edit(Action<IExtendedList<T>> updateAction)
+    {
+        updateAction.ThrowArgumentNullExceptionIfNull(nameof(updateAction));
+
+        lock (_locker)
+        {
+            IChangeSet<T>? changes = null;
+
+            _editLevel++;
+            _isEditInProgress.OnNext(_editLevel is not 0);
+
+            if (_editLevel == 1)
+            {
+                changes = _changesPreview.HasObservers ? _readerWriter.WriteWithPreview(updateAction, InvokeNextPreview) : _readerWriter.Write(updateAction);
+            }
+            else
+            {
+                _readerWriter.WriteNested(updateAction);
+            }
+
+            _editLevel--;
+
+            if (changes is not null && _editLevel == 0)
+            {
+                InvokeNext(changes);
+            }
+
+            _isEditInProgress.OnNext(_editLevel is not 0);
+        }
+    }
+
+    /// <inheritdoc />
+    public IObservable<IChangeSet<T>> Preview(Func<T, bool>? predicate = null)
+    {
+        IObservable<IChangeSet<T>> observable = _changesPreview;
+
+        if (predicate is not null)
+        {
+            observable = new FilterStatic<T>(observable, predicate).Run();
+        }
+
+        return observable;
+    }
+
+    private IObservable<IChangeSet<T>> CreateConnectObservable(Func<T, bool>? predicate)
     {
         var observable = Observable.Create<IChangeSet<T>>(
             observer =>
@@ -98,55 +176,6 @@ public sealed class SourceList<T> : ISourceList<T>
                     return source.SubscribeSafe(observer);
                 }
             });
-
-        if (predicate is not null)
-        {
-            observable = new FilterStatic<T>(observable, predicate).Run();
-        }
-
-        return observable;
-    }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        _cleanUp.Dispose();
-        _changesPreview.Dispose();
-    }
-
-    /// <inheritdoc />
-    public void Edit(Action<IExtendedList<T>> updateAction)
-    {
-        updateAction.ThrowArgumentNullExceptionIfNull(nameof(updateAction));
-
-        lock (_locker)
-        {
-            IChangeSet<T>? changes = null;
-
-            _editLevel++;
-
-            if (_editLevel == 1)
-            {
-                changes = _changesPreview.HasObservers ? _readerWriter.WriteWithPreview(updateAction, InvokeNextPreview) : _readerWriter.Write(updateAction);
-            }
-            else
-            {
-                _readerWriter.WriteNested(updateAction);
-            }
-
-            _editLevel--;
-
-            if (changes is not null && _editLevel == 0)
-            {
-                InvokeNext(changes);
-            }
-        }
-    }
-
-    /// <inheritdoc />
-    public IObservable<IChangeSet<T>> Preview(Func<T, bool>? predicate = null)
-    {
-        IObservable<IChangeSet<T>> observable = _changesPreview;
 
         if (predicate is not null)
         {
@@ -195,6 +224,7 @@ public sealed class SourceList<T> : ISourceList<T>
         {
             _changesPreview.OnCompleted();
             _changes.OnCompleted();
+            _isEditInProgress.OnCompleted();
         }
     }
 
@@ -204,6 +234,7 @@ public sealed class SourceList<T> : ISourceList<T>
         {
             _changesPreview.OnError(exception);
             _changes.OnError(exception);
+            _isEditInProgress.OnError(exception);
         }
     }
 }

--- a/src/DynamicData/List/SourceList.cs
+++ b/src/DynamicData/List/SourceList.cs
@@ -107,7 +107,10 @@ public sealed class SourceList<T> : ISourceList<T>
     {
         _cleanUp.Dispose();
         _changesPreview.Dispose();
-        _isEditInProgress.OnCompleted();
+        // Intentionally skipping disposal for _isEditInProgress, as it's technically redundant after _cleanUp.Dispose()
+        // calls .OnCompleted(), and doing disposal anyway causes a whole bunch of test failures. That really suggests
+        // we need to rework the lifecycle mechanics of this class, as a whole, but that's probably going to involve
+        // breaking changes.
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Fixed that subscriptions occurring during an `.Edit()` operation upon a `SourceCache<>` or `SourceList<>` would still publish an initial notification to the subscriber. This resulted in the potential for notifications to be duplicated, for items added or manipulated during the edit.

Instead, such subscriptions now have their notifications deferred until the `.Edit()` is complete.

Resolves #1129.