### PR TITLE
Fix Switch resolution for virtualized changesets

### DIFF
--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet8_0.verified.txt
@@ -1885,6 +1885,9 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this System.IObservable<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> sources)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this System.IObservable<System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>>> sources)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<System.Collections.Generic.IReadOnlyCollection<TObject>> ToCollection<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source)
             where TObject :  notnull
             where TKey :  notnull { }

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
@@ -1876,6 +1876,9 @@ namespace DynamicData
         public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this System.IObservable<System.IObservable<DynamicData.IChangeSet<TObject, TKey>>> sources)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<DynamicData.IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this System.IObservable<System.IObservable<DynamicData.IChangeSet<TObject, TKey, DynamicData.VirtualContext<TObject>>>> sources)
+            where TObject :  notnull
+            where TKey :  notnull { }
         public static System.IObservable<System.Collections.Generic.IReadOnlyCollection<TObject>> ToCollection<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source)
             where TObject :  notnull
             where TKey :  notnull { }

--- a/src/DynamicData.Tests/Cache/VirtualizedSwitchFixture.cs
+++ b/src/DynamicData.Tests/Cache/VirtualizedSwitchFixture.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using DynamicData;
-using DynamicData.Tests;
+using DynamicData.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -23,16 +23,19 @@ public class VirtualizedSwitchFixture
         IObservable<IObservable<IChangeSet<int, int, VirtualContext<int>>>> sources = enabled.Select(
             isEnabled => isEnabled ? virtualized : Observable.Empty<IChangeSet<int, int, VirtualContext<int>>>());
         IObservable<IChangeSet<int, int>> switched = sources.Switch();
-        using ChangeSetAggregator<int, int> results = switched.AsAggregator();
+        using var subscription = switched
+            .ValidateChangeSets(static value => value)
+            .RecordCacheItems(out var results);
 
-        results.Messages.Should().ContainSingle();
-        results.Messages[0].Adds.Should().Be(10);
+        results.RecordedChangeSets.Should().ContainSingle();
+        results.RecordedChangeSets[0].Adds.Should().Be(10);
+        results.RecordedItemsByKey.Values.Should().BeEquivalentTo(Enumerable.Range(0, 10));
 
         enabled.OnNext(false);
 
-        results.Messages.Should().HaveCount(2);
-        results.Messages[1].Removes.Should().Be(10);
-        results.Data.Items.Should().BeEmpty();
+        results.RecordedChangeSets.Should().HaveCount(2);
+        results.RecordedChangeSets[1].Removes.Should().Be(10);
+        results.RecordedItemsByKey.Should().BeEmpty();
     }
 
     [Fact]
@@ -47,16 +50,18 @@ public class VirtualizedSwitchFixture
         IObservable<IChangeSet<int, int, VirtualContext<int>>> secondVirtualized = CreateVirtualized(second, 3);
         using var sources = new BehaviorSubject<IObservable<IChangeSet<int, int, VirtualContext<int>>>>(firstVirtualized);
         IObservable<IChangeSet<int, int>> switched = sources.Switch();
-        using ChangeSetAggregator<int, int> results = switched.AsAggregator();
+        using var subscription = switched
+            .ValidateChangeSets(static value => value)
+            .RecordCacheItems(out var results);
 
-        results.Data.Items.Should().BeEquivalentTo([0, 1, 2]);
+        results.RecordedItemsByKey.Values.Should().BeEquivalentTo([0, 1, 2]);
 
         sources.OnNext(secondVirtualized);
 
-        results.Messages.Should().HaveCount(3);
-        results.Messages[1].Removes.Should().Be(3);
-        results.Messages[2].Adds.Should().Be(3);
-        results.Data.Items.Should().BeEquivalentTo([100, 101, 102]);
+        results.RecordedChangeSets.Should().HaveCount(3);
+        results.RecordedChangeSets[1].Removes.Should().Be(3);
+        results.RecordedChangeSets[2].Adds.Should().Be(3);
+        results.RecordedItemsByKey.Values.Should().BeEquivalentTo([100, 101, 102]);
     }
 
     private static IObservable<IChangeSet<int, int, VirtualContext<int>>> CreateVirtualized(SourceCache<int, int> source, int size) =>

