### PR TITLE
Fix that the list Switch operator drops completion and throws errors

### DIFF
--- a/src/DynamicData.Tests/List/SwitchFixture.cs
+++ b/src/DynamicData.Tests/List/SwitchFixture.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
+
+using DynamicData.Tests.Utilities;
 
 using FluentAssertions;
 
@@ -240,10 +243,20 @@ public class SwitchFixture : IDisposable
     [Fact]
     public void IgnoresErrorsFromASupersededSource()
     {
-        // Switching away from a source means everything it produces afterwards belongs to a source
-        // that is no longer selected, and that includes its failures.
+        // Switching away from a source means anything it produces afterwards belongs to a source that
+        // is no longer selected, and that includes its failures. Ordinarily disposal stops a
+        // superseded source being heard from again, but disposal cannot reach a notification that is
+        // already in flight, so the operator has to discard it on arrival. The raw observable hands
+        // back the observer directly, which is how that in-flight failure is reproduced here without
+        // needing a race to land.
+        var supersededObserver = default(IObserver<IChangeSet<int>>);
+        var superseded = RawAnonymousObservable.Create<IChangeSet<int>>(observer =>
+        {
+            supersededObserver = observer;
+            return Disposable.Empty;
+        });
+
         using var switchable = new Subject<IObservable<IChangeSet<int>>>();
-        using var superseded = new Subject<IChangeSet<int>>();
         using var current = new Subject<IChangeSet<int>>();
 
         using var results = switchable.Switch().AsAggregator();
@@ -251,7 +264,8 @@ public class SwitchFixture : IDisposable
         switchable.OnNext(superseded);
         switchable.OnNext(current);
 
-        superseded.OnError(new Exception("Test"));
+        supersededObserver.Should().NotBeNull("the superseded source should have been subscribed");
+        supersededObserver!.OnError(new Exception("Test"));
 
         results.Exception.Should().BeNull("the failed source had already been switched away from");
 

--- a/src/DynamicData.Tests/List/SwitchFixture.cs
+++ b/src/DynamicData.Tests/List/SwitchFixture.cs
@@ -236,4 +236,27 @@ public class SwitchFixture : IDisposable
 
         producerFinished.Should().BeTrue("writing to the source must not block while a subscriber holds onto a notification");
     }
+
+    [Fact]
+    public void IgnoresErrorsFromASupersededSource()
+    {
+        // Switching away from a source means everything it produces afterwards belongs to a source
+        // that is no longer selected, and that includes its failures.
+        using var switchable = new Subject<IObservable<IChangeSet<int>>>();
+        using var superseded = new Subject<IChangeSet<int>>();
+        using var current = new Subject<IChangeSet<int>>();
+
+        using var results = switchable.Switch().AsAggregator();
+
+        switchable.OnNext(superseded);
+        switchable.OnNext(current);
+
+        superseded.OnError(new Exception("Test"));
+
+        results.Exception.Should().BeNull("the failed source had already been switched away from");
+
+        current.OnNext(new ChangeSet<int> { new Change<int>(ListChangeReason.Add, 1, 0) });
+
+        results.Data.Count.Should().Be(1, "the selected source should still be delivering");
+    }
 }

--- a/src/DynamicData.Tests/List/SwitchFixture.cs
+++ b/src/DynamicData.Tests/List/SwitchFixture.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 
 using FluentAssertions;
 
@@ -59,5 +61,179 @@ public class SwitchFixture : IDisposable
         _results.Data.Count.Should().Be(100);
 
         inital.Should().BeEquivalentTo(_source.Items);
