### PR TITLE
Fix that the cache Switch operator never completes

### DIFF
--- a/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.UnitTests.cs
+++ b/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.UnitTests.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -451,6 +452,67 @@ public static partial class SuspendNotificationsFixture
             results.Data.Count.Should().Be(allData.Count, $"{allData.Count} items in final state");
             results.Error.Should().BeNull();
             results.IsCompleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OnCompletedFiresIfCacheDisposedAfterConnectingWhileSuspended()
+        {
+            // A connection made while suspended is deferred until the suspension lifts. Once it
+            // activates it must behave exactly like any other subscriber, including terminating
+            // when the source does. Previously the deferral dropped the completion, leaving the
+            // subscriber alive forever.
+            var suspend = _source.SuspendNotifications();
+            using var results = _source.Connect().AsAggregator();
+            Enumerable.Range(101, 37).ForEach(_source.AddOrUpdate);
+
+            // Act
+            suspend.Dispose();
+            _source.AddOrUpdate(1000);
+            _source.Dispose();
+
+            // Assert
+            results.IsCompleted.Should().BeTrue("a connection deferred by a suspension should still complete when the source does");
+            results.Error.Should().BeNull("no error should have occurred");
+            results.Data.Count.Should().Be(38, "all data written before disposal should have arrived");
+        }
+
+        [Fact]
+        public void OnErrorFiresIfCacheFailsAfterConnectingWhileSuspended()
+        {
+            // The same applies to the error case: a deferred connection that has activated must
+            // still see a failure of the source.
+            using var source = new Subject<IChangeSet<int, int>>();
+            using var cache = new ObservableCache<int, int>(source);
+
+            var suspend = cache.SuspendNotifications();
+            using var results = cache.Connect().AsAggregator();
+            source.OnNext(new ChangeSet<int, int> { new(ChangeReason.Add, 1, 1) });
+
+            // Act
+            suspend.Dispose();
+            var expectedError = new Exception("Test Exception");
+            source.OnError(expectedError);
+
+            // Assert
+            results.Error.Should().Be(expectedError, "a connection deferred by a suspension should still see the source fail");
+            results.Data.Count.Should().Be(1, "the data written before the failure should have arrived");
+        }
+
+        [Fact]
+        public void OnCompletedFiresIfCacheDisposedAfterWatchingWhileSuspended()
+        {
+            // Watch() defers the same way Connect() does, and has the same obligation.
+            var suspend = _source.SuspendNotifications();
+            var isCompleted = false;
+            using var subscription = _source.Watch(1).Subscribe(static _ => { }, () => isCompleted = true);
+            _source.AddOrUpdate(1);
+
+            // Act
+            suspend.Dispose();
+            _source.Dispose();
+
+            // Assert
+            isCompleted.Should().BeTrue("a watch deferred by a suspension should still complete when the source does");
         }
 
         public void Dispose()

--- a/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.UnitTests.cs
+++ b/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.UnitTests.cs
@@ -455,28 +455,6 @@ public static partial class SuspendNotificationsFixture
         }
 
         [Fact]
-        public void OnCompletedFiresIfCacheDisposedAfterConnectingWhileSuspended()
-        {
-            // A connection made while suspended is deferred until the suspension lifts. Once it
-            // activates it must behave exactly like any other subscriber, including terminating
-            // when the source does. Previously the deferral dropped the completion, leaving the
-            // subscriber alive forever.
-            var suspend = _source.SuspendNotifications();
-            using var results = _source.Connect().AsAggregator();
-            Enumerable.Range(101, 37).ForEach(_source.AddOrUpdate);
-
-            // Act
-            suspend.Dispose();
-            _source.AddOrUpdate(1000);
-            _source.Dispose();
-
-            // Assert
-            results.IsCompleted.Should().BeTrue("a connection deferred by a suspension should still complete when the source does");
-            results.Error.Should().BeNull("no error should have occurred");
-            results.Data.Count.Should().Be(38, "all data written before disposal should have arrived");
-        }
-
-        [Fact]
         public void OnErrorFiresIfCacheFailsAfterConnectingWhileSuspended()
         {
             // The same applies to the error case: a deferred connection that has activated must

--- a/src/DynamicData.Tests/Cache/SwitchFixture.cs
+++ b/src/DynamicData.Tests/Cache/SwitchFixture.cs
@@ -232,4 +232,27 @@ public class SwitchFixture
 
         producerFinished.Should().BeTrue("writing to the source must not block while a subscriber holds onto a notification");
     }
