### PR TITLE
feat: add refresh-aware and immutable Sum operators

### DIFF
--- a/src/DynamicData.Benchmarks/Cache/Sum_Cache.cs
+++ b/src/DynamicData.Benchmarks/Cache/Sum_Cache.cs
@@ -19,6 +19,7 @@ public class Sum_Cache
 
     private IChangeSet<Item, int> _seedAfterAdds = null!;
     private IChangeSet<Item, int> _seedAfterReplaces = null!;
+    private IChangeSet<Item, int> _seedAfterRefreshes = null!;
 
     [Params(100, 500, 1_000, 10_000)]
     public int Count { get; set; }
@@ -45,6 +46,11 @@ public class Sum_Cache
 
         var addedItems = (Item[])items.Clone();
 
+        // Each non-add benchmark only forms a valid sequence for a stateful operator after it has seen
+        // the preceding population. Seed snapshots are collapsed into one change set so their cost stays
+        // outside the measured sequence as far as possible.
+        _seedAfterAdds = BuildSeed(addedItems);
+
         var replaceChangeSets = new List<IChangeSet<Item, int>>(capacity: Count);
         for (var id = 1; id <= Count; ++id)
         {
@@ -58,6 +64,7 @@ public class Sum_Cache
             replaceChangeSets.Add(source.CaptureChanges());
         }
         _replaceChangeSets = replaceChangeSets;
+        _seedAfterReplaces = BuildSeed(items);
 
         var refreshChangeSets = new List<IChangeSet<Item, int>>(capacity: Count);
         for (var id = 1; id <= Count; ++id)
@@ -68,6 +75,7 @@ public class Sum_Cache
             refreshChangeSets.Add(source.CaptureChanges());
         }
         _refreshChangeSets = refreshChangeSets;
+        _seedAfterRefreshes = BuildSeed(items);
 
         var removeChangeSets = new List<IChangeSet<Item, int>>(capacity: Count);
         for (var id = 1; id <= Count; ++id)
@@ -76,14 +84,6 @@ public class Sum_Cache
             removeChangeSets.Add(source.CaptureChanges());
         }
         _removeChangeSets = removeChangeSets;
-
-        // Replaces, refreshes, and removes only form a valid sequence for an operator that has already
-        // seen the items they refer to, so each of those runs gets seeded with the population as it stood
-        // beforehand. Collapsing the seed into a single change set keeps its cost off the measurement as
-        // far as possible: replaces follow on from the items that were added, while refreshes and removes
-        // follow on from the items that replaced them.
-        _seedAfterAdds = BuildSeed(addedItems);
-        _seedAfterReplaces = BuildSeed(items);
     }
 
     [Benchmark]
@@ -96,14 +96,18 @@ public class Sum_Cache
     public void Refreshes() => Run(_seedAfterReplaces, _refreshChangeSets);
 
     [Benchmark]
-    public void Removes() => Run(_seedAfterReplaces, _removeChangeSets);
+    public void Removes() => Run(_seedAfterRefreshes, _removeChangeSets);
 
     private static IChangeSet<Item, int> BuildSeed(Item[] items)
     {
         var seed = new ChangeAwareCache<Item, int>(capacity: items.Length - 1);
 
         for (var id = 1; id < items.Length; ++id)
-            seed.Add(items[id], key: id);
+            seed.Add(new Item()
+            {
+                Id = items[id].Id,
+                Value = items[id].Value
+            }, key: id);
 
         return seed.CaptureChanges();
     }

--- a/src/DynamicData.Benchmarks/List/Sum_List.cs
+++ b/src/DynamicData.Benchmarks/List/Sum_List.cs
@@ -19,6 +19,7 @@ public class Sum_List
 
     private IChangeSet<Item> _seedAfterAdds = null!;
     private IChangeSet<Item> _seedAfterReplaces = null!;
+    private IChangeSet<Item> _seedAfterRefreshes = null!;
 
     [Params(100, 500, 1_000, 10_000)]
     public int Count { get; set; }
@@ -44,6 +45,11 @@ public class Sum_List
 
         var addedItems = (Item[])items.Clone();
 
+        // Each non-add benchmark only forms a valid sequence for a stateful operator after it has seen
+        // the preceding population. Seed snapshots are collapsed into one change set so their cost stays
+        // outside the measured sequence as far as possible.
+        _seedAfterAdds = BuildSeed(addedItems);
+
         var replaceChangeSets = new List<IChangeSet<Item>>(capacity: Count);
         for (var index = 0; index < Count; ++index)
         {
@@ -56,6 +62,7 @@ public class Sum_List
             replaceChangeSets.Add(source.CaptureChanges());
         }
         _replaceChangeSets = replaceChangeSets;
+        _seedAfterReplaces = BuildSeed(items);
 
         var refreshChangeSets = new List<IChangeSet<Item>>(capacity: Count);
         for (var index = 0; index < Count; ++index)
@@ -66,6 +73,7 @@ public class Sum_List
             refreshChangeSets.Add(source.CaptureChanges());
         }
         _refreshChangeSets = refreshChangeSets;
+        _seedAfterRefreshes = BuildSeed(items);
 
         var removeChangeSets = new List<IChangeSet<Item>>(capacity: Count);
         for (var id = 1; id <= Count; ++id)
@@ -74,14 +82,6 @@ public class Sum_List
             removeChangeSets.Add(source.CaptureChanges());
         }
         _removeChangeSets = removeChangeSets;