+    }
+
+    [Fact]
+    public void PropagatesOuterErrors()
+    {
+        using var source = new SourceList<int>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<int>>>(source.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        source.AddRange(Enumerable.Range(1, 100));
+
+        var error = new Exception("Test");
+        switchable.OnError(error);
+
+        results.Exception.Should().Be(error);
+    }
+
+    [Fact]
+    public void PropagatesInnerErrors()
+    {
+        using var source = new SourceList<int>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<int>>>(source.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        source.AddRange(Enumerable.Range(1, 100));
+
+        using var source2 = new Subject<IChangeSet<int>>();
+        switchable.OnNext(source2);
+
+        var error = new Exception("Test");
+        source2.OnError(error);
+
+        results.Exception.Should().Be(error);
+    }
+
+    [Fact]
+    public void CompletesWhenSourcesAndInnerComplete()
+    {
+        using var source = new SourceList<int>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<int>>>(source.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        source.AddRange(Enumerable.Range(1, 100));
+
+        switchable.OnCompleted();
+        results.IsCompleted.Should().BeFalse("the inner sequence is still running");
+
+        source.Dispose();
+
+        results.IsCompleted.Should().BeTrue("both the sources and the inner sequence have completed");
+        results.Exception.Should().BeNull();
+        results.Data.Count.Should().Be(100, "all data should have been received before completion");
+    }
+
+    [Fact]
+    public void DoesNotCompleteWhileInnerIsStillRunning()
+    {
+        using var source = new SourceList<int>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<int>>>(source.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        switchable.OnCompleted();
+        source.Add(1);
+
+        results.IsCompleted.Should().BeFalse("the inner sequence has not completed");
+        results.Data.Count.Should().Be(1, "changes should still flow after the sources sequence completes");
+    }
+
+    [Fact]
+    public void DoesNotCompleteWhenOnlyASupersededInnerCompletes()
+    {
+        using var first = new SourceList<int>();
+        using var second = new SourceList<int>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<int>>>(first.Connect());
+        using var results = switchable.Switch().AsAggregator();
+
+        switchable.OnNext(second.Connect());
+        switchable.OnCompleted();
+
+        first.Dispose();
+
+        results.IsCompleted.Should().BeFalse("the superseded sequence is not the current one");
+
+        second.Add(1);
+        results.Data.Count.Should().Be(1, "the current sequence should still be delivering");
+
+        second.Dispose();
+        results.IsCompleted.Should().BeTrue("the current sequence has now completed");
+    }
+
+    [Fact]
+    public void CompletesWhenSourcesAndInnerCompleteSynchronously()
+    {
+        using var results = Observable.Return(Observable.Empty<IChangeSet<int>>()).Switch().AsAggregator();
+
+        results.IsCompleted.Should().BeTrue("everything completed during subscription");
+        results.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void DeliversChangesEmittedBeforeSynchronousCompletion()
+    {
+        var change = new ChangeSet<int> { new(ListChangeReason.Add, 42) };
+        using var results = Observable.Return(Observable.Return((IChangeSet<int>)change)).Switch().AsAggregator();
+
+        results.Data.Count.Should().Be(1, "changes emitted before a synchronous completion must not be lost");
+        results.IsCompleted.Should().BeTrue("the source completed");
+        results.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void IgnoresChangesFromASupersededSource()
+    {
+        using var first = new Subject<IChangeSet<int>>();
+        using var second = new Subject<IChangeSet<int>>();
+        using var switchable = new BehaviorSubject<IObservable<IChangeSet<int>>>(first);
+        using var results = switchable.Switch().AsAggregator();
+
+        first.OnNext(new ChangeSet<int> { new(ListChangeReason.Add, 1) });
+        results.Data.Count.Should().Be(1);
+
+        switchable.OnNext(second);
+        results.Data.Count.Should().Be(0, "moving to a new source drops what the previous one contributed");
+
+        first.OnNext(new ChangeSet<int> { new(ListChangeReason.Add, 2) });
+
+        results.Data.Count.Should().Be(0, "a superseded source must not be able to write into the result");
+        results.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void PropagatesInnerErrorsRaisedSynchronously()
+    {
+        var error = new Exception("Test");
+        using var results = Observable.Return(Observable.Throw<IChangeSet<int>>(error)).Switch().AsAggregator();
+
+        results.Exception.Should().Be(error, "the error was raised during subscription");
+    }
+
+    [Fact]
+    public void DoesNotHoldALockWhileDeliveringDownstream()
+    {
+        // Observable.Switch holds its gate for the whole of downstream delivery, which is the shape that
+        // deadlocks when a pipeline crosses into another collection. Delivery has to go through the queue,
+        // which enqueues and returns, so a producer is never held up by whatever a subscriber is doing.
+        using var switchable = new Subject<IObservable<IChangeSet<int>>>();
+        using var first = new Subject<IChangeSet<int>>();
+
+        using var isDelivering = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        using var subscription = switchable.Switch().Subscribe(_ =>
+        {
+            isDelivering.Set();
+            release.Wait(TimeSpan.FromSeconds(10));
+        });
+
+        switchable.OnNext(first);
+
+        var deliverer = new Thread(() => first.OnNext(new ChangeSet<int> { new Change<int>(ListChangeReason.Add, 1, 0) })) { IsBackground = true };
+        deliverer.Start();
+
+        isDelivering.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the subscriber should have been handed the change");
+
+        var producer = new Thread(() => switchable.OnNext(new Subject<IChangeSet<int>>())) { IsBackground = true };
+        producer.Start();
+
+        var producerFinished = producer.Join(TimeSpan.FromSeconds(2));
+
+        release.Set();
+        deliverer.Join(TimeSpan.FromSeconds(10));
+        producer.Join(TimeSpan.FromSeconds(10));
+
+        producerFinished.Should().BeTrue("writing to the source must not block while a subscriber holds onto a notification");
     }
 }

--- a/src/DynamicData/List/Internal/Switch.cs
+++ b/src/DynamicData/List/Internal/Switch.cs
@@ -31,7 +31,7 @@ internal sealed class Switch<T>(IObservable<IObservable<IChangeSet<T>>> sources)
                 var isSourceRunning = false;
                 var areSourcesComplete = false;
 
-                var outer = _sources.Subscribe(
+                var outer = _sources.SubscribeSafe(
                     source =>
                     {
                         int id;
@@ -50,7 +50,7 @@ internal sealed class Switch<T>(IObservable<IObservable<IChangeSet<T>>> sources)
 
                         // Subscribed outside the lock. The source may deliver synchronously, and that
                         // delivery takes the lock for itself.
-                        subscription.Disposable = source.Subscribe(
+                        subscription.Disposable = source.SubscribeSafe(
                             changes =>
                             {
                                 using var scope = queue.AcquireLock();
@@ -109,7 +109,13 @@ internal sealed class Switch<T>(IObservable<IObservable<IChangeSet<T>>> sources)
                         }
                     });
 
-                // Queue first, so that delivery is finished before the subscriptions are torn down.
-                return new CompositeDisposable(queue, outer, subscription);
+                // Disposal order matters and CompositeDisposable does not specify one. The queue goes first
+                // so that any delivery in flight is finished before the subscriptions feeding it are torn down.
+                return Disposable.Create(() =>
+                {
+                    queue.Dispose();
+                    outer.Dispose();
+                    subscription.Dispose();
+                });
             });
 }

--- a/src/DynamicData/List/Internal/Switch.cs
+++ b/src/DynamicData/List/Internal/Switch.cs
@@ -15,21 +15,91 @@ internal sealed class Switch<T>(IObservable<IObservable<IChangeSet<T>>> sources)
     public IObservable<IChangeSet<T>> Run() => Observable.Create<IChangeSet<T>>(
             observer =>
             {
-                var locker = InternalEx.NewLock();
+                // Switching is done by hand rather than with Observable.Switch, which holds its gate for
+                // the whole of downstream delivery. The queue enqueues and returns instead, so a producer
+                // is never held up by whatever a subscriber does with the notification, and a pipeline
+                // crossing into another collection cannot deadlock against it.
+                var queue = new DeliveryQueue<IChangeSet<T>>(observer);
 
-                var destination = new SourceList<T>();
+                // What the current source has contributed, so that switching away can take it back out.
+                var current = new List<T>();
+                var subscription = new SerialDisposable();
 
-                var populator = Observable.Switch(
-                    _sources.Do(
-                        _ =>
+                // Identifies the current source. A superseded one may still be mid-delivery, and anything
+                // it produces after this point belongs to a source that has already been switched away from.
+                var active = 0;
+                var isSourceRunning = false;
+                var areSourcesComplete = false;
+
+                var outer = _sources.Subscribe(
+                    source =>
+                    {
+                        int id;
+
+                        using (var scope = queue.AcquireLock())
                         {
-                            lock (locker)
-                            {
-                                destination.Clear();
-                            }
-                        })).Synchronize(locker).PopulateInto(destination);
+                            id = ++active;
+                            isSourceRunning = true;
 
-                var publisher = destination.Connect().SubscribeSafe(observer);
-                return new CompositeDisposable(destination, populator, publisher);
+                            if (current.Count != 0)
+                            {
+                                scope.EnqueueNext(new ChangeSet<T> { new Change<T>(ListChangeReason.Clear, current.ToArray()) });
+                                current.Clear();
+                            }
+                        }
+
+                        // Subscribed outside the lock. The source may deliver synchronously, and that
+                        // delivery takes the lock for itself.
+                        subscription.Disposable = source.Subscribe(
+                            changes =>
+                            {
+                                using var scope = queue.AcquireLock();
+
+                                if (id != active)
+                                {
+                                    return;
+                                }
+
+                                current.Clone(changes);
+
+                                if (changes.Count != 0)
+                                {
+                                    scope.EnqueueNext(changes);
+                                }
+                            },
+                            queue.OnError,
+                            () =>
+                            {
+                                using var scope = queue.AcquireLock();
+
+                                if (id != active)
+                                {
+                                    return;
+                                }
+
+                                isSourceRunning = false;
+
+                                if (areSourcesComplete)
+                                {
+                                    scope.EnqueueCompleted();
+                                }
+                            });
+                    },
+                    queue.OnError,
+                    () =>
+                    {
+                        using var scope = queue.AcquireLock();
+
+                        areSourcesComplete = true;
+
+                        // The current source may still be running, and the result ends only once both have.
+                        if (!isSourceRunning)
+                        {
+                            scope.EnqueueCompleted();
+                        }
+                    });
+
+                // Queue first, so that delivery is finished before the subscriptions are torn down.
+                return new CompositeDisposable(queue, outer, subscription);
             });
 }

--- a/src/DynamicData/List/Internal/Switch.cs
+++ b/src/DynamicData/List/Internal/Switch.cs
@@ -67,7 +67,17 @@ internal sealed class Switch<T>(IObservable<IObservable<IChangeSet<T>>> sources)
                                     scope.EnqueueNext(changes);
                                 }
                             },
-                            queue.OnError,
+                            error =>
+                            {
+                                using var scope = queue.AcquireLock();
+
+                                if (id != active)
+                                {
+                                    return;
+                                }
+
+                                scope.EnqueueError(error);
+                            },
                             () =>
                             {
                                 using var scope = queue.AcquireLock();


### PR DESCRIPTION
Fixes #1138.

The list `Switch` operator dropped completion, threw errors instead of delivering them, and routed delivery through a lock.

### Dropped completion, thrown errors

It relayed changes through a private `SourceList` and subscribed the observer to that:

```csharp
var destination = new SourceList<T>();

var populator = Observable.Switch(_sources.Do(...)).Synchronize(locker).PopulateInto(destination);

var publisher = destination.Connect().SubscribeSafe(observer);
```

A relay only ends when it is disposed, so the terminal event of the source had nowhere to go. Completion was dropped outright. An error was worse than dropped: `PopulateInto` subscribes without an error handler, so Rx rethrew it out of the subscription, on whatever thread happened to be writing to the source rather than at the subscription.

That is a step worse than the cache operator (#1137), which at least carried errors across by hand.

### The lock

The obvious fix is to let `Observable.Switch` sit between the sources and the observer and propagate terminal events on its own. That is wrong here, and it took a measurement to see why.

`Observable.Switch` holds its gate for the whole of the downstream `OnNext` call. A pipeline that crosses into another collection runs that work under the gate, and a producer on another thread blocks behind it. That is precisely the cross cache deadlock shape the delivery queue exists to avoid, and the operator on `main` avoids it today by keeping the observer on the far side of the relay list.

Measured with a subscriber that blocks inside `OnNext`, writing to the source from another thread:

| | time to return |
|---|---|
| `main` | 0 ms |
| via `Observable.Switch` | 748 ms |
| this PR | 1 ms |

So the operator is now written by hand. A `SerialDisposable` holds the current inner subscription, and every subscription carries an identity, so a superseded source still delivering concurrently is dropped rather than applied on top of the state its replacement has already established. All state changes and all delivery go through the queue, which releases its lock before handing anything downstream, so a second producer enqueues and returns instead of waiting.

The `Clear` that removes the previous source's contribution is enqueued under the same lock acquisition that takes the new identity, which keeps it ordered against the changes that follow it.

### Terminal semantics

Completes once the sources and the current inner have both completed. Fails as soon as either does. That matches `Observable.Switch`, which is what callers reasonably expect from something called Switch.

### Tests

`List/SwitchFixture`:

- `CompletesWhenSourcesAndInnerComplete`
- `DoesNotCompleteWhileInnerIsStillRunning`
- `DoesNotCompleteWhenOnlyASupersededInnerCompletes`
- `CompletesWhenSourcesAndInnerCompleteSynchronously`
- `DeliversChangesEmittedBeforeSynchronousCompletion`
- `PropagatesInnerErrorsRaisedSynchronously`
- `IgnoresChangesFromASupersededSource`
- `DoesNotHoldALockWhileDeliveringDownstream`

That last one blocks a subscriber inside `OnNext` and asserts that writing to the source from another thread still returns. It fails against an `Observable.Switch` implementation and passes against this one, so the lock behaviour cannot quietly come back.

Note the list aggregator exposes `Exception` where the cache one exposes `Error`, which is why the error assertions read differently from #1137.

### Notes

Rebased onto current `main` and squashed. Only `List/Internal/Switch.cs` and its fixture are touched.

The cache `Switch` has the same defects and is fixed the same way in #1137. The two are independent and can land in either order.

Behavioural change to a public operator: sequences that previously never terminated now terminate when their sources do, and an error that previously escaped as a thrown exception now arrives as `OnError`. `main` is on `10.0-preview`.
