### PR TITLE
Fixed that .WhenPropertyChanged() did not support a variety of types of implicit casts…

### DIFF
--- a/src/DynamicData.Tests/Binding/WhenPropertyChangedBehaviorFixture.cs
+++ b/src/DynamicData.Tests/Binding/WhenPropertyChangedBehaviorFixture.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-
+using System.Linq;
 using DynamicData.Binding;
-
+using DynamicData.Tests.Utilities;
 using FluentAssertions;
 
 using Xunit;
@@ -154,6 +154,39 @@ public sealed class WhenPropertyChangedBehaviorFixture
         emissions.Should().Equal(new[] { 10, 20, 30 }, "leaf event on detached subtree is ignored");
     }
 
+    // https://github.com/reactivemarbles/DynamicData/issues/1149
+    [Fact]
+    public void ExpressionContainsImplicitInterfaceCast()
+    {
+        var child = new ChildModel()
+        {
+            Age = 10
+        };
+        
+        using var subscription = ObserveAge(child)
+            .RecordValues(out var results);
+
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedValues.Should().ContainSingle("the initial value of the observed expression should have been published");
+        results.RecordedValues[0].Should().Be(child.Age, "the initial value of the observed expression should have been published");
+
+        ++child.Age;
+
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedValues.Skip(1).Should().ContainSingle("the value of the observed expression changed once");
+        results.RecordedValues[1].Should().Be(child.Age, "the correct value should have been published");
+
+        static IObservable<int> ObserveAge<T>(T source)
+                where T : IHasAge
+            => source.WhenValueChanged(source => source.Age);
+    }
+    
+    private interface IHasAge
+        : INotifyPropertyChanged
+    {
+        int Age { get; }
+    }
+
     private sealed class TestModel : INotifyPropertyChanged
     {
         private int _value;
@@ -188,7 +221,8 @@ public sealed class WhenPropertyChangedBehaviorFixture
         }
     }
 
-    private sealed class ChildModel : INotifyPropertyChanged
+    private sealed class ChildModel
+        : IHasAge
     {
         private int _age;
 

--- a/src/DynamicData/Binding/ExpressionBuilder.cs
+++ b/src/DynamicData/Binding/ExpressionBuilder.cs
@@ -53,13 +53,11 @@ internal static class ExpressionBuilder
 
                 return property.GetValue;
 
-            case UnaryExpression { NodeType: ExpressionType.Convert } convertExpression:
-                return (convertExpression.Type.IsGenericType
-                        && (convertExpression.Type.GetGenericTypeDefinition() == typeof(Nullable<>)))
-                    ? static target => target
-                    : target => Convert.ChangeType(
-                        value: target,
-                        conversionType: convertExpression.Type);
+            // I.E. cast operations. Since we're just dealing with everything as `object`, there's really nothing for us
+            // to do. If we cast from `object` to the desired type, we'll just immediately cast back to `object` to
+            // return. The runtime has to resolve and do the correct cast anyway, regardless of what we do here.
+            case UnaryExpression { NodeType: ExpressionType.Convert }:
+                return static target => target;
 
             case null:
                 throw new ArgumentNullException(nameof(source));


### PR DESCRIPTION
… within the target expression that it should have. In particular, this allows for more flexibility for the operation, within generic type contexts.

Resolves #1149.

Long story short, when I added support for implicit casts back in #1059, I misinterpreted what `Convert.ChangeType()` is supposed to do. Based on some other examples of code that parses cast expressions, I identified `Convert.ChangeType()` as the runtime's internal mechanism for doing a broad range of casts. It's actually only for doing casts between `IConvertible` types. Really, the runtime itself is already capable of doing all the casting work we need, given that we're operating exclusively in `object` land, and we hand off to the runtime to get us back in to generic-typed land. So, I just removed `Convert.ChangeType()` entirely, and that covers all the existing behavior we had tests for, as well as the new scenario from #1149.