-
-        // Replaces, refreshes, and removes only form a valid sequence for an operator that has already
-        // seen the items they refer to, so each of those runs gets seeded with the population as it stood
-        // beforehand. Collapsing the seed into a single change set keeps its cost off the measurement as
-        // far as possible: replaces follow on from the items that were added, while refreshes and removes
-        // follow on from the items that replaced them.
-        _seedAfterAdds = BuildSeed(addedItems);
-        _seedAfterReplaces = BuildSeed(items);
     }
 
     [Benchmark]
@@ -94,13 +94,20 @@ public class Sum_List
     public void Refreshes() => Run(_seedAfterReplaces, _refreshChangeSets);
 
     [Benchmark]
-    public void Removes() => Run(_seedAfterReplaces, _removeChangeSets);
+    public void Removes() => Run(_seedAfterRefreshes, _removeChangeSets);
 
     private static IChangeSet<Item> BuildSeed(Item[] items)
     {
         var seed = new ChangeAwareList<Item>(capacity: items.Length);
 
-        seed.AddRange(items);
+        foreach (var item in items)
+        {
+            seed.Add(new Item()
+            {
+                Id = item.Id,
+                Value = item.Value
+            });
+        }
 
         return seed.CaptureChanges();
     }

--- a/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
+++ b/src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt
@@ -225,6 +225,56 @@ namespace DynamicData.Aggregation
         public static System.IObservable<long> Sum<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, long?> valueSelector)
             where TObject :  notnull
             where TKey :  notnull { }
+        public static System.IObservable<decimal> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, decimal> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<decimal> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, decimal?> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<double> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, double> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<double> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, double?> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<float> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, float> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<float> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, float?> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<int> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, int> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<int> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, int?> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<long> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, long> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<long> SumImmutable<T>(this System.IObservable<DynamicData.IChangeSet<T>> source, System.Func<T, long?> valueSelector)
+            where T :  notnull { }
+        public static System.IObservable<decimal> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, decimal> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<decimal> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, decimal?> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<double> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, double> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<double> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, double?> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<float> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, float> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<float> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, float?> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<int> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, int> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<int> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, int?> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<long> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, long> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
+        public static System.IObservable<long> SumImmutable<TObject, TKey>(this System.IObservable<DynamicData.IChangeSet<TObject, TKey>> source, System.Func<TObject, long?> valueSelector)
+            where TObject :  notnull
+            where TKey :  notnull { }
     }
 }
 namespace DynamicData.Alias

--- a/src/DynamicData.Tests/AggregationTests/SumFixture.ForCache.cs
+++ b/src/DynamicData.Tests/AggregationTests/SumFixture.ForCache.cs
@@ -348,6 +348,64 @@ public partial class SumFixture
                 .Which.Should().Be(40, "null values should be treated as zero, so the sum should be 10 + 0 + 30 = 40");
         }
 
+        [Fact]
+        public void ItemIsRefreshed_SumReflectsMutatedValue()
+        {
+            using var source = new TestSourceCache<Person, string>(p => p.Name);
+            var person = new Person("A", 10);
+
+            source.AddOrUpdate(person);
+
+            using var subscription = source.Connect()
+                .Sum(p => p.Age)
+                .RecordValues(out var results);
+
+            person.Age = 40;
+            source.Refresh(person);
+
+            results.RecordedValues.Should().Equal(10, 40);
+
+            source.Remove(person.Name);
+
+            results.RecordedValues[^1].Should().Be(0, "removal should subtract the value captured by the refresh");
+        }
+
+        [Fact]
+        public void NullableItemIsRefreshed_SumReflectsMutatedValue()
+        {
+            using var source = new TestSourceCache<Person, string>(p => p.Name);
+            var person = new Person("A", new int?(10));
+
+            source.AddOrUpdate(person);
+
+            using var subscription = source.Connect()
+                .Sum(p => p.AgeNullable)
+                .RecordValues(out var results);
+
+            person.AgeNullable = null;
+            source.Refresh(person);
+
+            results.RecordedValues.Should().Equal(10, 0);
+        }
+
+        [Fact]
+        public void ItemIsRefreshed_SumImmutableDoesNotReevaluateMutatedValue()
+        {
+            using var source = new TestSourceCache<Person, string>(p => p.Name);
+            var person = new Person("A", 10);
+
+            source.AddOrUpdate(person);
+
+            using var subscription = source.Connect()
+                .SumImmutable(p => p.Age)
+                .RecordValues(out var results);
+
+            person.Age = 40;
+            source.Refresh(person);
+
+            results.RecordedValues.Should().Equal(10, 10);
+        }
+
         [Theory]
         [InlineData(new[] { 10, 20, 30 }, 60)]
         [InlineData(new[] { int.MaxValue }, int.MaxValue)]

--- a/src/DynamicData.Tests/AggregationTests/SumFixture.ForList.cs
+++ b/src/DynamicData.Tests/AggregationTests/SumFixture.ForList.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 
 using DynamicData.Aggregation;
+using DynamicData.Tests.Domain;
 using DynamicData.Tests.Utilities;
 
 using FluentAssertions;
@@ -263,6 +264,66 @@ public partial class SumFixture
 
             results.Error.Should().BeSameAs(error, "the error from the source should propagate to the subscriber immediately upon subscription");
             results.HasCompleted.Should().BeFalse("an error is not a completion");
