### PR TITLE
Added tests for `ObservableCacheEx.ToCollection()`,…

### DIFF
--- a/src/DynamicData.Tests/Cache/FilterFixture.Base.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.Base.cs
@@ -356,15 +356,15 @@ public static partial class FilterFixture
         }
 
         [Theory]
-        [InlineData(CompletionStrategy.Asynchronous)]
-        [InlineData(CompletionStrategy.Immediate)]
-        public void SourceFails_ErrorPropagates(CompletionStrategy completionStrategy)
+        [InlineData(StreamCompletionStrategy.Asynchronous)]
+        [InlineData(StreamCompletionStrategy.Immediate)]
+        public void SourceFails_ErrorPropagates(StreamCompletionStrategy completionStrategy)
         {
             var error = new Exception("Test");
 
             using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
-            if (completionStrategy is CompletionStrategy.Immediate)
+            if (completionStrategy is StreamCompletionStrategy.Immediate)
                 source.SetError(error);
 
             using var subscription = BuildUut(
@@ -375,7 +375,7 @@ public static partial class FilterFixture
                 .ValidateChangeSets(Item.SelectId)
                 .RecordCacheItems(out var results);
 
-            if (completionStrategy is CompletionStrategy.Asynchronous)
+            if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                 source.SetError(error);
 
             results.Error.Should().Be(error);

--- a/src/DynamicData.Tests/Cache/FilterFixture.DynamicPredicate.UnitTests.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.DynamicPredicate.UnitTests.cs
@@ -141,9 +141,9 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void PredicateChangedCompletesAfterInitialValue_CompletionWaitsForSourceCompletion(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void PredicateChangedCompletesAfterInitialValue_CompletionWaitsForSourceCompletion(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -158,7 +158,7 @@ public static partial class FilterFixture
                     new Item() { Id = 6, IsIncluded = false }
                 });
 
-                var predicateChanged = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateChanged = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Func<Item, bool>>()
                     : Observable.Return(Item.FilterByIsIncluded);
 
@@ -188,7 +188,7 @@ public static partial class FilterFixture
                 source.Complete();
 
                 results.Error.Should().BeNull();
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     results.RecordedChangeSets.Skip(2).Should().BeEmpty("no source operations were performed");
                 else
                     results.RecordedChangeSets.Skip(1).Should().BeEmpty("no source operations were performed");
@@ -200,18 +200,18 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.SuppressEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.SuppressEmptyChangesets)]
             public void PredicateChangedCompletesBeforeInitialValue_CompletionPropagatesIfEmptyChangesetsAreSuppressed(
-                CompletionStrategy      completionStrategy,
-                EmptyChangesetPolicy    emptyChangesetPolicy)
+                StreamCompletionStrategy    completionStrategy,
+                EmptyChangesetPolicy        emptyChangesetPolicy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
-                var predicateChanged = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateChanged = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Func<Item, bool>>()
                     : Observable.Empty<Func<Item, bool>>();
 
@@ -237,16 +237,16 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void PredicateChangedFails_ErrorPropagates(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void PredicateChangedFails_ErrorPropagates(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
                 var error = new Exception("Test");
 
-                var predicateChanged = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateChanged = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Func<Item, bool>>()
                     : Observable.Throw<Func<Item, bool>>(error);
 
@@ -276,19 +276,19 @@ public static partial class FilterFixture
                     .Throw<ArgumentNullException>();
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.SuppressEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.SuppressEmptyChangesets)]
             public void SourceCompletesWhenEmpty_CompletionPropagatesWhenEmptyChangesetsAreSuppressed(
-                CompletionStrategy      completionStrategy,
-                EmptyChangesetPolicy    emptyChangesetPolicy)
+                StreamCompletionStrategy    completionStrategy,
+                EmptyChangesetPolicy        emptyChangesetPolicy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
                 // UUT Initialization & Action