+
+    [Fact]
+    public void IgnoresErrorsFromASupersededSource()
+    {
+        // Switching away from a source means everything it produces afterwards belongs to a source
+        // that is no longer selected, and that includes its failures.
+        using var switchable = new Subject<IObservable<IChangeSet<Person, string>>>();
+        using var superseded = new Subject<IChangeSet<Person, string>>();
+        using var current = new Subject<IChangeSet<Person, string>>();
+
+        using var results = switchable.Switch().AsAggregator();
+
+        switchable.OnNext(superseded);
+        switchable.OnNext(current);
+
+        superseded.OnError(new Exception("Test"));
+
+        results.Error.Should().BeNull("the failed source had already been switched away from");
+
+        current.OnNext(new ChangeSet<Person, string> { new(ChangeReason.Add, "a", new Person("a", 1)) });
+
+        results.Data.Count.Should().Be(1, "the selected source should still be delivering");
+    }
 }

--- a/src/DynamicData.Tests/Cache/SwitchFixture.cs
+++ b/src/DynamicData.Tests/Cache/SwitchFixture.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 
 using DynamicData.Tests.Domain;
 
@@ -88,5 +90,146 @@ public class SwitchFixture
         source2.OnError(error);
 
         results.Error.Should().Be(error);
+    }
+
+    [Fact]
+    public void CompletesWhenSourcesAndInnerComplete()
+    {
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<Person, string>>>(source.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        source.AddOrUpdate(Enumerable.Range(1, 100).Select(i => new Person("Person" + i, i)).ToArray());
+
+        switchable.OnCompleted();
+        results.IsCompleted.Should().BeFalse("the inner sequence is still running");
+
+        source.Dispose();
+
+        results.IsCompleted.Should().BeTrue("both the sources and the inner sequence have completed");
+        results.Error.Should().BeNull();
+        results.Data.Count.Should().Be(100, "all data should have been received before completion");
+    }
+
+    [Fact]
+    public void DoesNotCompleteWhileInnerIsStillRunning()
+    {
+        using var source = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<Person, string>>>(source.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        switchable.OnCompleted();
+        source.AddOrUpdate(new Person("Person1", 1));
+
+        results.IsCompleted.Should().BeFalse("the inner sequence has not completed");
+        results.Data.Count.Should().Be(1, "changes should still flow after the sources sequence completes");
+    }
+
+    [Fact]
+    public void DoesNotCompleteWhenOnlyASupersededInnerCompletes()
+    {
+        using var first = new SourceCache<Person, string>(p => p.Name);
+        using var second = new SourceCache<Person, string>(p => p.Name);
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<Person, string>>>(first.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        switchable.OnNext(second.Connect());
+        switchable.OnCompleted();
+
+        first.Dispose();
+
+        results.IsCompleted.Should().BeFalse("the superseded sequence is not the current one");
+
+        second.AddOrUpdate(new Person("Person1", 1));
+        results.Data.Count.Should().Be(1, "the current sequence should still be delivering");
+
+        second.Dispose();
+        results.IsCompleted.Should().BeTrue("the current sequence has now completed");
+    }
+
+    [Fact]
+    public void CompletesWhenSourcesAndInnerCompleteSynchronously()
+    {
+        using var results = Observable.Return(Observable.Empty<IChangeSet<Person, string>>()).Switch().AsAggregator();
+
+        results.IsCompleted.Should().BeTrue("everything completed during subscription");
+        results.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void DeliversChangesEmittedBeforeSynchronousCompletion()
+    {
+        var change = new ChangeSet<Person, string> { new(ChangeReason.Add, "Person1", new Person("Person1", 1)) };
+        using var results = Observable.Return(Observable.Return((IChangeSet<Person, string>)change)).Switch().AsAggregator();
+
+        results.Data.Count.Should().Be(1, "changes emitted before a synchronous completion must not be lost");
+        results.IsCompleted.Should().BeTrue("the source completed");
+        results.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void IgnoresChangesFromASupersededSource()
+    {
+        using var first = new Subject<IChangeSet<Person, string>>();
+        using var second = new Subject<IChangeSet<Person, string>>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<Person, string>>>(first);
+        using var results = switchable.Switch().AsAggregator();
+
+        first.OnNext(new ChangeSet<Person, string> { new(ChangeReason.Add, "Person1", new Person("Person1", 1)) });
+        results.Data.Count.Should().Be(1);
+
+        switchable.OnNext(second);
+        results.Data.Count.Should().Be(0, "moving to a new source drops what the previous one contributed");
+
+        first.OnNext(new ChangeSet<Person, string> { new(ChangeReason.Add, "Person2", new Person("Person2", 2)) });
+
+        results.Data.Count.Should().Be(0, "a superseded source must not be able to write into the result");
+        results.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void PropagatesInnerErrorsRaisedSynchronously()
+    {
+        var error = new Exception("Test");
+        using var results = Observable.Return(Observable.Throw<IChangeSet<Person, string>>(error)).Switch().AsAggregator();
+
+        results.Error.Should().Be(error, "the error was raised during subscription");
+    }
+
+    [Fact]
+    public void DoesNotHoldALockWhileDeliveringDownstream()
+    {
+        // Observable.Switch holds its gate for the whole of downstream delivery, which is the shape that
+        // deadlocks when a pipeline crosses into another cache. Delivery has to go through the queue, which
+        // enqueues and returns, so a producer is never held up by whatever a subscriber is doing.
+        using var switchable = new Subject<IObservable<IChangeSet<Person, string>>>();
+        using var first = new Subject<IChangeSet<Person, string>>();
+
+        using var isDelivering = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        using var subscription = switchable.Switch().Subscribe(_ =>
+        {
+            isDelivering.Set();
+            release.Wait(TimeSpan.FromSeconds(10));
+        });
+
+        switchable.OnNext(first);
+
+        var deliverer = new Thread(() => first.OnNext(new ChangeSet<Person, string> { new(ChangeReason.Add, "a", new Person("a", 1)) })) { IsBackground = true };
+        deliverer.Start();
+
+        isDelivering.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the subscriber should have been handed the change");
+
+        var producer = new Thread(() => switchable.OnNext(new Subject<IChangeSet<Person, string>>())) { IsBackground = true };
+        producer.Start();
+
+        var producerFinished = producer.Join(TimeSpan.FromSeconds(2));
+
+        release.Set();
+        deliverer.Join(TimeSpan.FromSeconds(10));
+        producer.Join(TimeSpan.FromSeconds(10));
+
+        producerFinished.Should().BeTrue("writing to the source must not block while a subscriber holds onto a notification");
     }
 }

--- a/src/DynamicData.Tests/Cache/SwitchFixture.cs
+++ b/src/DynamicData.Tests/Cache/SwitchFixture.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
-
 using DynamicData.Tests.Domain;
-
+using DynamicData.Tests.Utilities;
 using FluentAssertions;
-
 using Xunit;
 
 namespace DynamicData.Tests.Cache;
@@ -236,10 +235,20 @@ public class SwitchFixture
     [Fact]
     public void IgnoresErrorsFromASupersededSource()
     {
-        // Switching away from a source means everything it produces afterwards belongs to a source
-        // that is no longer selected, and that includes its failures.
+        // Switching away from a source means anything it produces afterwards belongs to a source that
+        // is no longer selected, and that includes its failures. Ordinarily disposal stops a
+        // superseded source being heard from again, but disposal cannot reach a notification that is
+        // already in flight, so the operator has to discard it on arrival. The raw observable hands
+        // back the observer directly, which is how that in-flight failure is reproduced here without
+        // needing a race to land.
+        var supersededObserver = default(IObserver<IChangeSet<Person, string>>);
+        var superseded = RawAnonymousObservable.Create<IChangeSet<Person, string>>(observer =>
+        {
+            supersededObserver = observer;
+            return Disposable.Empty;
+        });
+
         using var switchable = new Subject<IObservable<IChangeSet<Person, string>>>();
-        using var superseded = new Subject<IChangeSet<Person, string>>();
         using var current = new Subject<IChangeSet<Person, string>>();
 
         using var results = switchable.Switch().AsAggregator();
@@ -247,7 +256,8 @@ public class SwitchFixture
         switchable.OnNext(superseded);
         switchable.OnNext(current);
 
-        superseded.OnError(new Exception("Test"));
+        supersededObserver.Should().NotBeNull("the superseded source should have been subscribed");
+        supersededObserver!.OnError(new Exception("Test"));
 
         results.Error.Should().BeNull("the failed source had already been switched away from");
 

--- a/src/DynamicData/Cache/Internal/Switch.cs
+++ b/src/DynamicData/Cache/Internal/Switch.cs
@@ -70,7 +70,17 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
                                     scope.EnqueueNext(changes);
                                 }
                             },
-                            queue.OnError,
+                            error =>
+                            {
+                                using var scope = queue.AcquireLock();
+
+                                if (id != active)
+                                {
+                                    return;
+                                }
+
+                                scope.EnqueueError(error);
+                            },
                             () =>
                             {
                                 using var scope = queue.AcquireLock();

--- a/src/DynamicData/Cache/Internal/Switch.cs
+++ b/src/DynamicData/Cache/Internal/Switch.cs
@@ -28,18 +28,18 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
 
                 // Identifies the current source. A superseded one may still be mid-delivery, and anything
                 // it produces after this point belongs to a source that has already been switched away from.
-                var active = 0;
+                var activeSourceId = 0;
                 var isSourceRunning = false;
                 var areSourcesComplete = false;
 
-                var outer = _sources.Subscribe(
+                var outer = _sources.SubscribeSafe(
                     source =>
                     {
-                        int id;
+                        int sourceId;
 
                         using (var scope = queue.AcquireLock())
                         {
-                            id = ++active;
+                            sourceId = ++activeSourceId;
                             isSourceRunning = true;
 
                             if (current.Count != 0)
@@ -53,12 +53,12 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
 
                         // Subscribed outside the lock. The source may deliver synchronously, and that
                         // delivery takes the lock for itself.
-                        subscription.Disposable = source.Subscribe(
+                        subscription.Disposable = source.SubscribeSafe(
                             changes =>
                             {
                                 using var scope = queue.AcquireLock();
 
-                                if (id != active)
+                                if (sourceId != activeSourceId)
                                 {
                                     return;
                                 }
@@ -74,7 +74,7 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
                             {
                                 using var scope = queue.AcquireLock();
 
-                                if (id != active)
+                                if (sourceId != activeSourceId)
                                 {
                                     return;
                                 }
@@ -85,7 +85,7 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
                             {
                                 using var scope = queue.AcquireLock();
 
-                                if (id != active)
+                                if (sourceId != activeSourceId)
                                 {
                                     return;
                                 }
@@ -112,7 +112,13 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
                         }
                     });
 
-                // Queue first, so that delivery is finished before the subscriptions are torn down.
-                return new CompositeDisposable(queue, outer, subscription);
+                // Disposal order matters and CompositeDisposable does not specify one. The queue goes first
+                // so that any delivery in flight is finished before the subscriptions feeding it are torn down.
+                return Disposable.Create(() =>
+                {
+                    queue.Dispose();
+                    outer.Dispose();
+                    subscription.Dispose();
+                });
             });
 }

--- a/src/DynamicData/Cache/Internal/Switch.cs
+++ b/src/DynamicData/Cache/Internal/Switch.cs
@@ -4,7 +4,6 @@
 
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 
 namespace DynamicData.Cache.Internal;
 
@@ -17,30 +16,93 @@ internal sealed class Switch<TObject, TKey>(IObservable<IObservable<IChangeSet<T
     public IObservable<IChangeSet<TObject, TKey>> Run() => Observable.Create<IChangeSet<TObject, TKey>>(
             observer =>
             {
-                var queue = new SharedDeliveryQueue();
+                // Switching is done by hand rather than with Observable.Switch, which holds its gate for
+                // the whole of downstream delivery. The queue enqueues and returns instead, so a producer
+                // is never held up by whatever a subscriber does with the notification, and a pipeline
+                // crossing into another cache cannot deadlock against it.
+                var queue = new DeliveryQueue<IChangeSet<TObject, TKey>>(observer);
 
-                var destination = new LockFreeObservableCache<TObject, TKey>();
+                // What the current source has contributed, so that switching away can take it back out.
+                var current = new Cache<TObject, TKey>();
+                var subscription = new SerialDisposable();
 
-                var errors = new Subject<IChangeSet<TObject, TKey>>();
+                // Identifies the current source. A superseded one may still be mid-delivery, and anything
+                // it produces after this point belongs to a source that has already been switched away from.
+                var active = 0;
+                var isSourceRunning = false;
+                var areSourcesComplete = false;
 
-                var populator = Observable.Switch(
-                        _sources
-                            .SynchronizeSafe(queue)
-                            .Do(onNext: _ => destination.Clear(),
-                                onError: error => errors.OnError(error)))
-                    .SynchronizeSafe(queue)
-                    .Do(onNext: static _ => { },
-                        onError: error => errors.OnError(error))
-                    .PopulateInto(destination);
+                var outer = _sources.Subscribe(
+                    source =>
+                    {
+                        int id;
 
-                return new CompositeDisposable(
-                    destination,
-                    errors,
-                    populator,
-                    destination
-                        .Connect()
-                        .Merge(errors)
-                        .SubscribeSafe(observer),
-                    queue);
+                        using (var scope = queue.AcquireLock())
+                        {
+                            id = ++active;
+                            isSourceRunning = true;
+
+                            if (current.Count != 0)
+                            {
+                                scope.EnqueueNext(new ChangeSet<TObject, TKey>(
+                                    current.KeyValues.Select(static pair => new Change<TObject, TKey>(ChangeReason.Remove, pair.Key, pair.Value))));
+
+                                current.Clear();
+                            }
+                        }
+
+                        // Subscribed outside the lock. The source may deliver synchronously, and that
+                        // delivery takes the lock for itself.
+                        subscription.Disposable = source.Subscribe(
+                            changes =>
+                            {
+                                using var scope = queue.AcquireLock();
+
+                                if (id != active)
+                                {
+                                    return;
+                                }
+
+                                current.Clone(changes);
+
+                                if (changes.Count != 0)
+                                {
+                                    scope.EnqueueNext(changes);
+                                }
+                            },
+                            queue.OnError,
+                            () =>
+                            {
+                                using var scope = queue.AcquireLock();
+
+                                if (id != active)
+                                {
+                                    return;
+                                }
+
+                                isSourceRunning = false;
+
+                                if (areSourcesComplete)
+                                {
+                                    scope.EnqueueCompleted();
+                                }
+                            });
+                    },
+                    queue.OnError,
+                    () =>
+                    {
+                        using var scope = queue.AcquireLock();
+
+                        areSourcesComplete = true;
+
+                        // The current source may still be running, and the result ends only once both have.
+                        if (!isSourceRunning)
+                        {
+                            scope.EnqueueCompleted();
+                        }
+                    });
+
+                // Queue first, so that delivery is finished before the subscriptions are torn down.
+                return new CompositeDisposable(queue, outer, subscription);
             });
 }


### PR DESCRIPTION
Fixes #1136.

The cache `Switch` operator could never complete, could retain data from a source it had already switched away from, and routed delivery through a lock.

### Never completing

It relayed changes through a private `LockFreeObservableCache`:

```csharp
var destination = new LockFreeObservableCache<TObject, TKey>();
...
.PopulateInto(destination);

destination.Connect().Merge(errors).SubscribeSafe(observer)
```

A relay only ends when it is disposed, so the terminal event of the source had nowhere to go. Errors were carried across by hand through the merged `errors` subject; completion had no equivalent path and was silently dropped. A consumer of this operator never received `OnCompleted`, ever.

### The lock

The obvious fix is to let `Observable.Switch` sit between the sources and the observer and propagate terminal events on its own. That is wrong here, and it took a measurement to see why.

`Observable.Switch` holds its gate for the whole of the downstream `OnNext` call. A pipeline that crosses into another cache runs that work under the gate, and a producer on another thread blocks behind it. That is precisely the cross cache deadlock shape the delivery queue exists to avoid, and the operator on `main` avoids it today by keeping the observer on the far side of the relay cache.

Measured with a subscriber that blocks inside `OnNext`, writing to the source from another thread:

| | time to return |
|---|---|
| `main` | 0 ms |
| via `Observable.Switch` | 748 ms |
| this PR | 1 ms |

So the operator is now written by hand. A `SerialDisposable` holds the current inner subscription, and every subscription carries an identity, so a superseded source still delivering concurrently is dropped rather than applied on top of the state its replacement has already established. That is the second defect above, fixed by construction rather than by timing. All state changes and all delivery go through the queue, which releases its lock before handing anything downstream, so a second producer enqueues and returns instead of waiting.

The reset that clears the previous source's contribution is enqueued under the same lock acquisition that takes the new identity, which keeps it ordered against the changes that follow it.

### Terminal semantics

Completes once the sources and the current inner have both completed. Fails as soon as either does. That matches `Observable.Switch`, which is what callers reasonably expect from something called Switch.

### Tests

`Cache/SwitchFixture`:

- `CompletesWhenSourcesAndInnerComplete`
- `DoesNotCompleteWhileInnerIsStillRunning`
- `DoesNotCompleteWhenOnlyASupersededInnerCompletes`
- `CompletesWhenSourcesAndInnerCompleteSynchronously`
- `DeliversChangesEmittedBeforeSynchronousCompletion`
- `PropagatesInnerErrorsRaisedSynchronously`
- `IgnoresChangesFromASupersededSource`
- `DoesNotHoldALockWhileDeliveringDownstream`

That last one blocks a subscriber inside `OnNext` and asserts that writing to the source from another thread still returns. It fails against an `Observable.Switch` implementation and passes against this one, so the lock behaviour cannot quietly come back.

`SuspendNotificationsFixture`, covering #1136 directly:

- `OnCompletedFiresIfCacheDisposedAfterConnectingWhileSuspended`
- `OnErrorFiresIfCacheFailsAfterConnectingWhileSuspended`
- `OnCompletedFiresIfCacheDisposedAfterWatchingWhileSuspended`

### Notes

Rebased onto current `main` and squashed. The branch previously carried a workaround in `ObservableCache.Connect()` that was later reverted in favour of fixing the operator, and replaying that history over #1132 conflicted repeatedly for no benefit. Nothing outside `Switch` and its tests is touched now.

The list `Switch` has the same three defects and is fixed the same way in #1139. The two are independent.

Behavioural change to a public operator: sequences that previously never terminated now terminate when their sources do. `main` is on `10.0-preview`.

Unrelated, and not addressed here: `AggregationEx.InvalidateWhen` still uses Rx's `Switch` and therefore still holds a gate during delivery. It operates on plain value streams rather than changesets, so the blast radius is smaller, but it is the same pattern if anyone is worried about it.
