### PR TITLE
Feature: Cancellation support for TransformAsync

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
@@ -1964,6 +1964,14 @@ namespace DynamicData
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.CancellationToken, System.Threading.Tasks.Task<TDestination>> transformFactory, DynamicData.TransformAsyncOptions options)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.CancellationToken, System.Threading.Tasks.Task<TDestination>> transformFactory, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformImmutable<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, TDestination> transformFactory)
             where TDestination :  notnull
             where TSource :  notnull
@@ -2105,6 +2113,14 @@ namespace DynamicData
             where TSource :  notnull
             where TKey :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.CancellationToken, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, DynamicData.TransformAsyncOptions options)
+            where TDestination :  notnull
+            where TSource :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this System.IObservable<DynamicData.IChangeSet<TSource, TKey>> source, System.Func<TSource, DynamicData.Kernel.Optional<TSource>, TKey, System.Threading.CancellationToken, System.Threading.Tasks.Task<TDestination>> transformFactory, System.Action<DynamicData.Kernel.Error<TSource, TKey>> errorHandler, System.IObservable<System.Func<TSource, TKey, bool>>? forceTransform = null)
             where TDestination :  notnull
             where TSource :  notnull
             where TKey :  notnull { }
@@ -2479,6 +2495,9 @@ namespace DynamicData
             where TSource :  notnull
             where TDestination :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(this System.IObservable<DynamicData.IChangeSet<TSource>> source, System.Func<TSource, DynamicData.Kernel.Optional<TDestination>, int, System.Threading.Tasks.Task<TDestination>> transformFactory, bool transformOnRefresh = false)
+            where TSource :  notnull
+            where TDestination :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(this System.IObservable<DynamicData.IChangeSet<TSource>> source, System.Func<TSource, DynamicData.Kernel.Optional<TDestination>, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<TDestination>> transformFactory, bool transformOnRefresh = false)
             where TSource :  notnull
             where TDestination :  notnull { }
         public static System.IObservable<DynamicData.IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this System.IObservable<DynamicData.IChangeSet<TSource>> source, System.Func<TSource, DynamicData.IObservableList<TDestination>> manySelector, System.Collections.Generic.IEqualityComparer<TDestination>? equalityComparer = null)

--- a/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformAsyncFixture.cs
@@ -200,7 +200,7 @@ public class TransformAsyncFixture
     }
 
 
-   
+
 
     [Theory, InlineData(true), InlineData(false)]
     public void TransformOnRefresh(bool transformOnRefresh)
@@ -215,7 +215,7 @@ public class TransformAsyncFixture
 
         results.Data.Count.Should().Be(1);
         results.Data.Lookup("SomeOne").Value.AgeGroup.Should().Be("Child");
-        
+
         person.Age = 21;
 
 
@@ -224,7 +224,28 @@ public class TransformAsyncFixture
 
     }
 
-    
+    [Fact]
+    public void TransformAsyncCancelsTokenOnUnSubscribe()
+    {
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        var tcs = new TaskCompletionSource<Person>();
+        using var sub = source.Connect()
+            .TransformAsync(async (c, p, key, cancel) =>
+            {
+                using (cancel.Register(() => tcs.SetCanceled(), useSynchronizationContext: false))
+                {
+                    return await tcs.Task.ConfigureAwait(false);
+                }
+            })
+            .Subscribe();
+
+        source.AddOrUpdate(new Person());
+
+        sub.Dispose();
+        Assert.True(tcs.Task.IsCanceled);
+    }
+
+
     [Theory, InlineData(10), InlineData(100)]
 
     public async Task WithMaxConcurrency(int maxConcurrency)
@@ -232,7 +253,7 @@ public class TransformAsyncFixture
         /* We need to test whether the max concurrency has any effect.
 
              If  maxConcurrency == 100, this test takes a little more than 100 ms
-             If maxConcurrency = 10, this test takes a little more than 1s 
+             If maxConcurrency = 10, this test takes a little more than 1s
 
             So it works, but how can it be tested in a scientific way ??
         */

--- a/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
+++ b/src/DynamicData.Tests/Cache/TransformSafeAsyncFixture.cs
@@ -208,6 +208,29 @@ public class TransformSafeAsyncFixture
     }
 
 