-                if (completionStrategy is CompletionStrategy.Immediate)
+                if (completionStrategy is StreamCompletionStrategy.Immediate)
                     source.Complete();
 
                 using var subscription = source.Connect()
@@ -301,7 +301,7 @@ public static partial class FilterFixture
                     .ValidateChangeSets(Item.SelectId)
                     .RecordCacheItems(out var results);
 
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     source.Complete();
 
                 results.Error.Should().BeNull();
@@ -317,9 +317,9 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void SourceCompletesWhenNotEmpty_CompletionWaitsForPredicateChangedCompletion(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void SourceCompletesWhenNotEmpty_CompletionWaitsForPredicateChangedCompletion(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -338,7 +338,7 @@ public static partial class FilterFixture
 
 
                 // UUT Initialization & Action
-                if (completionStrategy is CompletionStrategy.Immediate)
+                if (completionStrategy is StreamCompletionStrategy.Immediate)
                     source.Complete();
 
                 using var subscription = source.Connect()
@@ -347,7 +347,7 @@ public static partial class FilterFixture
                     .ValidateChangeSets(Item.SelectId)
                     .RecordCacheItems(out var results);
 
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     source.Complete();
 
                 results.Error.Should().BeNull();

--- a/src/DynamicData.Tests/Cache/FilterFixture.DynamicPredicateAndReFiltering.UnitTests.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.DynamicPredicateAndReFiltering.UnitTests.cs
@@ -139,13 +139,13 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous,    DynamicParameter.Source)]
-            [InlineData(CompletionStrategy.Asynchronous,    DynamicParameter.ReapplyFilter)]
-            [InlineData(CompletionStrategy.Immediate,       DynamicParameter.Source)]
-            [InlineData(CompletionStrategy.Immediate,       DynamicParameter.ReapplyFilter)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  DynamicParameter.Source)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  DynamicParameter.ReapplyFilter)]
+            [InlineData(StreamCompletionStrategy.Immediate,     DynamicParameter.Source)]
+            [InlineData(StreamCompletionStrategy.Immediate,     DynamicParameter.ReapplyFilter)]
             public void PredicateChangedCompletesAfterInitialValue_CompletionWaitsForSourceAndReapplyFilterCompletion(
-                CompletionStrategy  completionStrategy,
-                DynamicParameter    lastCompletion)
+                StreamCompletionStrategy    completionStrategy,
+                DynamicParameter            lastCompletion)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -160,7 +160,7 @@ public static partial class FilterFixture
                     new Item() { Id = 6, IsIncluded = false }
                 });
 
-                var predicateChanged = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateChanged = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Func<Item, bool>>()
                     : Observable.Return(Item.FilterByIsIncluded);
 
@@ -195,7 +195,7 @@ public static partial class FilterFixture
                     reapplyFilter.OnCompleted();
 
                 results.Error.Should().BeNull();
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     results.RecordedChangeSets.Skip(2).Should().BeEmpty("no source operations were performed");
                 else
                     results.RecordedChangeSets.Skip(1).Should().BeEmpty("no source operations were performed");
@@ -209,7 +209,7 @@ public static partial class FilterFixture
                     source.Complete();
 
                 results.Error.Should().BeNull();
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     results.RecordedChangeSets.Skip(2).Should().BeEmpty("no source operations were performed");
                 else
                     results.RecordedChangeSets.Skip(1).Should().BeEmpty("no source operations were performed");
@@ -221,18 +221,18 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.SuppressEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.SuppressEmptyChangesets)]
             public void PredicateChangedCompletesBeforeInitialValue_CompletionPropagatesIfEmptyChangesetsAreSuppressed(
-                CompletionStrategy      completionStrategy,
-                EmptyChangesetPolicy    emptyChangesetPolicy)
+                StreamCompletionStrategy    completionStrategy,
+                EmptyChangesetPolicy        emptyChangesetPolicy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
-                var predicateChanged = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateChanged = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Func<Item, bool>>()
                     : Observable.Empty<Func<Item, bool>>();
 