+        }
+
+        [Fact]
+        public void ItemIsRefreshed_SumReflectsMutatedValue()
+        {
+            using var source = new TestSourceList<Person>();
+            var person = new Person("A", 10);
+
+            source.Add(person);
+
+            using var subscription = source.Connect()
+                .Sum(p => p.Age)
+                .RecordValues(out var results);
+
+            person.Age = 40;
+            source.Refresh(0);
+
+            results.RecordedValues.Should().Equal(10, 40);
+
+            source.RemoveAt(0);
+
+            results.RecordedValues[^1].Should().Be(0, "removal should subtract the value captured by the refresh");
+        }
+
+        [Fact]
+        public void ItemIsMoved_RefreshUsesItsNewIndex()
+        {
+            using var source = new TestSourceList<Person>();
+            var first = new Person("A", 10);
+            var second = new Person("B", 20);
+
+            source.AddRange(new[] { first, second });
+
+            using var subscription = source.Connect()
+                .Sum(p => p.Age)
+                .RecordValues(out var results);
+
+            source.Move(1, 0);
+            second.Age = 50;
+            source.Refresh(0);
+
+            results.RecordedValues.Should().Equal(30, 30, 60);
+        }
+
+        [Fact]
+        public void ItemIsRefreshed_SumImmutableDoesNotReevaluateMutatedValue()
+        {
+            using var source = new TestSourceList<Person>();
+            var person = new Person("A", 10);
+
+            source.Add(person);
+
+            using var subscription = source.Connect()
+                .SumImmutable(p => p.Age)
+                .RecordValues(out var results);
+
+            person.Age = 40;
+            source.Refresh(0);
+
+            results.RecordedValues.Should().Equal(10, 10);
         }
 
         [Theory]