+    [Fact]
+    public void TransformSafeAsyncCancelsTokenOnUnSubscribe()
+    {
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        var tcs = new TaskCompletionSource<Person>();
+        using var sub = source.Connect()
+            .TransformSafeAsync(async (c, p, key, cancel) =>
+            {
+                using (cancel.Register(() => tcs.SetCanceled(), useSynchronizationContext: false))
+                {
+                    return await tcs.Task.ConfigureAwait(false);
+                }
+            },
+            error => Assert.Fail($"Unexpected error: {error}")) // NOTE: Cancellation exception should not be called because the handler should be torn down with subscription
+            .Subscribe();
+
+        source.AddOrUpdate(new Person());
+
+        sub.Dispose();
+        Assert.True(tcs.Task.IsCanceled);
+    }
+
+
     [Theory, InlineData(10), InlineData(100)]
 
     public async Task WithMaxConcurrency(int maxConcurrency)
@@ -215,7 +238,7 @@ public class TransformSafeAsyncFixture
         /* We need to test whether the max concurrency has any effect.
 
              If  maxConcurrency == 100, this test takes a little more than 100 ms
-             If maxConcurrency = 10, this test takes a little more than 1s 
+             If maxConcurrency = 10, this test takes a little more than 1s
 
             So it works, but how can it be tested in a scientific way ??
         */

--- a/src/DynamicData.Tests/List/TransformAsyncFixture.cs
+++ b/src/DynamicData.Tests/List/TransformAsyncFixture.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-
+using DynamicData.Kernel;
 using DynamicData.Tests.Domain;
 using FluentAssertions;
 using Xunit;
@@ -164,5 +165,26 @@ public class TransformAsyncFixture : IDisposable
         results.Messages.Count.Should().Be(5);
 
         results.Messages.Last().First().Reason.Should().Be(ListChangeReason.Replace);
+    }
+
+    [Fact]
+    public void TransformAsyncCancelsTokenOnUnSubscribe()
+    {
+        using var source = new SourceList<Person>();
+        var tcs = new TaskCompletionSource<Person>();
+        using var sub = source.Connect()
+            .TransformAsync<Person, Person>(async (c, p, count, cancel) =>
+            {
+                using (cancel.Register(() => tcs.SetCanceled(), useSynchronizationContext: false))
+                {
+                    return await tcs.Task.ConfigureAwait(false);
+                }
+            })
+            .Subscribe();
+
+        source.Add(new Person());
+
+        sub.Dispose();
+        Assert.True(tcs.Task.IsCanceled);
     }
 }