@@ -259,16 +259,16 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void PredicateChangedFails_ErrorPropagates(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void PredicateChangedFails_ErrorPropagates(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
                 var error = new Exception("Test");
 
-                var predicateChanged = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateChanged = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Func<Item, bool>>()
                     : Observable.Throw<Func<Item, bool>>(error);
 
@@ -299,13 +299,13 @@ public static partial class FilterFixture
                     .Throw<ArgumentNullException>();
 
             [Theory]
-            [InlineData(CompletionStrategy.Immediate,       DynamicParameter.PredicateChanged)]
-            [InlineData(CompletionStrategy.Immediate,       DynamicParameter.Source)]
-            [InlineData(CompletionStrategy.Asynchronous,    DynamicParameter.PredicateChanged)]
-            [InlineData(CompletionStrategy.Asynchronous,    DynamicParameter.Source)]
+            [InlineData(StreamCompletionStrategy.Immediate,     DynamicParameter.PredicateChanged)]
+            [InlineData(StreamCompletionStrategy.Immediate,     DynamicParameter.Source)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  DynamicParameter.PredicateChanged)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  DynamicParameter.Source)]
             public void ReapplyFilterCompletes_CompletionWaitsForSourceAndPredicateChangedCompletion(
-                CompletionStrategy  completionStrategy,
-                DynamicParameter    lastCompletion)
+                StreamCompletionStrategy    completionStrategy,
+                DynamicParameter            lastCompletion)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -322,7 +322,7 @@ public static partial class FilterFixture
 
                 var predicateChanged = new BehaviorSubject<Func<Item, bool>>(Item.FilterByIsIncluded);
 
-                var reapplyFilter = (completionStrategy is CompletionStrategy.Asynchronous)
+                var reapplyFilter = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Unit>()
                     : Observable.Empty<Unit>();
 
@@ -372,16 +372,16 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void ReapplyFilterFails_ErrorPropagates(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void ReapplyFilterFails_ErrorPropagates(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
                 var error = new Exception("Test");
 
-                var reapplyFilter = (completionStrategy is CompletionStrategy.Asynchronous)
+                var reapplyFilter = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<Unit>()
                     : Observable.Throw<Unit>(error);
 
@@ -466,20 +466,20 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.SuppressEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.SuppressEmptyChangesets)]
             public void SourceCompletesWhenEmpty_CompletionPropagatesWhenEmptyChangesetsAreSuppressed(
-                CompletionStrategy      completionStrategy,
-                EmptyChangesetPolicy    emptyChangesetPolicy)
+                StreamCompletionStrategy    completionStrategy,
+                EmptyChangesetPolicy        emptyChangesetPolicy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
 
                 // UUT Initialization & Action
-                if (completionStrategy is CompletionStrategy.Immediate)
+                if (completionStrategy is StreamCompletionStrategy.Immediate)
                     source.Complete();
 
                 using var subscription = source.Connect()
@@ -493,7 +493,7 @@ public static partial class FilterFixture
                     .ValidateChangeSets(Item.SelectId)
                     .RecordCacheItems(out var results);
 
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     source.Complete();
 
                 results.Error.Should().BeNull();
@@ -509,13 +509,13 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous,    DynamicParameter.PredicateChanged)]
-            [InlineData(CompletionStrategy.Asynchronous,    DynamicParameter.ReapplyFilter)]
-            [InlineData(CompletionStrategy.Immediate,       DynamicParameter.PredicateChanged)]
-            [InlineData(CompletionStrategy.Immediate,       DynamicParameter.ReapplyFilter)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  DynamicParameter.PredicateChanged)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  DynamicParameter.ReapplyFilter)]
+            [InlineData(StreamCompletionStrategy.Immediate,     DynamicParameter.PredicateChanged)]
+            [InlineData(StreamCompletionStrategy.Immediate,     DynamicParameter.ReapplyFilter)]
             public void SourceCompletesWhenNotEmpty_CompletionWaitsForPredicateChangedAndReapplyFilterCompletion(
-                CompletionStrategy  completionStrategy,
-                DynamicParameter    lastCompletion)
+                StreamCompletionStrategy    completionStrategy,
+                DynamicParameter            lastCompletion)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -535,7 +535,7 @@ public static partial class FilterFixture
 
 
                 // UUT Initialization & Action
