### PR TITLE
Fix that a source failure is reported as successful completion to deferred subscriptions

### DIFF
--- a/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.UnitTests.cs
+++ b/src/DynamicData.Tests/Cache/SuspendNotificationsFixture.UnitTests.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading.Tasks;
 
 using FluentAssertions;
@@ -451,6 +452,64 @@ public static partial class SuspendNotificationsFixture
             results.Data.Count.Should().Be(allData.Count, $"{allData.Count} items in final state");
             results.Error.Should().BeNull();
             results.IsCompleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OnErrorFiresIfCacheFailsWhileSuspended()
+        {
+            // A connection made while suspended is deferred, and must still be told when the source
+            // fails. Reporting the failure as a successful completion leaves the subscriber's error
+            // handling unrun and its data looking complete.
+            using var source = new Subject<IChangeSet<int, int>>();
+            using var cache = new IntermediateCache<int, int>(source);
+
+            using var suspend = cache.SuspendNotifications();
+            using var results = cache.Connect().AsAggregator();
+
+            var expectedError = new Exception("Test Exception");
+            source.OnError(expectedError);
+
+            results.Error.Should().Be(expectedError, "a connection deferred by a suspension should see the source fail");
+            results.IsCompleted.Should().BeFalse("the source failed, it did not complete");
+        }
+
+        [Fact]
+        public void OnErrorFiresIfCacheFailsWhileWatchIsSuspended()
+        {
+            // Watch defers the same way Connect does, and has the same obligation.
+            using var source = new Subject<IChangeSet<int, int>>();
+            using var cache = new IntermediateCache<int, int>(source);
+
+            using var suspend = cache.SuspendNotifications();
+            Exception? actualError = null;
+            var isCompleted = false;
+            using var subscription = cache.Watch(1).Subscribe(static _ => { }, error => actualError = error, () => isCompleted = true);
+
+            var expectedError = new Exception("Test Exception");
+            source.OnError(expectedError);
+
+            actualError.Should().Be(expectedError, "a watch deferred by a suspension should see the source fail");
+            isCompleted.Should().BeFalse("the source failed, it did not complete");
+        }
+
+        [Fact]
+        public void OnErrorFiresIfCacheFailsAfterResumingWhileConnectionWasSuspended()
+        {
+            // The deferred connection has activated by the time the failure arrives, so this covers
+            // the path through the connection itself rather than through the suspension gate.
+            using var source = new Subject<IChangeSet<int, int>>();
+            using var cache = new IntermediateCache<int, int>(source);
+
+            var suspend = cache.SuspendNotifications();
+            using var results = cache.Connect().AsAggregator();
+            source.OnNext(new ChangeSet<int, int> { new(ChangeReason.Add, 1, 1) });
+
+            suspend.Dispose();
+            var expectedError = new Exception("Test Exception");
+            source.OnError(expectedError);
+
+            results.Error.Should().Be(expectedError, "an activated connection should still see the source fail");
+            results.Data.Count.Should().Be(1, "the data written before the failure should have arrived");
         }
 
         public void Dispose()

--- a/src/DynamicData/Cache/ObservableCache.cs
+++ b/src/DynamicData/Cache/ObservableCache.cs
@@ -120,9 +120,14 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     // Create the Connection Observable
                     ? CreateConnectObservable(predicate, suppressEmptyChangeSets)
 
-                    // Defer until notifications are no longer suspended
-                    : _suspensionTracker.Value.NotificationsSuspendedObservable.Do(static _ => { }, observer.OnCompleted)
-                        .Where(static b => !b).Take(1).Select(_ => CreateConnectObservable(predicate, suppressEmptyChangeSets)).Switch();
+                    // Defer until notifications are no longer suspended. Take(1) means there is only
+                    // ever one inner sequence, so SelectMany carries the terminal event of the gate
+                    // through on its own: the connection ends when the cache does, and fails when it
+                    // fails, rather than reporting a failure as a successful completion.
+                    : _suspensionTracker.Value.NotificationsSuspendedObservable
+                        .Where(static areNotificationsSuspended => !areNotificationsSuspended)
+                        .Take(1)
+                        .SelectMany(_ => CreateConnectObservable(predicate, suppressEmptyChangeSets));
 
                 return observable.SubscribeSafe(observer);
             }