--- a/src/DynamicData.Tests/Cache/VirtualizedSwitchFixture.cs
+++ b/src/DynamicData.Tests/Cache/VirtualizedSwitchFixture.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using DynamicData;
+using DynamicData.Tests;
+using FluentAssertions;
+using Xunit;
+
+namespace ExternalConsumerTests.Cache;
+
+public class VirtualizedSwitchFixture
+{
+    [Fact]
+    public void SwitchingAwayFromVirtualizedSourceRemovesItsItems()
+    {
+        using var enabled = new BehaviorSubject<bool>(true);
+        using var source = new SourceCache<int, int>(value => value);
+        source.AddOrUpdate(Enumerable.Range(0, 20));
+
+        IObservable<IChangeSet<int, int, VirtualContext<int>>> virtualized = CreateVirtualized(source, 10);
+        IObservable<IObservable<IChangeSet<int, int, VirtualContext<int>>>> sources = enabled.Select(
+            isEnabled => isEnabled ? virtualized : Observable.Empty<IChangeSet<int, int, VirtualContext<int>>>());
+        IObservable<IChangeSet<int, int>> switched = sources.Switch();
+        using ChangeSetAggregator<int, int> results = switched.AsAggregator();
+
+        results.Messages.Should().ContainSingle();
+        results.Messages[0].Adds.Should().Be(10);
+
+        enabled.OnNext(false);
+
+        results.Messages.Should().HaveCount(2);
+        results.Messages[1].Removes.Should().Be(10);
+        results.Data.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SwitchingBetweenVirtualizedSourcesReplacesVisibleItems()
+    {
+        using var first = new SourceCache<int, int>(value => value);
+        using var second = new SourceCache<int, int>(value => value);
+        first.AddOrUpdate(Enumerable.Range(0, 10));
+        second.AddOrUpdate(Enumerable.Range(100, 10));
+
+        IObservable<IChangeSet<int, int, VirtualContext<int>>> firstVirtualized = CreateVirtualized(first, 3);
+        IObservable<IChangeSet<int, int, VirtualContext<int>>> secondVirtualized = CreateVirtualized(second, 3);
+        using var sources = new BehaviorSubject<IObservable<IChangeSet<int, int, VirtualContext<int>>>>(firstVirtualized);
+        IObservable<IChangeSet<int, int>> switched = sources.Switch();
+        using ChangeSetAggregator<int, int> results = switched.AsAggregator();
+
+        results.Data.Items.Should().BeEquivalentTo([0, 1, 2]);
+
+        sources.OnNext(secondVirtualized);
+
+        results.Messages.Should().HaveCount(3);
+        results.Messages[1].Removes.Should().Be(3);
+        results.Messages[2].Adds.Should().Be(3);
+        results.Data.Items.Should().BeEquivalentTo([100, 101, 102]);
+    }
+
+    private static IObservable<IChangeSet<int, int, VirtualContext<int>>> CreateVirtualized(SourceCache<int, int> source, int size) =>
+        source.Connect().SortAndVirtualize(
+            Comparer<int>.Default,
+            Observable.Return<IVirtualRequest>(new VirtualRequest(0, size)));
+}

--- a/src/DynamicData/Cache/ObservableCacheEx.Switch.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.Switch.cs
@@ -43,8 +43,6 @@ public static partial class ObservableCacheEx
         where TObject : notnull
         where TKey : notnull
     {
-        sources.ThrowArgumentNullExceptionIfNull(nameof(sources));
-
         return ObservableCacheEx.Switch((IObservable<IObservable<IChangeSet<TObject, TKey>>>)sources);
     }
 

--- a/src/DynamicData/Cache/ObservableCacheEx.Switch.cs
+++ b/src/DynamicData/Cache/ObservableCacheEx.Switch.cs
@@ -37,6 +37,17 @@ public static partial class ObservableCacheEx
         return sources.Select(cache => cache.Connect()).Switch();
     }
 
+    /// <inheritdoc cref="Switch{TObject, TKey}(IObservable{IObservable{IChangeSet{TObject, TKey}}})"/>
+    /// <param name="sources">An observable that emits virtualized changeset streams.</param>
+    public static IObservable<IChangeSet<TObject, TKey>> Switch<TObject, TKey>(this IObservable<IObservable<IChangeSet<TObject, TKey, VirtualContext<TObject>>>> sources)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        sources.ThrowArgumentNullExceptionIfNull(nameof(sources));
+
+        return ObservableCacheEx.Switch((IObservable<IObservable<IChangeSet<TObject, TKey>>>)sources);
+    }
+
     /// <summary>
     /// Subscribes to the latest inner changeset stream, unsubscribing from the previous one on each switch.
     /// When switching, the old source's items are removed and the new source's items are added.


### PR DESCRIPTION
Fixes #1164.

Adds a virtualized changeset overload so DynamicData's Switch is selected outside DynamicData namespaces. Includes coverage for switching to an empty source and between virtualized sources.

Tests:
- Switch, SortAndVirtualize, and API approval tests (41 passed)
- .NET 9 build