--- a/src/DynamicData/Cache/Internal/TransformAsync.cs
+++ b/src/DynamicData/Cache/Internal/TransformAsync.cs
@@ -10,7 +10,7 @@ namespace DynamicData.Cache.Internal;
 
 internal class TransformAsync<TDestination, TSource, TKey>(
     IObservable<IChangeSet<TSource, TKey>> source,
-    Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory,
+    Func<TSource, Optional<TSource>, TKey, CancellationToken, Task<TDestination>> transformFactory,
     Action<Error<TSource, TKey>>? exceptionCallback,
     IObservable<Func<TSource, TKey, bool>>? forceTransform = null,
     int? maximumConcurrency = null,
@@ -45,7 +45,7 @@ internal class TransformAsync<TDestination, TSource, TKey>(
         var toTransform = cache.KeyValues.Where(kvp => shouldTransform(kvp.Value.Source, kvp.Key)).Select(kvp =>
             new Change<TSource, TKey>(ChangeReason.Update, kvp.Key, kvp.Value.Source, kvp.Value.Source)).ToArray();
 
-        return toTransform.Select(change => Observable.Defer(() => Transform(change).ToObservable()))
+        return toTransform.Select(change => Observable.FromAsync(t => Transform(change, t)))
             .Merge(maximumConcurrency ?? int.MaxValue)
             .ToArray()
             .Select(transformed => ProcessUpdates(cache, transformed));
@@ -54,7 +54,7 @@ internal class TransformAsync<TDestination, TSource, TKey>(
     private IObservable<IChangeSet<TDestination, TKey>> DoTransform(
         ChangeAwareCache<TransformedItemContainer, TKey> cache, IChangeSet<TSource, TKey> changes)
     {
-        return changes.Select(change => Observable.FromAsync(() => Transform(change)))
+        return changes.Select(change => Observable.FromAsync(t => Transform(change, t)))
             .Merge(maximumConcurrency ?? int.MaxValue)
             .ToArray()
             .Select(transformed => ProcessUpdates(cache, transformed));
@@ -105,13 +105,13 @@ internal class TransformAsync<TDestination, TSource, TKey>(
         return new ChangeSet<TDestination, TKey>(transformed);
     }
 
-    private async Task<TransformResult> Transform(Change<TSource, TKey> change)
+    private async Task<TransformResult> Transform(Change<TSource, TKey> change, CancellationToken cancellationToken)
     {
         try
         {
             if (change.Reason is ChangeReason.Add or ChangeReason.Update || (change.Reason is ChangeReason.Refresh && transformOnRefresh))
             {
-                var destination = await transformFactory(change.Current, change.Previous, change.Key)
+                var destination = await transformFactory(change.Current, change.Previous, change.Key, cancellationToken)
                     .ConfigureAwait(false);
                 return new TransformResult(change, new TransformedItemContainer(change.Current, destination));
             }

--- a/src/DynamicData/Cache/ObservableCacheEx.TransformAsync.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.TransformAsync.cs
@@ -54,6 +54,20 @@ public static partial class ObservableCacheEx
         return source.TransformAsync((current, _, key) => transformFactory(current, key), forceTransform);
     }
 
+    /// <inheritdoc cref="TransformAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, Task{TDestination}}, IObservable{Func{TSource, TKey, bool}}?)"/>
+    /// <remarks>This overload takes a factory that receives the current item the previous item and key.</remarks>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+
+        return source.TransformAsync((current, previous, key, _) => transformFactory(current, previous, key), forceTransform);
+    }
+
     /// <summary>
     /// Async version of <see cref="Transform{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, TDestination}, IObservable{Func{TSource, TKey, bool}}?)"/>.
     /// Projects each item using an async factory that returns <see cref="Task{TResult}"/>.
@@ -88,7 +102,7 @@ public static partial class ObservableCacheEx
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="transformFactory"/> is <see langword="null"/>.</exception>
     [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
-    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, CancellationToken, Task<TDestination>> transformFactory, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
         where TDestination : notnull
         where TSource : notnull
         where TKey : notnull
@@ -124,13 +138,27 @@ public static partial class ObservableCacheEx
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
         transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
 
-        return source.TransformAsync((current, _, key) => transformFactory(current, key), options);
+        return TransformAsync(source, (current, _, key, _) => transformFactory(current, key), options);
     }
 
     /// <inheritdoc cref="TransformAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, Task{TDestination}}, IObservable{Func{TSource, TKey, bool}}?)"/>
     /// <remarks>This overload accepts <see cref="TransformAsyncOptions"/> to control concurrency and Refresh handling.</remarks>
     [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
     public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+
+        return TransformAsync(source, (current, previous, key, _) => transformFactory(current, previous, key), options);
+    }
+
+    /// <inheritdoc cref="TransformAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, CancellationToken, Task{TDestination}}, IObservable{Func{TSource, TKey, bool}}?)"/>
+    /// <remarks>This overload accepts <see cref="TransformAsyncOptions"/> to control concurrency and Refresh handling.</remarks>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, CancellationToken, Task<TDestination>> transformFactory, TransformAsyncOptions options)
         where TDestination : notnull
         where TSource : notnull
         where TKey : notnull

--- a/src/DynamicData/Cache/ObservableCacheEx.TransformSafeAsync.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.TransformSafeAsync.cs
@@ -55,6 +55,20 @@ public static partial class ObservableCacheEx
         return source.TransformSafeAsync((current, _, key) => transformFactory(current, key), errorHandler, forceTransform);
     }
 
+    /// <inheritdoc cref="TransformSafeAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, CancellationToken, Task{TDestination}}, Action{Error{TSource, TKey}}, IObservable{Func{TSource, TKey, bool}}?)"/>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+        errorHandler.ThrowArgumentNullExceptionIfNull(nameof(errorHandler));
+
+        return source.TransformSafeAsync((s, p, k, t) => transformFactory(s, p, k), errorHandler, forceTransform);
+    }
+
     /// <summary>
     /// Async version of <see cref="TransformSafe{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, TDestination}, Action{Error{TSource, TKey}}, IObservable{Func{TSource, TKey, bool}}?)"/>.
     /// Projects each item using an async factory, catching factory exceptions via a mandatory error handler.
@@ -63,14 +77,14 @@ public static partial class ObservableCacheEx
     /// <typeparam name="TSource">The type of the source items.</typeparam>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <param name="source">The source <see cref="IObservable{IChangeSet{TSource, TKey}}"/> to transform asynchronously with error handling.</param>
-    /// <param name="transformFactory">The <see cref="Func{TSource, Optional{TSource}, TKey, Task{TDestination}}"/> async function that produces a <typeparamref name="TDestination"/>.</param>
+    /// <param name="transformFactory">The <see cref="Func{TSource, Optional{TSource}, TKey, CancellationToken, Task{TDestination}}"/> async function that produces a <typeparamref name="TDestination"/>.</param>
     /// <param name="errorHandler">A <see cref="Action{T}"/> that called when <paramref name="transformFactory"/> throws or faults. The item is skipped and the stream continues.</param>
     /// <param name="forceTransform">An optional <see cref="IObservable{T}"/> that forces re-transformation of matching items.</param>
     /// <returns>An observable changeset of transformed items.</returns>
     /// <remarks>Combines the async execution model of <see cref="TransformAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, Task{TDestination}}, IObservable{Func{TSource, TKey, bool}}?)"/> with the error-safe behavior of <see cref="TransformSafe{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, TDestination}, Action{Error{TSource, TKey}}, IObservable{Func{TSource, TKey, bool}}?)"/>.</remarks>
     /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="transformFactory"/>, or <paramref name="errorHandler"/> is <see langword="null"/>.</exception>
     [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
-    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, CancellationToken, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, IObservable<Func<TSource, TKey, bool>>? forceTransform = null)
         where TDestination : notnull
         where TSource : notnull
         where TKey : notnull
@@ -112,10 +126,21 @@ public static partial class ObservableCacheEx
         return source.TransformSafeAsync((current, _, key) => transformFactory(current, key), errorHandler, options);
     }
 
-    /// <inheritdoc cref="TransformSafeAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, Task{TDestination}}, Action{Error{TSource, TKey}}, IObservable{Func{TSource, TKey, bool}}?)"/>
+    /// <inheritdoc cref="TransformSafeAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, CancellationToken, Task{TDestination}}, Action{Error{TSource, TKey}}, IObservable{Func{TSource, TKey, bool}}?)"/>
     /// <remarks>This overload accepts <see cref="TransformAsyncOptions"/> to control concurrency and Refresh handling.</remarks>
     [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
     public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, TransformAsyncOptions options)
+        where TDestination : notnull
+        where TSource : notnull
+        where TKey : notnull
+    {
+        return source.TransformSafeAsync((current, previous, key, cancel) => transformFactory(current, previous, key), errorHandler, options);
+    }
+
+    /// <inheritdoc cref="TransformSafeAsync{TDestination, TSource, TKey}(IObservable{IChangeSet{TSource, TKey}}, Func{TSource, Optional{TSource}, TKey, CancellationToken, Task{TDestination}}, Action{Error{TSource, TKey}}, IObservable{Func{TSource, TKey, bool}}?)"/>
+    /// <remarks>This overload accepts <see cref="TransformAsyncOptions"/> to control concurrency and Refresh handling.</remarks>
+    [SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination, TKey>> TransformSafeAsync<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source, Func<TSource, Optional<TSource>, TKey, CancellationToken, Task<TDestination>> transformFactory, Action<Error<TSource, TKey>> errorHandler, TransformAsyncOptions options)
         where TDestination : notnull
         where TSource : notnull
         where TKey : notnull

--- a/src/DynamicData/List/Internal/TransformAsync.cs
+++ b/src/DynamicData/List/Internal/TransformAsync.cs
@@ -10,23 +10,23 @@ internal sealed class TransformAsync<TSource, TDestination>
     where TSource : notnull
     where TDestination : notnull
 {
-    private readonly Func<TSource, Optional<TDestination>, int, Task<Transformer<TSource, TDestination>.TransformedItemContainer>> _containerFactory;
+    private readonly Func<TSource, Optional<TDestination>, int, CancellationToken, Task<Transformer<TSource, TDestination>.TransformedItemContainer>> _containerFactory;
 
     private readonly IObservable<IChangeSet<TSource>> _source;
     private readonly bool _transformOnRefresh;
 
     public TransformAsync(
         IObservable<IChangeSet<TSource>> source,
-        Func<TSource, Optional<TDestination>, int, Task<TDestination>> factory,
+        Func<TSource, Optional<TDestination>, int, CancellationToken, Task<TDestination>> factory,
         bool transformOnRefresh)
     {
         factory.ThrowArgumentNullExceptionIfNull(nameof(factory));
 
         _source = source ?? throw new ArgumentNullException(nameof(source));
         _transformOnRefresh = transformOnRefresh;
-        _containerFactory = async (item, prev, index) =>
+        _containerFactory = async (item, prev, index, cancel) =>
         {
-            var destination = await factory(item, prev, index).ConfigureAwait(false);
+            var destination = await factory(item, prev, index, cancel).ConfigureAwait(false);
             return new Transformer<TSource, TDestination>.TransformedItemContainer(item, destination);
         };
     }
@@ -35,33 +35,59 @@ internal sealed class TransformAsync<TSource, TDestination>
 
     private IObservable<IChangeSet<TDestination>> RunImpl()
     {
-        var state = new ChangeAwareList<Transformer<TSource, TDestination>.TransformedItemContainer>();
-        var asyncLock = new SemaphoreSlim(1, 1);
-
-        return _source.Select(async changes =>
-                {
-                    try
-                    {
-                        await asyncLock.WaitAsync();
-                        await Transform(state, changes);
-                        return state;
-                    }
-                    finally
-                    {
-                        asyncLock.Release();
-                    }
-                })
-            .Concat()
-            .Select(transformed =>
+        return Observable.Using(
+            () => new SemaphoreSlim(1, 1),
+            asyncLock =>
             {
-                var changed = transformed.CaptureChanges();
-                return changed.Transform(container => container.Destination);
+                var state = new ChangeAwareList<Transformer<TSource, TDestination>.TransformedItemContainer>();
+
+                return _source.Select(changes => Observable.FromAsync(async cancel =>
+                        {
+                            // NOTE: lock outside of the try to avoid releasing another scope's lock if the token is canceled before we acquire the lock.
+                            try
+                            {
+                                await asyncLock.WaitAsync(cancel);
+                            }
+                            catch (Exception e) when (e is ObjectDisposedException)
+                            {
+                                return Optional.None<ChangeAwareList<Transformer<TSource, TDestination>.TransformedItemContainer>>();
+                            }
+
+                            try
+                            {
+                                await Transform(state, changes, cancel);
+                                return Optional.Some(state);
+                            }
+                            finally
+                            {
+                                try
+                                {
+                                    // token is canceled when outer stream is disposed which is attached to the lock's lifetime.
+                                    if (!cancel.IsCancellationRequested)
+                                    {
+                                        asyncLock.Release();
+                                    }
+                                }
+                                catch (ObjectDisposedException)
+                                {
+                                    // outer stream was disposed during inner transform.
+                                }
+                            }
+                        }))
+                    .Concat()
+                    .SelectValues()
+                    .Select(transformed =>
+                    {
+                        var changed = transformed.CaptureChanges();
+                        return changed.Transform(container => container.Destination);
+                    });
             });
     }
 
     private async Task Transform(
         ChangeAwareList<Transformer<TSource, TDestination>.TransformedItemContainer> transformed,
-        IChangeSet<TSource> changes)
+        IChangeSet<TSource> changes,
+        CancellationToken cancel)
     {
         changes.ThrowArgumentNullExceptionIfNull(nameof(changes));
 
@@ -78,7 +104,8 @@ internal sealed class TransformAsync<TSource, TDestination>
                                 await _containerFactory(
                                     item.Item.Current,
                                     Optional<TDestination>.None,
-                                    transformed.Count).ConfigureAwait(false);
+                                    transformed.Count,
+                                    cancel).ConfigureAwait(false);
                             transformed.Add(container);
                         }
                         else
@@ -87,7 +114,8 @@ internal sealed class TransformAsync<TSource, TDestination>
                                 await _containerFactory(
                                     item.Item.Current,
                                     Optional<TDestination>.None,
-                                    change.CurrentIndex).ConfigureAwait(false);
+                                    change.CurrentIndex,
+                                    cancel).ConfigureAwait(false);
                             transformed.Insert(change.CurrentIndex, container);
                         }
 