@@ -144,9 +149,12 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
                     // Create the Watch Observable
                     ? CreateWatchObservable(key)
 
-                    // Defer until notifications are no longer suspended
-                    : _suspensionTracker.Value.NotificationsSuspendedObservable.Do(static _ => { }, observer.OnCompleted)
-                        .Where(static b => !b).Take(1).Select(_ => CreateWatchObservable(key)).Switch();
+                    // Defer until notifications are no longer suspended. See Connect() for why
+                    // SelectMany is used here.
+                    : _suspensionTracker.Value.NotificationsSuspendedObservable
+                        .Where(static areNotificationsSuspended => !areNotificationsSuspended)
+                        .Take(1)
+                        .SelectMany(_ => CreateWatchObservable(key));
 
                 return observable.SubscribeSafe(observer);
             }
@@ -394,7 +402,7 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
 
             if (cache._suspensionTracker.IsValueCreated)
             {
-                cache._suspensionTracker.Value.Dispose();
+                cache._suspensionTracker.Value.Fault(error);
             }
         }
 
@@ -515,6 +523,12 @@ internal sealed class ObservableCache<TObject, TKey> : IObservableCache<TObject,
             {
                 _areNotificationsSuspended.OnNext(false);
             }
+        }
+
+        public void Fault(Exception error)
+        {
+            _areNotificationsSuspended.OnError(error);
+            _areNotificationsSuspended.Dispose();
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixes #1140.

A `Connect()` or `Watch()` made while notifications are suspended is deferred until the suspension lifts. When the cache's source failed, that deferral reported the failure as a **successful completion**.

```csharp
// normal subscriber   -> OnError
// deferred subscriber -> OnCompleted
```

Same source, same failure, opposite terminal event, decided purely by whether the subscriber happened to connect during a suspension. That is worse than losing the error: the subscriber's error handling never runs, `Finally` and `Catch` see a normal end of stream, and the consumer is left believing it holds a complete, valid dataset.

### Why

Two things combined.

`CacheUpdateObserver.OnError` disposed the suspension tracker, and disposal completes the subject the deferral is waiting on:

```csharp
public void Dispose()
{
    _areNotificationsSuspended.OnCompleted();
    _areNotificationsSuspended.Dispose();
}
```

And the deferral mapped that completion straight onto the observer:

```csharp
: _suspensionTracker.Value.NotificationsSuspendedObservable.Do(static _ => { }, observer.OnCompleted)
    .Where(static b => !b).Take(1).Select(_ => CreateConnectObservable(...)).Switch();
```

So the failure path completed the gate, and the `Do` turned that into `observer.OnCompleted`.

### The change

`Fault(Exception)` faults the subject rather than completing it, and `OnError` calls that instead of `Dispose()`. The exception now has a path to the deferred subscriber.

`SelectMany` replaces `Select` followed by `Switch`, and the `Do` is dropped. `Take(1)` means there is only ever one inner sequence, so the two are equivalent for delivery, but `SelectMany` propagates the gate's terminal event by itself. The deferral is then self-contained rather than depending on the behaviour of another operator, and the terminal event travels through the chain rather than bypassing it.

`Watch()` had the same shape and is changed the same way.

### Tests

- `OnErrorFiresIfCacheFailsWhileSuspended`
- `OnErrorFiresIfCacheFailsWhileWatchIsSuspended`
- `OnErrorFiresIfCacheFailsAfterResumingWhileConnectionWasSuspended`

The first two fail without the change. The existing `OnCompletedFiresIfCacheDisposedWhileSuspended` covers the completion path, which must keep working and does.

### Notes

Independent of #1137. That one repairs the cache `Switch` operator, which is what #1136 was really about; this removes the deferral's dependence on `Switch` altogether, so the two do not overlap and can land in either order. #1137 also adds tests to `SuspendNotificationsFixture`, so a trivial conflict is possible depending on merge order.

Related to #1133, which reuses this deferral shape for subscriptions made during an `Edit()`. That PR would widen the trigger from suspensions to ordinary edits, so this is worth landing first.

One unrelated failure appears on this branch and on `main`: `ConcurrentSuspendDuringResumeDoesNotCorrupt` fails when run in isolation. That is #1131, which #1132 addresses.