-                if (completionStrategy is CompletionStrategy.Immediate)
+                if (completionStrategy is StreamCompletionStrategy.Immediate)
                     source.Complete();
 
                 using var subscription = source.Connect()
@@ -546,7 +546,7 @@ public static partial class FilterFixture
                     .ValidateChangeSets(Item.SelectId)
                     .RecordCacheItems(out var results);
 
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     source.Complete();
 
                 results.Error.Should().BeNull();

--- a/src/DynamicData.Tests/Cache/FilterFixture.DynamicPredicateState.UnitTests.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.DynamicPredicateState.UnitTests.cs
@@ -99,9 +99,9 @@ public static partial class FilterFixture
                     .Throw<ArgumentNullException>();
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void PredicateStateCompletesAfterInitialValue_CompletionWaitsForSourceCompletion(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void PredicateStateCompletesAfterInitialValue_CompletionWaitsForSourceCompletion(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -116,7 +116,7 @@ public static partial class FilterFixture
                     new Item() { Id = 6, IsIncluded = false }
                 });
 
-                var predicateState = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateState = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<object>()
                     : Observable.Return(new object());
 
@@ -146,7 +146,7 @@ public static partial class FilterFixture
                 source.Complete();
 
                 results.Error.Should().BeNull();
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     results.RecordedChangeSets.Skip(2).Should().BeEmpty("no source operations were performed");
                 else
                     results.RecordedChangeSets.Skip(1).Should().BeEmpty("no source operations were performed");
@@ -158,18 +158,18 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.SuppressEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.SuppressEmptyChangesets)]
             public void PredicateStateCompletesBeforeInitialValue_CompletionPropagatesIfEmptyChangesetsAreSuppressed(
-                CompletionStrategy      completionStrategy,
-                EmptyChangesetPolicy    emptyChangesetPolicy)
+                StreamCompletionStrategy    completionStrategy,
+                EmptyChangesetPolicy        emptyChangesetPolicy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
-                var predicateState = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateState = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<object>()
                     : Observable.Empty<object>();
 
@@ -196,16 +196,16 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void PredicateStateFails_ErrorPropagates(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void PredicateStateFails_ErrorPropagates(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
                 var error = new Exception("Test");
 
-                var predicateState = (completionStrategy is CompletionStrategy.Asynchronous)
+                var predicateState = (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     ? new Subject<object>()
                     : Observable.Throw<object>(error);
 
@@ -285,20 +285,20 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Asynchronous,    EmptyChangesetPolicy.SuppressEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.IncludeEmptyChangesets)]
-            [InlineData(CompletionStrategy.Immediate,       EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Asynchronous,  EmptyChangesetPolicy.SuppressEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.IncludeEmptyChangesets)]
+            [InlineData(StreamCompletionStrategy.Immediate,     EmptyChangesetPolicy.SuppressEmptyChangesets)]
             public void SourceCompletesWhenEmpty_CompletionPropagatesWhenEmptyChangesetsAreSuppressed(
-                CompletionStrategy      completionStrategy,
-                EmptyChangesetPolicy    emptyChangesetPolicy)
+                StreamCompletionStrategy    completionStrategy,
+                EmptyChangesetPolicy        emptyChangesetPolicy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
 
                 // UUT Initialization & Action
-                if (completionStrategy is CompletionStrategy.Immediate)
+                if (completionStrategy is StreamCompletionStrategy.Immediate)
                     source.Complete();
 
                 using var subscription = source.Connect()
@@ -312,7 +312,7 @@ public static partial class FilterFixture
                     .ValidateChangeSets(Item.SelectId)
                     .RecordCacheItems(out var results);
 
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     source.Complete();
 
                 results.Error.Should().BeNull();
@@ -328,9 +328,9 @@ public static partial class FilterFixture
             }
 
             [Theory]