--- a/src/DynamicData/Aggregation/SumEx.Immutable.cs
+++ b/src/DynamicData/Aggregation/SumEx.Immutable.cs
@@ -1,0 +1,352 @@
+// Copyright (c) 2011-2025 Roland Pheasant. All rights reserved.
+// Roland Pheasant licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+
+namespace DynamicData.Aggregation;
+
+/// <summary>
+/// Provides immutable-item sum aggregation extensions.
+/// </summary>
+public static partial class SumEx
+{
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<int> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<int> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int?> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutableNullable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<long> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<long> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long?> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutableNullable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<double> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<double> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double?> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutableNullable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<decimal> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<decimal> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal?> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutableNullable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<float> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="TObject">The type of the object.</typeparam>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<float> SumImmutable<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float?> valueSelector)
+        where TObject : notnull
+        where TKey : notnull => SumCacheImmutableNullable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<int> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, int> valueSelector)
+        where T : notnull => SumListImmutable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<int> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, int?> valueSelector)
+        where T : notnull => SumListImmutableNullable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<long> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, long> valueSelector)
+        where T : notnull => SumListImmutable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<long> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, long?> valueSelector)
+        where T : notnull => SumListImmutableNullable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<double> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, double> valueSelector)
+        where T : notnull => SumListImmutable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<double> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, double?> valueSelector)
+        where T : notnull => SumListImmutableNullable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<decimal> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal> valueSelector)
+        where T : notnull => SumListImmutable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<decimal> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal?> valueSelector)
+        where T : notnull => SumListImmutableNullable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<float> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, float> valueSelector)
+        where T : notnull => SumListImmutable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
+
+    /// <summary>
+    /// Continually computes the sum, optimized for immutable items. Refresh changes do not re-evaluate items.
+    /// </summary>
+    /// <typeparam name="T">The type of the item.</typeparam>
+    /// <param name="source">The source.</param>
+    /// <param name="valueSelector">The value selector.</param>
+    /// <returns>An observable which emits the summed value.</returns>
+    public static IObservable<float> SumImmutable<T>(this IObservable<IChangeSet<T>> source, Func<T, float?> valueSelector)
+        where T : notnull => SumListImmutableNullable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
+
+    private static IObservable<TValue> SumCacheImmutable<TObject, TKey, TValue>(
+        IObservable<IChangeSet<TObject, TKey>> source,
+        Func<TObject, TValue> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+        where TKey : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return source.Scan(seed, (sum, changes) =>
+        {
+            foreach (var change in changes)
+            {
+                switch (change.Reason)
+                {
+                    case ChangeReason.Add:
+                        sum = add(sum, valueSelector(change.Current));
+                        break;
+
+                    case ChangeReason.Update:
+                        sum = subtract(sum, valueSelector(change.Previous.Value));
+                        sum = add(sum, valueSelector(change.Current));
+                        break;
+
+                    case ChangeReason.Remove:
+                        sum = subtract(sum, valueSelector(change.Current));
+                        break;
+                }
+            }
+
+            return sum;
+        });
+    }
+
+    private static IObservable<TValue> SumCacheImmutableNullable<TObject, TKey, TValue>(
+        IObservable<IChangeSet<TObject, TKey>> source,
+        Func<TObject, TValue?> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+        where TKey : notnull
+        where TValue : struct
+    {
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return SumCacheImmutable(source, item => valueSelector(item).GetValueOrDefault(), seed, add, subtract);
+    }
+
+    private static IObservable<TValue> SumListImmutable<TObject, TValue>(
+        IObservable<IChangeSet<TObject>> source,
+        Func<TObject, TValue> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return source.Scan(seed, (sum, changes) =>
+        {
+            foreach (var change in changes)
+            {
+                switch (change.Reason)
+                {
+                    case ListChangeReason.Add:
+                        sum = add(sum, valueSelector(change.Item.Current));
+                        break;
+
+                    case ListChangeReason.AddRange:
+                        foreach (var item in change.Range)
+                        {
+                            sum = add(sum, valueSelector(item));
+                        }
+
+                        break;
+
+                    case ListChangeReason.Replace:
+                        sum = subtract(sum, valueSelector(change.Item.Previous.Value));
+                        sum = add(sum, valueSelector(change.Item.Current));
+                        break;
+
+                    case ListChangeReason.Remove:
+                        sum = subtract(sum, valueSelector(change.Item.Current));
+                        break;
+
+                    case ListChangeReason.RemoveRange:
+                    case ListChangeReason.Clear:
+                        foreach (var item in change.Range)
+                        {
+                            sum = subtract(sum, valueSelector(item));
+                        }
+
+                        break;
+                }
+            }
+
+            return sum;
+        });
+    }
+
+    private static IObservable<TValue> SumListImmutableNullable<TObject, TValue>(
+        IObservable<IChangeSet<TObject>> source,
+        Func<TObject, TValue?> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+        where TValue : struct
+    {
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return SumListImmutable(source, item => valueSelector(item).GetValueOrDefault(), seed, add, subtract);
+    }
+}

--- a/src/DynamicData/Aggregation/SumEx.cs
+++ b/src/DynamicData/Aggregation/SumEx.cs
@@ -2,12 +2,17 @@
 // Roland Pheasant licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reactive.Linq;
+
 namespace DynamicData.Aggregation;
 
 /// <summary>
 /// Aggregation extensions.
 /// </summary>
-public static class SumEx
+/// <remarks>
+/// Sum overloads operating directly on cache and list change sets retain projection state and re-evaluate refreshed items.
+/// </remarks>
+public static partial class SumEx
 {
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -19,7 +24,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStateful(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -31,7 +36,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, int?> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStatefulNullable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -43,7 +48,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStateful(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -55,7 +60,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, long?> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStatefulNullable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -67,7 +72,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStateful(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -79,7 +84,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, double?> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStatefulNullable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -91,7 +96,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStateful(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -103,7 +108,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, decimal?> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStatefulNullable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -115,7 +120,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStateful(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -127,7 +132,7 @@ public static class SumEx
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, Func<TObject, float?> valueSelector)
         where TObject : notnull
-        where TKey : notnull => source.ForAggregation().Sum(valueSelector);
+        where TKey : notnull => SumCacheStatefulNullable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -137,7 +142,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, int> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStateful(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -147,7 +152,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, int?> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStatefulNullable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -157,7 +162,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, long> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStateful(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -167,7 +172,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, long?> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStatefulNullable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -177,7 +182,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, double> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStateful(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -187,7 +192,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, double?> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStatefulNullable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -197,7 +202,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStateful(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -207,7 +212,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, decimal?> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStatefulNullable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -217,7 +222,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, float> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStateful(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -227,7 +232,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<T>(this IObservable<IChangeSet<T>> source, Func<T, float?> valueSelector)
-        where T : notnull => source.ForAggregation().Sum(valueSelector);
+        where T : notnull => SumListStatefulNullable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -237,12 +242,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<int> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, int> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0, valueSelector, (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregate(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -251,7 +251,8 @@ public static class SumEx
     /// <param name="source">The source.</param>
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
-    public static IObservable<int> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, int?> valueSelector) => source.Accumulate(0, t => valueSelector(t).GetValueOrDefault(), (current, value) => current + value, (current, value) => current - value);
+    public static IObservable<int> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, int?> valueSelector)
+        => SumAggregateNullable(source, valueSelector, 0, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -261,12 +262,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, long> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0, valueSelector, (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregate(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -276,12 +272,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<long> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, long?> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0L, t => valueSelector(t).ValueOr(0), (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregateNullable(source, valueSelector, 0L, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -291,12 +282,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, double> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0, valueSelector, (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregate(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -306,12 +292,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<double> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, double?> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0D, t => valueSelector(t).ValueOr(0), (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregateNullable(source, valueSelector, 0D, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -321,12 +302,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, decimal> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0, valueSelector, (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregate(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -336,12 +312,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<decimal> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, decimal?> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0M, t => valueSelector(t).ValueOr(0), (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregateNullable(source, valueSelector, 0M, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -351,12 +322,7 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, float> valueSelector)
-    {
-        source.ThrowArgumentNullExceptionIfNull(nameof(source));
-        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
-
-        return source.Accumulate(0, valueSelector, (current, value) => current + value, (current, value) => current - value);
-    }
+        => SumAggregate(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
 
     /// <summary>
     /// Continual computes the sum of values matching the value selector.
@@ -366,10 +332,330 @@ public static class SumEx
     /// <param name="valueSelector">The value selector.</param>
     /// <returns>An observable which emits the summed value.</returns>
     public static IObservable<float> Sum<T>(this IObservable<IAggregateChangeSet<T>> source, Func<T, float?> valueSelector)
+        => SumAggregateNullable(source, valueSelector, 0F, static (current, value) => current + value, static (current, value) => current - value);
+
+    private static IObservable<TValue> SumCacheStateful<TObject, TKey, TValue>(
+        IObservable<IChangeSet<TObject, TKey>> source,
+        Func<TObject, TValue> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+        where TKey : notnull
     {
         source.ThrowArgumentNullExceptionIfNull(nameof(source));
         valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
 
-        return source.Accumulate(0F, t => valueSelector(t).ValueOr(0), (current, value) => current + value, (current, value) => current - value);
+        return Observable.Defer(() =>
+        {
+            var values = new Dictionary<TKey, TValue>();
+
+            return source.Scan(seed, (sum, changes) =>
+            {
+                foreach (var change in changes)
+                {
+                    switch (change.Reason)
+                    {
+                        case ChangeReason.Add:
+                            {
+                                var value = valueSelector(change.Current);
+                                values.Add(change.Key, value);
+                                sum = add(sum, value);
+                                break;
+                            }
+
+                        case ChangeReason.Update:
+                        case ChangeReason.Refresh:
+                            {
+                                var previousValue = values[change.Key];
+                                var currentValue = valueSelector(change.Current);
+                                values[change.Key] = currentValue;
+                                sum = subtract(sum, previousValue);
+                                sum = add(sum, currentValue);
+                                break;
+                            }
+
+                        case ChangeReason.Remove:
+                            {
+                                var value = values[change.Key];
+                                values.Remove(change.Key);
+                                sum = subtract(sum, value);
+                                break;
+                            }
+                    }
+                }
+
+                return sum;
+            });
+        });
+    }
+
+    private static IObservable<TValue> SumCacheStatefulNullable<TObject, TKey, TValue>(
+        IObservable<IChangeSet<TObject, TKey>> source,
+        Func<TObject, TValue?> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+        where TKey : notnull
+        where TValue : struct
+    {
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return SumCacheStateful(source, item => valueSelector(item).GetValueOrDefault(), seed, add, subtract);
+    }
+
+    private static IObservable<TValue> SumListStateful<TObject, TValue>(
+        IObservable<IChangeSet<TObject>> source,
+        Func<TObject, TValue> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return Observable.Defer(() =>
+        {
+            var values = new List<(TObject Item, TValue Value)>();
+
+            return source.Scan(seed, (sum, changes) =>
+            {
+                foreach (var change in changes)
+                {
+                    switch (change.Reason)
+                    {
+                        case ListChangeReason.Add:
+                            {
+                                var item = (Item: change.Item.Current, Value: valueSelector(change.Item.Current));
+                                if (change.Item.CurrentIndex < 0 || change.Item.CurrentIndex >= values.Count)
+                                {
+                                    values.Add(item);
+                                }
+                                else
+                                {
+                                    values.Insert(change.Item.CurrentIndex, item);
+                                }
+
+                                sum = add(sum, item.Value);
+                                break;
+                            }
+
+                        case ListChangeReason.AddRange:
+                            {
+                                var items = new List<(TObject Item, TValue Value)>(change.Range.Count);
+                                foreach (var item in change.Range)
+                                {
+                                    var value = valueSelector(item);
+                                    items.Add((item, value));
+                                    sum = add(sum, value);
+                                }
+
+                                if (change.Range.Index < 0 || change.Range.Index >= values.Count)
+                                {
+                                    values.AddRange(items);
+                                }
+                                else
+                                {
+                                    values.InsertRange(change.Range.Index, items);
+                                }
+
+                                break;
+                            }
+
+                        case ListChangeReason.Replace:
+                            {
+                                var previousIndex = change.Item.PreviousIndex;
+                                if (previousIndex < 0)
+                                {
+                                    previousIndex = IndexOf(values, change.Item.Previous.Value);
+                                }
+
+                                if (previousIndex < 0)
+                                {
+                                    throw new UnspecifiedIndexException($"Cannot find index of {change.Item.Previous.Value}");
+                                }
+
+                                var previousValue = values[previousIndex].Value;
+                                var currentValue = valueSelector(change.Item.Current);
+
+                                if (change.Item.CurrentIndex < 0 || change.Item.CurrentIndex == previousIndex)
+                                {
+                                    values[previousIndex] = (change.Item.Current, currentValue);
+                                }
+                                else
+                                {
+                                    values.RemoveAt(previousIndex);
+                                    values.Insert(change.Item.CurrentIndex, (change.Item.Current, currentValue));
+                                }
+
+                                sum = subtract(sum, previousValue);
+                                sum = add(sum, currentValue);
+                                break;
+                            }
+
+                        case ListChangeReason.Remove:
+                            {
+                                var index = change.Item.CurrentIndex;
+                                if (index < 0)
+                                {
+                                    index = IndexOf(values, change.Item.Current);
+                                }
+
+                                if (index < 0)
+                                {
+                                    throw new UnspecifiedIndexException($"Cannot find index of {change.Item.Current}");
+                                }
+
+                                var value = values[index].Value;
+                                values.RemoveAt(index);
+                                sum = subtract(sum, value);
+                                break;
+                            }
+
+                        case ListChangeReason.RemoveRange:
+                            if (change.Range.Index >= 0)
+                            {
+                                var rangeEnd = change.Range.Index + change.Range.Count;
+                                for (var index = change.Range.Index; index < rangeEnd; ++index)
+                                {
+                                    sum = subtract(sum, values[index].Value);
+                                }
+
+                                values.RemoveRange(change.Range.Index, change.Range.Count);
+                            }
+                            else
+                            {
+                                foreach (var item in change.Range)
+                                {
+                                    var index = IndexOf(values, item);
+                                    if (index < 0)
+                                    {
+                                        throw new UnspecifiedIndexException($"Cannot find index of {item}");
+                                    }
+
+                                    sum = subtract(sum, values[index].Value);
+                                    values.RemoveAt(index);
+                                }
+                            }
+
+                            break;
+
+                        case ListChangeReason.Clear:
+                            foreach (var item in values)
+                            {
+                                sum = subtract(sum, item.Value);
+                            }
+
+                            values.Clear();
+                            break;
+
+                        case ListChangeReason.Moved:
+                            {
+                                var item = values[change.Item.PreviousIndex];
+                                values.RemoveAt(change.Item.PreviousIndex);
+                                values.Insert(change.Item.CurrentIndex, item);
+                                break;
+                            }
+
+                        case ListChangeReason.Refresh:
+                            {
+                                var index = change.Item.CurrentIndex;
+                                if (index < 0)
+                                {
+                                    index = IndexOf(values, change.Item.Current);
+                                }
+
+                                if (index < 0)
+                                {
+                                    throw new UnspecifiedIndexException($"Cannot find index of {change.Item.Current}");
+                                }
+
+                                var previousValue = values[index].Value;
+                                var currentValue = valueSelector(change.Item.Current);
+                                values[index] = (change.Item.Current, currentValue);
+                                sum = subtract(sum, previousValue);
+                                sum = add(sum, currentValue);
+                                break;
+                            }
+                    }
+                }
+
+                return sum;
+            });
+        });
+    }
+
+    private static IObservable<TValue> SumListStatefulNullable<TObject, TValue>(
+        IObservable<IChangeSet<TObject>> source,
+        Func<TObject, TValue?> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TObject : notnull
+        where TValue : struct
+    {
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return SumListStateful(source, item => valueSelector(item).GetValueOrDefault(), seed, add, subtract);
+    }
+
+    private static int IndexOf<TObject, TValue>(List<(TObject Item, TValue Value)> values, TObject item)
+        where TObject : notnull
+    {
+        for (var index = 0; index < values.Count; ++index)
+        {
+            if (ReferenceEquals(values[index].Item, item))
+            {
+                return index;
+            }
+        }
+
+        var comparer = EqualityComparer<TObject>.Default;
+        for (var index = 0; index < values.Count; ++index)
+        {
+            if (comparer.Equals(values[index].Item, item))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static IObservable<TValue> SumAggregate<TObject, TValue>(
+        IObservable<IAggregateChangeSet<TObject>> source,
+        Func<TObject, TValue> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+    {
+        source.ThrowArgumentNullExceptionIfNull(nameof(source));
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return source.Scan(seed, (sum, changes) =>
+        {
+            foreach (var change in changes)
+            {
+                var value = valueSelector(change.Item);
+                sum = change.Type == AggregateType.Add ? add(sum, value) : subtract(sum, value);
+            }
+
+            return sum;
+        });
+    }
+
+    private static IObservable<TValue> SumAggregateNullable<TObject, TValue>(
+        IObservable<IAggregateChangeSet<TObject>> source,
+        Func<TObject, TValue?> valueSelector,
+        TValue seed,
+        Func<TValue, TValue, TValue> add,
+        Func<TValue, TValue, TValue> subtract)
+        where TValue : struct
+    {
+        valueSelector.ThrowArgumentNullExceptionIfNull(nameof(valueSelector));
+
+        return SumAggregate(source, item => valueSelector(item).GetValueOrDefault(), seed, add, subtract);
     }
 }


### PR DESCRIPTION
> [!NOTE]
I did a bunch of AI-assisted coding for this, especially when it comes to the tests and benchmark edits as well as creating the comparison tables.

Follow-up for previous PRs that originated from: #1031 

# Sum operator rewrite

## Summary

The `Sum` operator has been rewritten to remove the intermediate `ForAggregation()` and `Accumulate()` pipeline. The public API now offers two explicit behavior and performance choices:

| Operator | Implementation | Refresh-aware | Intended use |
|---|---|---:|---|
| `Sum` | Stateful direct scan | Yes | Default choice; supports mutable items and recalculates projections on refresh, SHOULD be perfectly backwards compatible. |
| `SumImmutable` | Stateless direct scan | No | Higher-throughput, lower-allocation choice when projected values cannot mutate |

The existing `Sum` signatures are unchanged. `SumImmutable` adds cache and list overloads for `int`, `long`, `double`, `decimal`, and `float`, including nullable selectors. The `IAggregateChangeSet<T>` overloads remain stateless because refresh information has already been discarded at that point in the pipeline.

## Implementation changes

### Stateful `Sum`

- Cache change sets retain the last projected value in a per-subscription dictionary keyed by `TKey`.
- List change sets retain the item and its last projected value in a per-subscription ordered list.
- Refreshes subtract the stored projection, evaluate the current item, store the new projection, and add it to the sum.
- List moves update the internal ordering so a later indexed refresh or removal addresses the correct state.
- Indexed and indexless list removals and replacements are supported. Indexless lookup prefers reference identity before falling back to the default equality comparer.
- Add, add-range, replace, remove, remove-range, clear, move, and refresh changes are handled directly without materializing aggregate change sets.
- Mutable state is created inside `Observable.Defer`, keeping subscriptions isolated from one another.
- Nullable selector results continue to contribute zero when they have no value.

See [SumEx.cs](src/DynamicData/Aggregation/SumEx.cs).

### Stateless `SumImmutable`

- Direct, allocation-conscious scan.
- Evaluates selectors only for adds, updates/replacements, and removals.
- Refresh and move changes emit the unchanged accumulated value without re-evaluating items.
- Avoids the dictionary or ordered projection state required by refresh-aware aggregation.

See [SumEx.Immutable.cs](src/DynamicData/Aggregation/SumEx.Immutable.cs).

### Tests and API approval

- Added cache and list tests proving that mutating and refreshing an item updates `Sum`.
- Added nullable refresh coverage.
- Added a list move-then-refresh test to verify internal state ordering.
- Added tests documenting that `SumImmutable` does not re-evaluate refreshed items.
- Added all new overloads to the .NET 9 API approval baseline.
- The focused Sum suite passes all 65 tests, and the API approval test passes.

See [SumFixture.ForCache.cs](src/DynamicData.Tests/AggregationTests/SumFixture.ForCache.cs), [SumFixture.ForList.cs](src/DynamicData.Tests/AggregationTests/SumFixture.ForList.cs), and [the API baseline](src/DynamicData.Tests/API/ApiApprovalTests.DynamicDataTests.DotNet9_0.verified.txt).

## Performance results

### Methodology

- BenchmarkDotNet 0.15.8, `ShortRun` job: one launch, three warmup iterations, and three measured iterations.
- Release build on .NET 9.0.4, x64 RyuJIT, Intel Core i9-9880H, macOS Sequoia 15.7.7.
- Cache and list workloads cover add, replace, refresh, and remove streams at 100, 500, 1,000, and 10,000 changes.
- The legacy operator is the implementation at commit `dda39067`. Only its benchmark seed construction was corrected to use isolated snapshots; its operator code was not changed.
- All three implementations used the same corrected benchmark streams and pre-operation snapshots.
- Timing ratios are `old time / compared time`; values above `1.00×` are faster than the old implementation and values below `1.00×` are slower.
- Allocation percentages are relative to the old implementation; negative values mean fewer allocated bytes.
- Summary figures are geometric means across the applicable operation and count combinations.

> **Refresh caveat:** only the new stateful `Sum` computes a correct changed sum after an in-place mutation followed by refresh. Legacy `Sum` and `SumImmutable` treat refresh as a no-op, so their refresh timings represent less work and are included only to quantify the contract/performance tradeoff.

### Aggregate comparison

| Scope | New `Sum` speed vs old | New `Sum` allocation vs old | `SumImmutable` speed vs old | `SumImmutable` allocation vs old |
|---|---:|---:|---:|---:|
| Cache | 0.99× | -14.9% | 1.55× | -56.8% |
| List | 1.58× | -44.8% | 2.66× | -69.9% |
| Overall | 1.25× | -31.5% | 2.03× | -64.0% |

The stateful implementation is essentially time-neutral for cache workloads overall, substantially faster for list workloads, and reduces allocation in both. `SumImmutable` retains the strongest performance when immutable-item semantics are valid.

### Cache timing

| Operation | Count | Old | New `Sum` | `SumImmutable` | New vs old | Immutable vs old |
|---|---:|---:|---:|---:|---:|---:|
| Adds | 100 | 9.046 μs | 8.195 μs | 5.580 μs | 1.10× | 1.62× |
| Replaces | 100 | 12.234 μs | 11.228 μs | 8.267 μs | 1.09× | 1.48× |
| Refreshes | 100 | 10.405 μs | 11.372 μs | 8.043 μs | 0.91× | 1.29× |
| Removes | 100 | 12.723 μs | 10.184 μs | 7.906 μs | 1.25× | 1.61× |
| Adds | 500 | 43.891 μs | 35.102 μs | 28.317 μs | 1.25× | 1.55× |
| Replaces | 500 | 59.807 μs | 53.394 μs | 39.083 μs | 1.12× | 1.53× |
| Refreshes | 500 | 52.448 μs | 49.763 μs | 36.078 μs | 1.05× | 1.45× |
| Removes | 500 | 60.778 μs | 49.626 μs | 37.637 μs | 1.22× | 1.61× |
| Adds | 1,000 | 90.439 μs | 78.420 μs | 52.410 μs | 1.15× | 1.73× |
| Replaces | 1,000 | 121.075 μs | 127.929 μs | 71.743 μs | 0.95× | 1.69× |
| Refreshes | 1,000 | 102.496 μs | 134.231 μs | 66.955 μs | 0.76× | 1.53× |
| Removes | 1,000 | 112.620 μs | 145.130 μs | 76.440 μs | 0.78× | 1.47× |
| Adds | 10,000 | 899.592 μs | 1,259.921 μs | 540.972 μs | 0.71× | 1.66× |
| Replaces | 10,000 | 1,223.615 μs | 1,354.874 μs | 784.386 μs | 0.90× | 1.56× |
| Refreshes | 10,000 | 1,111.518 μs | 1,259.388 μs | 704.599 μs | 0.88× | 1.58× |
| Removes | 10,000 | 1,176.302 μs | 1,276.298 μs | 762.237 μs | 0.92× | 1.54× |

### Cache allocation

| Operation | Count | Old | New `Sum` | `SumImmutable` | New vs old | Immutable vs old |
|---|---:|---:|---:|---:|---:|---:|
| Adds | 100 | 16.97 KB | 14.84 KB | 7.45 KB | -12.6% | -56.1% |
| Replaces | 100 | 17.13 KB | 14.91 KB | 7.52 KB | -13.0% | -56.1% |
| Refreshes | 100 | 17.13 KB | 14.91 KB | 7.52 KB | -13.0% | -56.1% |
| Removes | 100 | 17.13 KB | 14.91 KB | 7.52 KB | -13.0% | -56.1% |
| Adds | 500 | 82.59 KB | 69.44 KB | 35.58 KB | -15.9% | -56.9% |
| Replaces | 500 | 82.76 KB | 69.51 KB | 35.65 KB | -16.0% | -56.9% |
| Refreshes | 500 | 82.76 KB | 69.51 KB | 35.65 KB | -16.0% | -56.9% |
| Removes | 500 | 82.76 KB | 69.51 KB | 35.65 KB | -16.0% | -56.9% |
| Adds | 1,000 | 164.63 KB | 142.36 KB | 70.73 KB | -13.5% | -57.0% |
| Replaces | 1,000 | 164.79 KB | 142.43 KB | 70.80 KB | -13.6% | -57.0% |
| Refreshes | 1,000 | 164.79 KB | 142.43 KB | 70.80 KB | -13.6% | -57.0% |
| Removes | 1,000 | 164.79 KB | 142.43 KB | 70.80 KB | -13.6% | -57.0% |
| Adds | 10,000 | 1,641.19 KB | 1,361.04 KB | 703.55 KB | -17.1% | -57.1% |
| Replaces | 10,000 | 1,641.35 KB | 1,361.11 KB | 703.62 KB | -17.1% | -57.1% |
| Refreshes | 10,000 | 1,641.35 KB | 1,361.10 KB | 703.62 KB | -17.1% | -57.1% |
| Removes | 10,000 | 1,641.35 KB | 1,361.10 KB | 703.62 KB | -17.1% | -57.1% |

### List timing

| Operation | Count | Old | New `Sum` | `SumImmutable` | New vs old | Immutable vs old |
|---|---:|---:|---:|---:|---:|---:|
| Adds | 100 | 8.012 μs | 5.305 μs | 3.061 μs | 1.51× | 2.62× |
| Replaces | 100 | 10.542 μs | 6.322 μs | 4.245 μs | 1.67× | 2.48× |
| Refreshes | 100 | 9.318 μs | 6.339 μs | 3.485 μs | 1.47× | 2.67× |
| Removes | 100 | 10.403 μs | 5.969 μs | 3.792 μs | 1.74× | 2.74× |
| Adds | 500 | 40.888 μs | 21.989 μs | 14.485 μs | 1.86× | 2.82× |
| Replaces | 500 | 51.116 μs | 26.407 μs | 18.895 μs | 1.94× | 2.71× |
| Refreshes | 500 | 42.975 μs | 26.566 μs | 15.772 μs | 1.62× | 2.72× |
| Removes | 500 | 51.500 μs | 26.158 μs | 17.126 μs | 1.97× | 3.01× |
| Adds | 1,000 | 81.179 μs | 45.306 μs | 29.511 μs | 1.79× | 2.75× |
| Replaces | 1,000 | 107.900 μs | 57.432 μs | 39.703 μs | 1.88× | 2.72× |
| Refreshes | 1,000 | 87.122 μs | 58.452 μs | 36.641 μs | 1.49× | 2.38× |
| Removes | 1,000 | 95.665 μs | 53.383 μs | 43.870 μs | 1.79× | 2.18× |
| Adds | 10,000 | 785.343 μs | 738.310 μs | 268.475 μs | 1.06× | 2.93× |
| Replaces | 10,000 | 1,038.356 μs | 798.241 μs | 410.861 μs | 1.30× | 2.53× |
| Refreshes | 10,000 | 965.673 μs | 776.385 μs | 345.074 μs | 1.24× | 2.80× |
| Removes | 10,000 | 978.571 μs | 772.720 μs | 380.368 μs | 1.27× | 2.57× |

### List allocation

| Operation | Count | Old | New `Sum` | `SumImmutable` | New vs old | Immutable vs old |
|---|---:|---:|---:|---:|---:|---:|
| Adds | 100 | 13.84 KB | 8.61 KB | 4.33 KB | -37.8% | -68.7% |
| Replaces | 100 | 14.02 KB | 7.81 KB | 4.41 KB | -44.3% | -68.5% |
| Refreshes | 100 | 14.02 KB | 7.81 KB | 4.41 KB | -44.3% | -68.5% |
| Removes | 100 | 14.02 KB | 7.81 KB | 4.41 KB | -44.3% | -68.5% |
| Adds | 500 | 66.97 KB | 36.28 KB | 19.95 KB | -45.8% | -70.2% |
| Replaces | 500 | 67.14 KB | 35.94 KB | 20.03 KB | -46.5% | -70.2% |
| Refreshes | 500 | 67.14 KB | 35.94 KB | 20.03 KB | -46.5% | -70.2% |
| Removes | 500 | 67.14 KB | 35.94 KB | 20.03 KB | -46.5% | -70.2% |
| Adds | 1,000 | 133.38 KB | 71.84 KB | 39.48 KB | -46.1% | -70.4% |
| Replaces | 1,000 | 133.55 KB | 71.09 KB | 39.56 KB | -46.8% | -70.4% |
| Refreshes | 1,000 | 133.55 KB | 71.09 KB | 39.56 KB | -46.8% | -70.4% |
| Removes | 1,000 | 133.55 KB | 71.09 KB | 39.56 KB | -46.8% | -70.4% |
| Adds | 10,000 | 1,328.69 KB | 903.55 KB | 391.05 KB | -32.0% | -70.6% |
| Replaces | 10,000 | 1,328.86 KB | 703.93 KB | 391.13 KB | -47.0% | -70.6% |
| Refreshes | 10,000 | 1,328.86 KB | 703.93 KB | 391.13 KB | -47.0% | -70.6% |
| Removes | 10,000 | 1,328.86 KB | 703.93 KB | 391.13 KB | -47.0% | -70.6% |

As you can see, general speedups and reductions in memory allocations across the board. We have a slight slowdown for the new stateful sum operator vs the old implementation but we still get a non-insignificant allocation drop on those runs. I'm open to any recommendations to help improve things any further. I focused mainly on back-compat in this case.