@@ -97,7 +125,7 @@ internal sealed class TransformAsync<TSource, TDestination>
                 case ListChangeReason.AddRange:
                     {
                         var startIndex = item.Range.Index < 0 ? transformed.Count : item.Range.Index;
-                        var tasks = item.Range.Select((t, idx) => _containerFactory(t, Optional<TDestination>.None, idx + startIndex));
+                        var tasks = item.Range.Select((t, idx) => _containerFactory(t, Optional<TDestination>.None, idx + startIndex, cancel));
                         var containers = await Task.WhenAll(tasks).ConfigureAwait(false);
                         transformed.AddOrInsertRange(containers, item.Range.Index);
                         break;
@@ -109,7 +137,7 @@ internal sealed class TransformAsync<TSource, TDestination>
                         if (_transformOnRefresh)
                         {
                             Optional<TDestination> previous = transformed[change.CurrentIndex].Destination;
-                            var container = await _containerFactory(change.Current, previous, change.CurrentIndex)
+                            var container = await _containerFactory(change.Current, previous, change.CurrentIndex, cancel)
                                 .ConfigureAwait(false);
                             transformed[change.CurrentIndex] = container;
                         }
@@ -128,12 +156,12 @@ internal sealed class TransformAsync<TSource, TDestination>
                         Optional<TDestination> previous = transformed[change.PreviousIndex].Destination;
                         if (change.CurrentIndex == change.PreviousIndex)
                         {
-                            transformed[change.CurrentIndex] = await _containerFactory(change.Current, previous, change.CurrentIndex);
+                            transformed[change.CurrentIndex] = await _containerFactory(change.Current, previous, change.CurrentIndex, cancel);
                         }
                         else
                         {
                             transformed.RemoveAt(change.PreviousIndex);
-                            transformed.Insert(change.CurrentIndex, await _containerFactory(change.Current, Optional<TDestination>.None, change.CurrentIndex));
+                            transformed.Insert(change.CurrentIndex, await _containerFactory(change.Current, Optional<TDestination>.None, change.CurrentIndex, cancel));
                         }
 
                         break;

--- a/src/DynamicData/List/ObservableListEx.TransformAsync.cs
+++ b/src/DynamicData/List/ObservableListEx.TransformAsync.cs
@@ -102,12 +102,30 @@ public static partial class ObservableListEx
 
     /// <inheritdoc cref="TransformAsync{TSource, TDestination}(IObservable{IChangeSet{TSource}}, Func{TSource, Task{TDestination}}, bool)"/>
     /// <summary>
-    /// Async transform overload receiving the source item, previously transformed value, and index. This is the terminal overload that all other TransformAsync overloads delegate to.
+    /// Async transform overload receiving the source item, previously transformed value, and index.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
     public static IObservable<IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(
         this IObservable<IChangeSet<TSource>> source,
         Func<TSource, Optional<TDestination>, int, Task<TDestination>> transformFactory,
+        bool transformOnRefresh = false)
+        where TSource : notnull
+        where TDestination : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        transformFactory.ThrowArgumentNullExceptionIfNull(nameof(transformFactory));
+
+        return new TransformAsync<TSource, TDestination>(source, (t, d, i, _) => transformFactory(t, d, i), transformOnRefresh).Run();
+    }
+
+    /// <inheritdoc cref="TransformAsync{TSource, TDestination}(IObservable{IChangeSet{TSource}}, Func{TSource, Task{TDestination}}, bool)"/>
+    /// <summary>
+    /// Async transform overload receiving the source item, previously transformed value, index, and CancellationToken attached to the underlying subscription. This is the terminal overload that all other TransformAsync overloads delegate to.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1047:Non-asynchronous method name should not end with 'Async'.", Justification = "By Design.")]
+    public static IObservable<IChangeSet<TDestination>> TransformAsync<TSource, TDestination>(
+        this IObservable<IChangeSet<TSource>> source,
+        Func<TSource, Optional<TDestination>, int, CancellationToken, Task<TDestination>> transformFactory,
         bool transformOnRefresh = false)
         where TSource : notnull
         where TDestination : notnull


### PR DESCRIPTION
Following [this discussion](https://github.com/reactivemarbles/DynamicData/discussions/1126#discussioncomment-17551854) I decided to revert back to just an additional overload of TransformAsync instead of using TransferAsyncCancel. I removed the ambiguous overload. 

I decided it was best to extend the existing pattern of using the overload with the most parameters and modified existing operators to use the new overload that has the cancellation token parameter and just discarded that argument for the overloads with fewer parameters.

I added support to the List variant too and modified the internals on that one to avoid a cancelation of one from releasing the async lock of another in the same stream.