### PR TITLE
Added documentation for clarity on the shadowing behavior of DynamicData's `.Switch()` operators.

### DIFF
--- a/src/DynamicData/Cache/ObservableCacheEx.Switch.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.Switch.cs
@@ -48,6 +48,7 @@ public static partial class ObservableCacheEx
     /// <remarks>
     /// <para>On switch: <b>Remove</b> is emitted for all items from the previous source, then <b>Add</b> for all items from the new source.</para>
     /// <para><b>Worth noting:</b> Each switch clears the entire downstream cache before populating from the new source. Subscribers see a full remove-then-add reset on every switch.</para>
+    /// <para><b>Also worth noting:</b>This operator intentionally shadows the native <see cref="Observable.Switch{TSource}(IObservable{IObservable{TSource}})"/> operator, as downstream listeners will generally become corrupt when the native operator is used. This is due to its lack of the automatic-clearing behavior mentioned above.</para>
     /// </remarks>
     public static IObservable<IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this IObservable<IObservable<IChangeSet<TObject, TKey>>> sources)
         where TObject : notnull

--- a/src/DynamicData/List/ObservableListEx.Switch.cs
+++ b/src/DynamicData/List/ObservableListEx.Switch.cs
@@ -52,10 +52,8 @@ public static partial class ObservableListEx
     /// <returns>A list changeset stream reflecting the most recently received inner changeset stream.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="sources"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// <para>
-    /// On each new inner stream, the operator clears the destination, disposes the previous subscription, and subscribes to the new stream.
-    /// This is the changeset-aware equivalent of Rx's <c>Switch()</c>.
-    /// </para>
+    /// <para><b>Worth noting:</b> Each switch clears the entire downstream list before populating from the new source. Subscribers see a full remove-then-add reset on every switch.</para>
+    /// <para><b>Also worth noting:</b>This operator intentionally shadows the native <see cref="Observable.Switch{TSource}(IObservable{IObservable{TSource}})"/> operator, as downstream listeners will generally become corrupt when the native operator is used. This is due to its lack of the automatic-clearing behavior mentioned above.</para>
     /// </remarks>
     /// <seealso cref="Switch{T}(IObservable{IObservableList{T}})"/>
     public static IObservable<IChangeSet<T>> Switch<T>(this IObservable<IObservable<IChangeSet<T>>> sources)


### PR DESCRIPTION
Resolves #1148.