-            [InlineData(CompletionStrategy.Asynchronous)]
-            [InlineData(CompletionStrategy.Immediate)]
-            public void SourceCompletesWhenNotEmpty_CompletionWaitsForPredicateChangedCompletion(CompletionStrategy completionStrategy)
+            [InlineData(StreamCompletionStrategy.Asynchronous)]
+            [InlineData(StreamCompletionStrategy.Immediate)]
+            public void SourceCompletesWhenNotEmpty_CompletionWaitsForPredicateChangedCompletion(StreamCompletionStrategy completionStrategy)
             {
                 // Setup
                 using var source = new TestSourceCache<Item, int>(Item.SelectId);
@@ -349,7 +349,7 @@ public static partial class FilterFixture
 
 
                 // UUT Initialization & Action
-                if (completionStrategy is CompletionStrategy.Immediate)
+                if (completionStrategy is StreamCompletionStrategy.Immediate)
                     source.Complete();
 
                 using var subscription = source.Connect()
@@ -360,7 +360,7 @@ public static partial class FilterFixture
                     .ValidateChangeSets(Item.SelectId)
                     .RecordCacheItems(out var results);
 
-                if (completionStrategy is CompletionStrategy.Asynchronous)
+                if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                     source.Complete();
 
                 results.Error.Should().BeNull();

--- a/src/DynamicData.Tests/Cache/FilterFixture.Static.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.Static.cs
@@ -1,14 +1,14 @@
 ﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
 using FluentAssertions;
 using Xunit;
 
-using DynamicData.Tests.Utilities;
 using DynamicData.Tests.Domain;
-using System.Collections.ObjectModel;
-using System.Linq;
+using DynamicData.Tests.Utilities;
 
 namespace DynamicData.Tests.Cache;
 
@@ -26,16 +26,16 @@ public static partial class FilterFixture
                 .Throw<ArgumentNullException>();
 
         [Theory]
-        [InlineData(CompletionStrategy.Asynchronous)]
-        [InlineData(CompletionStrategy.Immediate)]
-        public void SourceCompletes_CompletionPropagates(CompletionStrategy completionStrategy)
+        [InlineData(StreamCompletionStrategy.Asynchronous)]
+        [InlineData(StreamCompletionStrategy.Immediate)]
+        public void SourceCompletes_CompletionPropagates(StreamCompletionStrategy completionStrategy)
         {
             // Setup
             using var source = new TestSourceCache<Item, int>(Item.SelectId);
 
 
             // UUT Initialization & Action
-            if (completionStrategy is CompletionStrategy.Immediate)
+            if (completionStrategy is StreamCompletionStrategy.Immediate)
                 source.Complete();
 
             using var subscription = source.Connect(suppressEmptyChangeSets: false)
@@ -44,7 +44,7 @@ public static partial class FilterFixture
                 .ValidateChangeSets(Item.SelectId)
                 .RecordCacheItems(out var results);
 
-            if (completionStrategy is CompletionStrategy.Asynchronous)
+            if (completionStrategy is StreamCompletionStrategy.Asynchronous)
                 source.Complete();
 
             results.Error.Should().BeNull();

--- a/src/DynamicData.Tests/Cache/FilterFixture.cs
+++ b/src/DynamicData.Tests/Cache/FilterFixture.cs
@@ -8,12 +8,6 @@ namespace DynamicData.Tests.Cache;
 
 public static partial class FilterFixture
 {
-    public enum CompletionStrategy
-    {
-        Immediate,
-        Asynchronous
-    }
-
     public enum EmptyChangesetPolicy
     {
         SuppressEmptyChangesets,

--- a/src/DynamicData.Tests/Cache/ToCollectionFixture.cs
+++ b/src/DynamicData.Tests/Cache/ToCollectionFixture.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+using DynamicData.Tests.Utilities;
+
+namespace DynamicData.Tests.Cache;
+
+public class ToCollectionFixture
+{
+    public ToCollectionFixture(ITestOutputHelper output)
+        => _output = output;
+
+    public record TestItem
+    {
+        public static int SelectId(TestItem item)
+            => item.Id;
+    
+        public required int Id { get; init; }
+        
+        public int Version { get; init; }
+    }
+
+    [Fact]
+    public void WhenChangesAreMade_ResultMatchesSourceAndPriorResultsAreNotMutated()
+    {
+        // Setup
+        using var source = new SourceCache<TestItem, int>(TestItem.SelectId);
+
+
+        // UUT Initialization
+        var priorResults = new List<IReadOnlyCollection<TestItem>>();
+
+        using var subscription = source.Connect()
+            .ToCollection()
+            .RecordValues(out var results);
+            
+        results.Error.Should().BeNull("no errors should have occurred");
+        // TODO: Disabled due to existing defect. Fix and restore.
+        //results.RecordedValues.Should().ContainSingle("an initial snapshot should always be published");
+        //results.RecordedValues[^1].Should().BeEmpty("no items have been added to the source");
+        results.HasCompleted.Should().BeFalse("the source has not completed");
+
+        // TODO: Disabled due to existing defect. Fix and restore.
+        //priorResults.Add(results.RecordedValues[^1].ToArray());
+        
+
+        // UUT Action (add items)
+        source.AddOrUpdate(new[]
+        {
+            new TestItem() { Id = 1 },
+            new TestItem() { Id = 2 },
+            new TestItem() { Id = 3 }
+        });
+        
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedValues.Skip(priorResults.Count).Should().ContainSingle("a single source operation was performed");
+        results.RecordedValues[^1].Should().BeEquivalentTo(source.Items, "snapshots should always match the source collection");
+        results.HasCompleted.Should().BeFalse("the source has not completed");
+
+        foreach (var (result, priorResult) in results.RecordedValues.Zip(priorResults))
+            result.Should().BeEquivalentTo(priorResult, "previous snapshots should not be mutated");
+
+        priorResults.Add(results.RecordedValues[^1].ToArray());
+        
+        
+        // UUT Action (replace items)
+        source.AddOrUpdate(new[]
+        {
+            new TestItem() { Id = 1, Version = 1 },
+            new TestItem() { Id = 2, Version = 1 },
+            new TestItem() { Id = 3, Version = 1 }
+        });
+        
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedValues.Skip(priorResults.Count).Should().ContainSingle("a single source operation was performed");
+        results.RecordedValues[^1].Should().BeEquivalentTo(source.Items, "snapshots should always match the source collection");
+        results.HasCompleted.Should().BeFalse("the source has not completed");
+
+        foreach (var (result, priorResult) in results.RecordedValues.Zip(priorResults))
+            result.Should().BeEquivalentTo(priorResult, "previous snapshots should not be mutated");
+
+        priorResults.Add(results.RecordedValues[^1].ToArray());
+
+
+        // UUT Action (remove items)
+        source.RemoveKeys(source.Keys.ToArray());
+        
+        results.Error.Should().BeNull("no errors should have occurred");
+        results.RecordedValues.Skip(priorResults.Count).Should().ContainSingle("a single source operation was performed");
+        results.RecordedValues[^1].Should().BeEquivalentTo(source.Items, "snapshots should always match the source collection");
+        results.HasCompleted.Should().BeFalse("the source has not completed");
+
+        foreach (var (result, priorResult) in results.RecordedValues.Zip(priorResults))
+            result.Should().BeEquivalentTo(priorResult, "previous snapshots should not be mutated");
+
+        priorResults.Add(results.RecordedValues[^1].ToArray());
+    }
+
+    [Theory]
+    [InlineData(StreamCompletionStrategy.Asynchronous)]
+    [InlineData(StreamCompletionStrategy.Immediate)]
+    public void WhenSourceCompletes_CompletionPropagates(StreamCompletionStrategy completionStrategy)
+    {
+        // Setup
+        using var source = new TestSourceCache<TestItem, int>(TestItem.SelectId);
+
+
+        // UUT Initialization & Action
+        if (completionStrategy is StreamCompletionStrategy.Immediate)
+            source.Complete();
+
+        using var subscription = source.Connect(suppressEmptyChangeSets: false)
+            .ToCollection()
+            .RecordValues(out var results);
+
+        if (completionStrategy is StreamCompletionStrategy.Asynchronous)
+            source.Complete();
+
+        results.Error.Should().BeNull();
+        results.RecordedValues.Should().ContainSingle("an initial snapshot should always be published");
+        results.RecordedValues[^1].Should().BeEmpty("no items were added to the source");
+        results.HasCompleted.Should().BeTrue("the source has completed");
+    }
+
+    [Theory]
+    [InlineData(StreamCompletionStrategy.Asynchronous)]
+    [InlineData(StreamCompletionStrategy.Immediate)]
+    public void WhenSourceFails_ErrorPropagates(StreamCompletionStrategy completionStrategy)
+    {
+        // Setup
+        using var source = new TestSourceCache<TestItem, int>(TestItem.SelectId);
+
+
+        // UUT Initialization & Action
+        var error = new Exception("Test");
+
+        if (completionStrategy is StreamCompletionStrategy.Immediate)
+            source.SetError(error);
+
+        using var subscription = source.Connect()
+            .ToCollection()
+            .RecordValues(out var results);
+
+        if (completionStrategy is StreamCompletionStrategy.Asynchronous)
+            source.SetError(error);
+
+        results.Error.Should().Be(error, "errors should propagate");
+        // TODO: Disabled due to existing defect. Fix and restore.
+        //results.RecordedValues.Should().ContainSingle("an initial snapshot should always be published");
+        //results.RecordedValues[^1].Should().BeEmpty("no items were added to the source");
+    }
+
+    [Fact]
+    public void WhenSourceIsNull_ThrowsException()
+    {
+        // UUT Action
+        var result = FluentActions.Invoking(() =>
+            {
+                _ = ObservableCacheEx.ToCollection<int, int>(null!);
+            })
+            .Should().Throw<ArgumentNullException>()
+            .WithParameterName("source")
+            .Which;
+            
+        _output.WriteLine(result.ToString());
+    }
+
+    [Fact]
+    public void WhenSubscriptionIsDisposed_SubscriptionDisposalPropagates()
+    {
+        // Setup
+        using var source = new Subject<IChangeSet<Item, int>>();
+
+
+        // UUT Initialization
+        using var subscription = source
+            .ToCollection()
+            .RecordValues(out var results);
+
+        results.Error.Should().BeNull();
+        // TODO: Disabled due to existing defect. Fix and restore.
+        //results.RecordedValues.Should().ContainSingle("an initial snapshot should always be published");
+        //results.RecordedValues[^1].Should().BeEmpty("no items were added to the source");
+        results.HasCompleted.Should().BeFalse("the source has not completed");
+
+
+        // UUT Action
+        subscription.Dispose();
+
+        source.HasObservers.Should().BeFalse("subscription disposal should propagate to the source");
+    }
+
+    private readonly ITestOutputHelper _output;
+}

--- a/src/DynamicData.Tests/Utilities/StreamCompletionStrategy.cs
+++ b/src/DynamicData.Tests/Utilities/StreamCompletionStrategy.cs
@@ -1,0 +1,7 @@
+namespace DynamicData.Tests.Utilities;
+
+public enum StreamCompletionStrategy
+{
+    Immediate,
+    Asynchronous
+}


### PR DESCRIPTION
… in preparation for operator rewrite, in accordance with #1014, and as part of optimization discussed in #1157.